### PR TITLE
fix: correct inverted logic in RevertButtons for SameLine property

### DIFF
--- a/alita/utils/helpers/helpers.go
+++ b/alita/utils/helpers/helpers.go
@@ -280,9 +280,9 @@ func RevertButtons(buttons []db.Button) string {
 	res := ""
 	for _, btn := range buttons {
 		if btn.SameLine {
-			res += fmt.Sprintf("\n[%s](buttonurl://%s)", btn.Name, btn.Url)
-		} else {
 			res += fmt.Sprintf("\n[%s](buttonurl://%s:same)", btn.Name, btn.Url)
+		} else {
+			res += fmt.Sprintf("\n[%s](buttonurl://%s)", btn.Name, btn.Url)
 		}
 	}
 	return res


### PR DESCRIPTION
## Summary
- Fixed inverted logic in `RevertButtons` function that was causing button layout issues
- Swapped the format strings in the if/else branches to correctly handle the `:same` modifier
- Now buttons with `SameLine=true` properly get the `:same` modifier appended

## Problem
The `RevertButtons` function in `alita/utils/helpers/helpers.go` had inverted logic when converting database buttons back to markdown format:
- When `SameLine=true`: Was outputting `[text](buttonurl://url)` (missing `:same`)
- When `SameLine=false`: Was outputting `[text](buttonurl://url:same)` (incorrectly adding `:same`)

This caused button layouts to break when editing and re-saving notes, filters, or greetings.

## Solution
Corrected the logic by swapping the format strings:
- When `SameLine=true`: Now outputs `[text](buttonurl://url:same)` 
- When `SameLine=false`: Now outputs `[text](buttonurl://url)`

## Testing
- [x] Code passes lint checks (`make lint`)
- [x] Code builds successfully (`make build`)
- [x] Logic now matches the tgmd2html spec

Fixes #549