### PR TITLE
fix: replace fatal error with warning when log channel message fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,8 +188,8 @@ func main() {
 			},
 		)
 		if err != nil {
-			log.Errorf("[Bot] Failed to send message to log group: %v", err)
-			log.Fatal(err)
+			log.Errorf("[Bot] Failed to send startup message to log group: %v", err)
+			log.Warn("[Bot] Continuing without log channel notifications")
 		}
 
 		// Log the message that bot started
@@ -255,8 +255,8 @@ func main() {
 			},
 		)
 		if err != nil {
-			log.Errorf("[Bot] Failed to send message to log group: %v", err)
-			log.Fatal(err)
+			log.Errorf("[Bot] Failed to send startup message to log group: %v", err)
+			log.Warn("[Bot] Continuing without log channel notifications")
 		}
 
 		// Log the message that bot started


### PR DESCRIPTION
## Summary
- Replaced `log.Fatal()` with `log.Warn()` when startup message to log channel fails
- Fixed issue in both webhook and polling modes
- Bot now continues operation even if log channel is unreachable

## Problem
The bot was using `log.Fatal()` when sending the startup message to the log channel failed, causing the entire process to terminate for what should be a non-critical operation. This led to unnecessary downtime when:
- Log channel was deleted or made private
- Bot was removed from the log channel
- Network issues prevented message delivery
- Invalid MESSAGE_DUMP configuration

## Solution
Changed the error handling to log a warning and continue execution instead of exiting. The bot will now:
1. Log the error as `log.Errorf()` with descriptive message
2. Log a warning that it's continuing without log channel notifications
3. Continue normal operation

## Testing
- ✅ Lint check passed (`make lint`)
- ✅ Build successful (`make build`)
- Bot will now start successfully even with invalid/inaccessible log channel

## Changes Made
- `main.go:191-192`: Replaced fatal error with warning in webhook mode
- `main.go:258-259`: Replaced fatal error with warning in polling mode

Fixes #551