### PR TITLE
feat(ci): add test performance tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,41 @@ jobs:
           exit 1
 
       - name: Run test suite
-        run: make test
+        run: |
+          # Run tests and capture timing
+          start_time=$(date +%s)
+          make test
+          end_time=$(date +%s)
+          duration=$((end_time - start_time))
+
+          # Print duration to logs
+          echo "Test suite duration: ${duration}s"
+
+          # Add to job summary
+          echo "## 🧪 Test Suite Performance" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total Duration:** ${duration} seconds" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results-${{ github.sha }}
+          path: |
+            coverage.out
+            test-results/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report-${{ github.sha }}
+          path: coverage.out
+          retention-days: 30
+          if-no-files-found: ignore
 
   # Docker build verification (single arch, fast)
   docker-verify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,9 +200,9 @@ jobs:
 
       - name: Run test suite
         run: |
-          # Run tests and capture timing
+          # Run tests and capture timing (capture exit status to track duration even on failure)
           start_time=$(date +%s)
-          make test
+          make test || test_exit=$?
           end_time=$(date +%s)
           duration=$((end_time - start_time))
 
@@ -215,16 +215,10 @@ jobs:
           echo "**Total Duration:** ${duration} seconds" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: test-results-${{ github.sha }}
-          path: |
-            coverage.out
-            test-results/
-          retention-days: 30
-          if-no-files-found: ignore
+          # Re-exit with test failure status if tests failed
+          if [ -n "${test_exit}" ]; then
+            exit ${test_exit}
+          fi
 
       - name: Upload coverage reports
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint:
 	$(GOLANGCI_LINT_CMD) run
 
 test:
-	$(GO_CMD) test ./...
+	$(GO_CMD) test -v -race -coverprofile=coverage.out -count=1 -timeout 10m ./...
 
 check-translations:
 	@echo "🔍 Checking for missing translations..."


### PR DESCRIPTION
## Summary

This PR adds test performance tracking to address the Agent Readiness signal for "Test Performance Tracking".

### Changes

1. **Makefile**: Updated test target to include:
   -  flag for verbose test output showing individual test names
   -  flag for race condition detection
   -  to generate coverage reports
   -  to disable test caching for accurate timing
   -  to set a reasonable timeout

2. **CI Workflow** ():
   - Added test duration capture using timestamps
   - Added test duration summary to GitHub job summary
   - Added artifact upload for test results (coverage reports)
   - Artifacts are retained for 30 days

### Benefits

- Test suite duration is now measured and shown in CI output
- Coverage reports are generated and uploaded as artifacts
- Test results are available for analysis via CI artifacts
- Enables monitoring of test performance over time