### PR TITLE
fix: keep math captcha images deterministic and readable

### DIFF
--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -872,7 +872,7 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 		80,            // height
 		240,           // width (wider for math expression)
 		0,             // noiseCount
-		2,             // showLineOptions
+		0,             // showLineOptions - keep math operators readable
 		len(question), // source length
 		question,      // source string (the question itself)
 		nil,           // bgColor

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -32,6 +32,18 @@ import (
 
 var captchaModule = moduleStruct{moduleName: "Captcha"}
 
+// fixedStringCaptchaDriver wraps DriverString so captcha.Generate renders
+// the exact provided content instead of randomly sampling from Source.
+type fixedStringCaptchaDriver struct {
+	*base64Captcha.DriverString
+	content string
+}
+
+func (d *fixedStringCaptchaDriver) GenerateIdQuestionAnswer() (id, q, a string) {
+	id = base64Captcha.RandomId()
+	return id, d.content, d.content
+}
+
 // messageTypeToString converts message type constants to human-readable strings
 func messageTypeToString(tr *i18n.Translator, messageType int) string {
 	var key string
@@ -843,8 +855,10 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 	// Use our reliable math generation
 	question, answer, options := generateMathCaptcha()
 
-	// Create a character driver to render the question as an image
-	driver := base64Captcha.NewDriverString(
+	// DriverString normally samples random characters from Source on Generate.
+	// Wrap it so the rendered image always matches the computed math question.
+	driver := &fixedStringCaptchaDriver{
+		DriverString: base64Captcha.NewDriverString(
 		80,            // height
 		240,           // width (wider for math expression)
 		0,             // noiseCount
@@ -854,7 +868,9 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 		nil,           // bgColor
 		nil,           // fonts
 		[]string{},    // fontsArray
-	)
+		),
+		content: question,
+	}
 
 	captcha := base64Captcha.NewCaptcha(driver, base64Captcha.DefaultMemStore)
 	_, b64s, _, err := captcha.Generate()

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -747,17 +747,17 @@ func generateMathCaptcha() (string, string, []string) {
 		a = secureIntn(50) + 1
 		b = secureIntn(50) + 1
 		answer = a + b
-		question = fmt.Sprintf("%d + %d", a, b)
+		question = formatMathQuestion(a, b, operation)
 	case "-":
 		a = secureIntn(50) + 20
 		b = secureIntn(a) + 1
 		answer = a - b
-		question = fmt.Sprintf("%d - %d", a, b)
+		question = formatMathQuestion(a, b, operation)
 	case "*":
 		a = secureIntn(12) + 1
 		b = secureIntn(12) + 1
 		answer = a * b
-		question = fmt.Sprintf("%d × %d", a, b)
+		question = formatMathQuestion(a, b, operation)
 	}
 
 	// Generate wrong answers
@@ -778,6 +778,16 @@ func generateMathCaptcha() (string, string, []string) {
 	secureShuffleStrings(options)
 
 	return question, strconv.Itoa(answer), options
+}
+
+func formatMathQuestion(a, b int, operation string) string {
+	operator := operation
+	if operation == "*" {
+		// Use ASCII x instead of the multiplication symbol to avoid missing glyphs
+		// in some embedded captcha fonts.
+		operator = "x"
+	}
+	return fmt.Sprintf("%d %s %d", a, operator, b)
 }
 
 // generateTextCaptcha generates a captcha image with random text.

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -44,6 +44,38 @@ func (d *fixedStringCaptchaDriver) GenerateIdQuestionAnswer() (id, q, a string) 
 	return id, d.content, d.content
 }
 
+// noopCaptchaStore avoids persisting unused answers for image-only generation paths.
+type noopCaptchaStore struct{}
+
+func (noopCaptchaStore) Set(id string, value string) error {
+	return nil
+}
+
+func (noopCaptchaStore) Get(id string, clear bool) string {
+	return ""
+}
+
+func (noopCaptchaStore) Verify(id, answer string, clear bool) bool {
+	return false
+}
+
+func newMathImageCaptchaDriver(question string) *fixedStringCaptchaDriver {
+	return &fixedStringCaptchaDriver{
+		DriverString: base64Captcha.NewDriverString(
+			80,            // height
+			240,           // width (wider for math expression)
+			0,             // noiseCount
+			0,             // showLineOptions - keep math operators readable
+			len(question), // source length
+			question,      // source string (the question itself)
+			nil,           // bgColor
+			nil,           // fonts
+			[]string{},    // fontsArray
+		),
+		content: question,
+	}
+}
+
 // messageTypeToString converts message type constants to human-readable strings
 func messageTypeToString(tr *i18n.Translator, messageType int) string {
 	var key string
@@ -867,22 +899,9 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 
 	// DriverString normally samples random characters from Source on Generate.
 	// Wrap it so the rendered image always matches the computed math question.
-	driver := &fixedStringCaptchaDriver{
-		DriverString: base64Captcha.NewDriverString(
-		80,            // height
-		240,           // width (wider for math expression)
-		0,             // noiseCount
-		0,             // showLineOptions - keep math operators readable
-		len(question), // source length
-		question,      // source string (the question itself)
-		nil,           // bgColor
-		nil,           // fonts
-		[]string{},    // fontsArray
-		),
-		content: question,
-	}
+	driver := newMathImageCaptchaDriver(question)
 
-	captcha := base64Captcha.NewCaptcha(driver, base64Captcha.DefaultMemStore)
+	captcha := base64Captcha.NewCaptcha(driver, noopCaptchaStore{})
 	_, b64s, _, err := captcha.Generate()
 	if err != nil {
 		return "", nil, nil, err

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -2,27 +2,12 @@ package modules
 
 import (
 	"testing"
-
-	"github.com/mojocn/base64Captcha"
 )
 
 func TestFixedStringCaptchaDriverReturnsExactQuestion(t *testing.T) {
 	const question = "12 + 34"
 
-	driver := &fixedStringCaptchaDriver{
-		DriverString: base64Captcha.NewDriverString(
-			80,
-			240,
-			0,
-			2,
-			len(question),
-			question,
-			nil,
-			nil,
-			[]string{},
-		),
-		content: question,
-	}
+	driver := newMathImageCaptchaDriver(question)
 
 	_, gotQuestion, gotAnswer := driver.GenerateIdQuestionAnswer()
 
@@ -46,20 +31,7 @@ func TestFormatMathQuestionUsesASCIIForMultiplication(t *testing.T) {
 func TestMathCaptchaDriverDisablesLineNoise(t *testing.T) {
 	const question = "10 x 3"
 
-	driver := &fixedStringCaptchaDriver{
-		DriverString: base64Captcha.NewDriverString(
-			80,
-			240,
-			0,
-			0,
-			len(question),
-			question,
-			nil,
-			nil,
-			[]string{},
-		),
-		content: question,
-	}
+	driver := newMathImageCaptchaDriver(question)
 
 	if driver.ShowLineOptions != 0 {
 		t.Fatalf("expected show line options to be disabled, got %d", driver.ShowLineOptions)

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -42,3 +42,26 @@ func TestFormatMathQuestionUsesASCIIForMultiplication(t *testing.T) {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
+
+func TestMathCaptchaDriverDisablesLineNoise(t *testing.T) {
+	const question = "10 x 3"
+
+	driver := &fixedStringCaptchaDriver{
+		DriverString: base64Captcha.NewDriverString(
+			80,
+			240,
+			0,
+			0,
+			len(question),
+			question,
+			nil,
+			nil,
+			[]string{},
+		),
+		content: question,
+	}
+
+	if driver.ShowLineOptions != 0 {
+		t.Fatalf("expected show line options to be disabled, got %d", driver.ShowLineOptions)
+	}
+}

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -34,3 +34,11 @@ func TestFixedStringCaptchaDriverReturnsExactQuestion(t *testing.T) {
 		t.Fatalf("expected generated answer payload %q, got %q", question, gotAnswer)
 	}
 }
+
+func TestFormatMathQuestionUsesASCIIForMultiplication(t *testing.T) {
+	got := formatMathQuestion(10, 3, "*")
+	want := "10 x 3"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -1,0 +1,36 @@
+package modules
+
+import (
+	"testing"
+
+	"github.com/mojocn/base64Captcha"
+)
+
+func TestFixedStringCaptchaDriverReturnsExactQuestion(t *testing.T) {
+	const question = "12 + 34"
+
+	driver := &fixedStringCaptchaDriver{
+		DriverString: base64Captcha.NewDriverString(
+			80,
+			240,
+			0,
+			2,
+			len(question),
+			question,
+			nil,
+			nil,
+			[]string{},
+		),
+		content: question,
+	}
+
+	_, gotQuestion, gotAnswer := driver.GenerateIdQuestionAnswer()
+
+	if gotQuestion != question {
+		t.Fatalf("expected generated question %q, got %q", question, gotQuestion)
+	}
+
+	if gotAnswer != question {
+		t.Fatalf("expected generated answer payload %q, got %q", question, gotAnswer)
+	}
+}


### PR DESCRIPTION
While testing the math captcha flow, I noticed that the image challenge could become unreadable after a few refreshes. In the worst cases the rendered image looked like a loose collection of digits, while the answer buttons were still generated from the original expression.

The main issue was that `generateMathImageCaptcha()` passed the full math expression into `base64Captcha.DriverString` as the source string. That driver does not render the given string verbatim on `Generate()`: it samples random characters from the source set, so the generated image content could drift away from the actual math question. On top of that, the multiplication glyph and line noise made operators harder to read than the digits.

This change keeps the existing math image captcha flow intact, but makes the rendered question deterministic and easier to read:

- wrap `DriverString` so it always renders the exact math expression that was generated
- use a stable ASCII `x` for multiplication instead of the glyph that some embedded captcha fonts render poorly
- disable line noise for math image captchas so `+`, `-`, and `x` remain legible
- add focused tests for the deterministic driver and the operator formatting/readability rules

Validation:

- `go test ./alita/modules`
- manual refresh testing of the math captcha flow after the change
