### PR TITLE
fix(tracing): move working_mode from resource to span attribute

### DIFF
--- a/alita/db/db.go
+++ b/alita/db/db.go
@@ -753,7 +753,7 @@ func getSpanAttributes(model any) []attribute.KeyValue {
 // It logs any errors that occur during the creation process.
 func CreateRecord(model any) error {
 	_, span := tracing.StartSpan(context.Background(), "db.create",
-		trace.WithAttributes(getSpanAttributes(model)...))
+		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
 	defer span.End()
 
 	result := DB.Create(model)
@@ -772,7 +772,7 @@ func CreateRecord(model any) error {
 // if you need to update boolean fields to false or other zero values.
 func UpdateRecord(model any, where any, updates any) error {
 	_, span := tracing.StartSpan(context.Background(), "db.update",
-		trace.WithAttributes(getSpanAttributes(model)...))
+		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
 	defer span.End()
 
 	result := DB.Model(model).Where(where).Updates(updates)
@@ -795,7 +795,7 @@ func UpdateRecord(model any, where any, updates any) error {
 // Returns gorm.ErrRecordNotFound if no matching record exists.
 func UpdateRecordWithZeroValues(model any, where any, updates map[string]any) error {
 	_, span := tracing.StartSpan(context.Background(), "db.update",
-		trace.WithAttributes(getSpanAttributes(model)...))
+		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
 	defer span.End()
 
 	result := DB.Model(model).Where(where).Updates(updates)
@@ -829,7 +829,7 @@ func Close() error {
 // Returns gorm.ErrRecordNotFound if no matching record is found.
 func GetRecord(model any, where any) error {
 	_, span := tracing.StartSpan(context.Background(), "db.get",
-		trace.WithAttributes(getSpanAttributes(model)...))
+		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
 	defer span.End()
 
 	result := DB.Where(where).First(model)
@@ -858,7 +858,7 @@ func ChatExists(chatID int64) bool {
 // The results are stored in the provided models slice.
 func GetRecords(models any, where any) error {
 	_, span := tracing.StartSpan(context.Background(), "db.find",
-		trace.WithAttributes(getSpanAttributes(models)...))
+		trace.WithAttributes(append(getSpanAttributes(models), tracing.WorkingModeAttribute())...))
 	defer span.End()
 
 	result := DB.Where(where).Find(models)

--- a/alita/utils/cache/cache.go
+++ b/alita/utils/cache/cache.go
@@ -110,6 +110,7 @@ func TracedGet(ctx context.Context, key string) (any, error) {
 		trace.WithAttributes(
 			attribute.String("cache.key_prefix", SanitizeCacheKey(key)),
 			attribute.Int("cache.key_segment_count", CacheKeySegmentCount(key)),
+			tracing.WorkingModeAttribute(),
 		))
 	defer span.End()
 
@@ -129,6 +130,7 @@ func TracedSet(ctx context.Context, key string, value any, opts ...store.Option)
 			attribute.String("cache.key_prefix", SanitizeCacheKey(key)),
 			attribute.Int("cache.key_segment_count", CacheKeySegmentCount(key)),
 			attribute.String("cache.value_type", fmt.Sprintf("%T", value)),
+			tracing.WorkingModeAttribute(),
 		))
 	defer span.End()
 
@@ -146,6 +148,7 @@ func TracedDelete(ctx context.Context, key string) error {
 		trace.WithAttributes(
 			attribute.String("cache.key_prefix", SanitizeCacheKey(key)),
 			attribute.Int("cache.key_segment_count", CacheKeySegmentCount(key)),
+			tracing.WorkingModeAttribute(),
 		))
 	defer span.End()
 

--- a/alita/utils/httpserver/server.go
+++ b/alita/utils/httpserver/server.go
@@ -197,6 +197,7 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 			attribute.String("http.method", r.Method),
 			// Record a sanitized route instead of the full URL to avoid leaking the webhook secret
 			attribute.String("http.route", "/webhook/{secret}"),
+			tracing.WorkingModeAttribute(),
 		))
 	defer span.End()
 

--- a/alita/utils/tracing/tracing.go
+++ b/alita/utils/tracing/tracing.go
@@ -62,7 +62,6 @@ func InitTracing() error {
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
 			attribute.String("bot.version", config.AppConfig.BotVersion),
-			attribute.String("bot.working_mode", config.AppConfig.WorkingMode),
 		),
 	)
 	if err != nil {
@@ -172,6 +171,13 @@ func GetPropagator() propagation.TextMapPropagator {
 		)
 	}
 	return propagator
+}
+
+// WorkingModeAttribute returns a span attribute for the current working mode.
+// This reads config.AppConfig.WorkingMode at call time, so it reflects the
+// actual runtime value (webhook/polling) rather than the default set at init.
+func WorkingModeAttribute() attribute.KeyValue {
+	return attribute.String("bot.working_mode", config.AppConfig.WorkingMode)
 }
 
 // StartSpan starts a new span with the given name and options.


### PR DESCRIPTION
## Summary

Fixes #641.

- **Removed** `bot.working_mode` from the OTel resource (set at `InitTracing()` time, before `WorkingMode` is determined — always wrong)
- **Added** `WorkingModeAttribute()` helper in `tracing` package that reads `config.AppConfig.WorkingMode` at call time
- **Injected** the attribute into all 9 traced spans: 1 webhook, 5 DB operations, 3 cache operations

## Test plan

- [x] `go vet ./...` passes
- [x] `make lint` passes (only pre-existing dupl/godox warnings)
- [x] `make test` passes (failures are pre-existing env-dependent packages)
- [x] Grep confirms `bot.working_mode` removed from resource creation
- [x] Grep confirms `WorkingModeAttribute()` present in all 9 span sites