### PR TITLE
feat: make dispatcher MaxRoutines configurable via environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func main() {
 			// Continue processing other updates
 			return ext.DispatcherActionNoop
 		},
-		MaxRoutines: 100, // Limit concurrent goroutines to prevent explosion
+		MaxRoutines: config.DispatcherMaxRoutines, // Configurable max concurrent goroutines
 	})
 
 	// Check if we should use webhooks or polling

--- a/sample.env
+++ b/sample.env
@@ -97,6 +97,16 @@ DROP_PENDING_UPDATES=true
 # Recommended: 15-60 seconds depending on operation complexity
 #OPERATION_TIMEOUT_SECONDS=30
 
+# Maximum concurrent goroutines for the update dispatcher
+# Controls how many updates can be processed simultaneously
+# Default: 100 goroutines
+# Recommended values:
+# - Low-resource environments: 20-50 to prevent memory issues
+# - Standard deployment: 100 (default)
+# - High-traffic bots: 200-500 for better throughput
+# - Development/testing: 10 for easier debugging
+#DISPATCHER_MAX_ROUTINES=100
+
 # Monitoring and Statistics (Optional)
 # Enable performance monitoring and background statistics collection
 


### PR DESCRIPTION
## Summary

This PR implements the enhancement requested in #553 to make the dispatcher's `MaxRoutines` setting configurable via environment variable.

## Changes

- ✅ Added `DISPATCHER_MAX_ROUTINES` configuration field to the `Config` struct  
- ✅ Updated config loading to read from `DISPATCHER_MAX_ROUTINES` environment variable
- ✅ Set default value to 100 (maintains backward compatibility)
- ✅ Added validation to ensure value is between 1 and 1000
- ✅ Updated `main.go` to use the config value instead of hardcoded 100
- ✅ Added comprehensive documentation to `sample.env` with recommended values

## Benefits

This change allows operators to tune dispatcher concurrency based on their infrastructure:

- **Low-resource environments**: Reduce to 20-50 to prevent memory issues
- **High-traffic bots**: Increase to 200-500 for better throughput  
- **Development/testing**: Set to 10 for easier debugging
- **Auto-scaling**: Adjust based on container resources

## Testing

- [x] Lint checks pass (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Default value (100) is applied when env var is not set
- [x] Validation correctly rejects invalid values

## Configuration Example

```bash
# Low resource VPS
DISPATCHER_MAX_ROUTINES=50

# High performance server
DISPATCHER_MAX_ROUTINES=500

# Development
DISPATCHER_MAX_ROUTINES=10
```

Fixes #553