### PR TITLE
fix(i18n loader): fix file path on windows system.

### DIFF
--- a/alita/i18n/loader.go
+++ b/alita/i18n/loader.go
@@ -3,6 +3,7 @@ package i18n
 import (
 	"bytes"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -39,7 +40,7 @@ func (lm *LocaleManager) loadLocaleFiles() error {
 			continue
 		}
 
-		filePath := filepath.Join(lm.localePath, fileName)
+		filePath := path.Join(lm.localePath, fileName)
 		langCode := extractLangCode(fileName)
 
 		if err := lm.loadSingleLocaleFile(filePath, langCode); err != nil {


### PR DESCRIPTION
while filepath should be used for filesystem paths but when using embed.Fs that will cause issues on windows system.