### PR TITLE
Fix locale discrepancies

### DIFF
--- a/locales/cs.yml
+++ b/locales/cs.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     čeština
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Dansk
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Deutsch
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Ελληνικά
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Spanish
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/fi.yml
+++ b/locales/fi.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Suomalainen
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Français
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/hi.yml
+++ b/locales/hi.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     हिंदी
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       <b>%s</b> में व्यवस्थापक:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         इस व्यक्ति ने यह चैट बनाई है, मैं उन्हें कैसे अवनत करूं?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Italiano
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     日本
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Hhollandske
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Polskie
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/ro.yml
+++ b/locales/ro.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Română
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     русский
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/sv.yml
+++ b/locales/sv.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     svenska
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Türkiye
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     Українська
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -8,9 +8,34 @@ main:
   language_name: |-
     中国人
 strings:
+  CommonStrings:
+    admin_cache:
+      cache_reloaded: |-
+        Successfully reloaded admin cache.
+      not_found: |-
+        Admincache not found. Ask an admin to use /admincache to reload the admin cache.
   Admin:
     adminlist: |-
       Admins in <b>%s</b>:
+    anon_admin:
+      enabled: |-
+        AnonAdmin mode is currently <b>enabled</b> for %s.
+        This allows all anonymous admin to perform admin actions without restriction.
+      disabled: |-
+        AnonAdmin mode is currently <b>disabled</b> for %s.
+        This requires anonymous admins to press a button to confirm their permissions.
+      enabled_now: |-
+        AnonAdmin mode is now <b>enabled</b> for %s.
+        From now onwards, I will ask the admins to verify permissions from anonymous admins.
+      disabled_now: |-
+        AnonAdmin mode is now <b>disabled</b> for %s.
+        From now onwards, I won't ask the admins to verify for permissions anymore from anonymous admins.
+      already_enabled: |-
+        AnonAdmin mode is already <b>enabled</b> for %s
+      already_disabled: |-
+        AnonAdmin mode is already <b>disabled</b> for %s
+      invalid_arg: |-
+        Invalid argument, I only understand <code>on</code>, <code>off</code>, <code>yes</code>, <code>no</code>
     demote:
       is_owner: |-
         This person created this chat, how would I demote them?
@@ -116,6 +141,8 @@ strings:
       user_approved: |-
         Approved User: %s
         They are now protected from bans, blacklists, locks and antiflood!
+      user_not_in_chat: |-
+        This user is not in this chat, and how can I approve them?
     unapprove:
       is_bot_itself: |-
         I'm an admin, I can't be unapproved!


### PR DESCRIPTION
## Summary
- backfill missing `admin_cache` strings into all locales
- add missing `anon_admin` responses
- sync `user_not_in_chat` message in approvals section

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684112489e9c832f8b8ed82c57bbb99d