### PR TITLE
fix: DevSettings.Dev maps to dropped column causing query crashes

### DIFF
--- a/alita/db/db.go
+++ b/alita/db/db.go
@@ -368,7 +368,6 @@ type DevSettings struct {
 	ID        uint      `gorm:"primaryKey;autoIncrement" json:"-"`
 	UserId    int64     `gorm:"column:user_id;uniqueIndex;not null" json:"user_id,omitempty"`
 	IsDev     bool      `gorm:"column:is_dev;default:false" json:"is_dev,omitempty"`
-	Dev       bool      `gorm:"column:dev;default:false" json:"dev,omitempty"`     // Dev flag (legacy)
 	Sudo      bool      `gorm:"column:sudo;default:false" json:"sudo,omitempty"` // Sudo privileges
 	CreatedAt time.Time `gorm:"column:created_at" json:"created_at,omitempty"`
 	UpdatedAt time.Time `gorm:"column:updated_at" json:"updated_at,omitempty"`
@@ -427,7 +426,7 @@ func (ConnectionSettings) TableName() string {
 type ConnectionChatSettings struct {
 	ID           uint      `gorm:"primaryKey;autoIncrement" json:"-"`
 	ChatId       int64     `gorm:"column:chat_id;uniqueIndex;not null" json:"chat_id,omitempty"`
-	Enabled      bool      `gorm:"column:enabled;default:true" json:"enabled,omitempty"`       // Connection enabled
+	Enabled      bool      `gorm:"column:enabled;default:true" json:"enabled,omitempty"` // Connection enabled
 	AllowConnect bool      `gorm:"column:allow_connect;default:true" json:"allow_connect,omitempty"`
 	CreatedAt    time.Time `gorm:"column:created_at" json:"created_at,omitempty"`
 	UpdatedAt    time.Time `gorm:"column:updated_at" json:"updated_at,omitempty"`


### PR DESCRIPTION
Fixes #689

## Summary
Remove the "Dev" field from the DevSettings struct in alita/db/db.go. The migration 20260420120000_consolidate_duplicate_fields.sql drops the "dev" column after syncing data to "is_dev", but the GORM struct still referenced the dropped column, causing query failures.

## Changes
- Removed `Dev bool` field with column:dev tag from DevSettings struct
- The IsDev field (column:is_dev) remains as the canonical field

## TDD
- TDD Exception: Schema-sync fix (removing struct field that maps to dropped column)
- Alternative validation: Build passes, go fmt passes, golangci-lint passes

## Validation
- go build ./... : SUCCESS
- go fmt ./alita/db/db.go : SUCCESS  
- golangci-lint run ./alita/db/... : No issues found

## Risk
- Low: Simple field removal, no code references .Dev field directly
- Migration already handles data migration (dev -> is_dev)

## Auto-merge readiness
- Ready: Low risk, build/validation passing, no breaking API changes
