### PR TITLE
fix(ci): bump trivy-action to 0.34.2 and upload-artifact to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts
           path: dist/*
@@ -159,7 +159,7 @@ jobs:
       security-events: write
     steps:
       - name: Scan Docker image with Trivy
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: ghcr.io/divkix/alita_robot:latest
           format: table


### PR DESCRIPTION
## Summary

- Bump `aquasecurity/trivy-action` from `0.34.1` → `0.34.2` — the 0.34.1 install script was failing with exit code 1 during Trivy binary installation
- Bump `actions/upload-artifact` from `v6` → `v7` — aligns with the rest of the project's CI workflows

Closes DIV-115

## Test plan

- [ ] CI passes on this PR
- [ ] Next release workflow run completes the post-release Trivy scan step
- [ ] Artifact upload step uses v7 correctly