### PR TITLE
fix: invert SplitMessage logic to properly split long messages

### DIFF
--- a/alita/utils/helpers/helpers.go
+++ b/alita/utils/helpers/helpers.go
@@ -75,7 +75,7 @@ func Smarkdown() *gotgbot.SendMessageOpts {
 // SplitMessage splits a message into multiple messages if it exceeds MaxMessageLength.
 // It splits on newlines to preserve message structure when possible.
 func SplitMessage(msg string) []string {
-	if len(msg) > MaxMessageLength {
+	if len(msg) <= MaxMessageLength {
 		tmp := make([]string, 1)
 		tmp[0] = msg
 		return tmp


### PR DESCRIPTION
## Summary
- Fixed inverted logic in SplitMessage function that prevented proper splitting of messages >4096 characters
- Messages exceeding Telegram's limit are now correctly split into chunks
- Resolves Telegram API errors: "Bad Request: message is too long"

## Problem
The `SplitMessage` function had inverted conditional logic:
- Messages >4096 chars were returned unsplit
- Messages ≤4096 chars went through unnecessary splitting logic

## Solution
Inverted the if/else conditions so that:
- Messages ≤ MaxMessageLength (4096) return as single-element array
- Messages > MaxMessageLength go through the splitting logic

## Test Plan
- [x] Code builds successfully (`make build`)
- [x] Linting passes (`make lint`)
- [ ] Test with messages >4096 characters to verify they're split correctly
- [ ] Test with messages <4096 characters to verify they're returned as-is

Fixes #548