### PR TITLE
feat(release): add grouped changelog and GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - "On Hold."
+    authors:
+      - dependabot[bot]
+      - github-actions[bot]
+  categories:
+    - title: "⚠️ Breaking Changes"
+      labels:
+        - breaking-change
+    - title: "🚀 New Features"
+      labels:
+        - enhancement
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "🔒 Security"
+      labels:
+        - security
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🔧 Other Changes"
+      labels:
+        - "*"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,13 +56,34 @@ archives:
         formats: [zip]
 
 changelog:
+  use: github
   sort: asc
+  abbrev: -1
+  groups:
+    - title: "🚀 Features"
+      regexp: '^feat(\(.+\))?!?:'
+      order: 0
+    - title: "🐛 Bug Fixes"
+      regexp: '^fix(\(.+\))?!?:'
+      order: 1
+    - title: "⚡ Performance"
+      regexp: '^perf(\(.+\))?!?:'
+      order: 2
+    - title: "🔒 Security"
+      regexp: '^sec(urity)?(\(.+\))?!?:'
+      order: 3
+    - title: "♻️ Refactoring"
+      regexp: '^refactor(\(.+\))?!?:'
+      order: 4
+    - title: "📦 Other"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
-      - "^ci:"
+      - '^docs(\(.+\))?:'
+      - '^test(\(.+\))?:'
+      - '^chore(\(.+\))?:'
+      - '^ci(\(.+\))?:'
+      - '^deps(\(.+\))?:'
       - Merge pull request
       - Merge branch
 


### PR DESCRIPTION
## Summary

- **GoReleaser changelog**: Replace flat sorted list with categorized groups (Features, Bug Fixes, Performance, Security, Refactoring, Other) using conventional commit regex. Adds `use: github` for contributor attribution, `abbrev: -1` to strip SHAs, and `^deps` exclusion for Dependabot.
- **GitHub release notes**: Add `.github/release.yml` for native PR-based release notes with categories mapped to repo labels (`enhancement`, `bug`, `security`, `documentation`, `dependencies`), bot author exclusions, and a new `breaking-change` label.
- **Label**: Created `breaking-change` label on the repo for surfacing breaking changes in release notes.

The two systems coexist without conflict — GoReleaser produces commit-based changelogs on tag push, while GitHub's release.yml activates for PR-based notes via the "Generate release notes" button.

## Test plan

- [x] `goreleaser check` validates config
- [x] `goreleaser release --snapshot --clean --skip=publish` succeeds (non-Docker steps)
- [x] `make lint` shows no regressions (pre-existing warnings only)
- [x] `breaking-change` label created on repo