### PR TITLE
fix: CLEAR_CACHE_ON_STARTUP env var silently ignored, always forced to true (#698)

### DIFF
--- a/alita/config/config.go
+++ b/alita/config/config.go
@@ -464,8 +464,10 @@ func (cfg *Config) setDefaults() {
 	}
 
 	// Set cache defaults
-	// ClearCacheOnStartup defaults to true for better reliability
-	cfg.ClearCacheOnStartup = true
+	// ClearCacheOnStartup defaults to true for better reliability, but only if not explicitly set via env var
+	if os.Getenv("CLEAR_CACHE_ON_STARTUP") == "" {
+		cfg.ClearCacheOnStartup = true
+	}
 
 	// Enable monitoring by default in production
 	if !cfg.Debug {

--- a/alita/config/config_test.go
+++ b/alita/config/config_test.go
@@ -428,16 +428,7 @@ func TestSetDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("ClearCacheOnStartup unconditional", func(t *testing.T) {
-		t.Parallel()
 
-		cfg := &Config{ClearCacheOnStartup: false}
-		cfg.setDefaults()
-
-		if !cfg.ClearCacheOnStartup {
-			t.Errorf("ClearCacheOnStartup: got false, want true (setDefaults always sets this to true)")
-		}
-	})
 
 	t.Run("Debug false enables monitoring", func(t *testing.T) {
 		t.Parallel()
@@ -450,6 +441,45 @@ func TestSetDefaults(t *testing.T) {
 		}
 		if !cfg.EnableBackgroundStats {
 			t.Errorf("EnableBackgroundStats: got false, want true when Debug=false")
+		}
+	})
+}
+
+// TestClearCacheOnStartupEnvVar tests that CLEAR_CACHE_ON_STARTUP env var is respected.
+// These tests do NOT call t.Parallel() because t.Setenv() is incompatible with parallel execution.
+func TestClearCacheOnStartupEnvVar(t *testing.T) {
+	skipIfNoConfig(t)
+
+	t.Run("defaults to true when env var not set", func(t *testing.T) {
+		t.Setenv("CLEAR_CACHE_ON_STARTUP", "")
+
+		cfg := &Config{}
+		cfg.setDefaults()
+
+		if !cfg.ClearCacheOnStartup {
+			t.Errorf("ClearCacheOnStartup: got false, want true (default when env var not set)")
+		}
+	})
+
+	t.Run("respects explicit false", func(t *testing.T) {
+		t.Setenv("CLEAR_CACHE_ON_STARTUP", "false")
+
+		cfg := &Config{ClearCacheOnStartup: typeConvertor{str: "false"}.Bool()}
+		cfg.setDefaults()
+
+		if cfg.ClearCacheOnStartup {
+			t.Errorf("ClearCacheOnStartup: got true, want false (should respect env var CLEAR_CACHE_ON_STARTUP=false)")
+		}
+	})
+
+	t.Run("respects explicit true", func(t *testing.T) {
+		t.Setenv("CLEAR_CACHE_ON_STARTUP", "true")
+
+		cfg := &Config{ClearCacheOnStartup: typeConvertor{str: "true"}.Bool()}
+		cfg.setDefaults()
+
+		if !cfg.ClearCacheOnStartup {
+			t.Errorf("ClearCacheOnStartup: got false, want true (should respect env var CLEAR_CACHE_ON_STARTUP=true)")
 		}
 	})
 }


### PR DESCRIPTION
Fixes #698

## Summary
Previously, \`setDefaults()\` unconditionally set \`cfg.ClearCacheOnStartup = true\`, overwriting any value set via the \`CLEAR_CACHE_ON_STARTUP\` environment variable. This meant that setting \`CLEAR_CACHE_ON_STARTUP=false\` was silently ignored and the cache was always cleared on startup.

## Changes
- Modified \`setDefaults()\` in \`alita/config/config.go\` to only set the default to \`true\` when the env var is not explicitly set
- Replaced the buggy test that verified the wrong behavior with three new tests:
  - \`TestClearCacheOnStartupEnvVar/defaults_to_true_when_env_var_not_set\` - verifies default behavior
  - \`TestClearCacheOnStartupEnvVar/respects_explicit_false\` - verifies env var=false is respected
  - \`TestClearCacheOnStartupEnvVar/respects_explicit_true\` - verifies env var=true is respected

## TDD
- **Red**: New tests failed with original implementation (env var values were overwritten)
- **Green**: All tests pass with the fix
- **Refactor**: Tests organized as separate top-level test function (t.Setenv incompatible with t.Parallel)

## Validation
- \`make test\`: All \`alita/config\` tests pass (pre-existing failures in other packages unrelated to this change)
- \`make lint\`: 0 issues
- Targeted test: \`go test -v -run TestClearCacheOnStartupEnvVar ./alita/config/...\` passes

## Risk
- **Low**: Change is minimal and scoped to config defaults only
- Backward compatible: default behavior unchanged when env var not set
- Users who were unknowingly having their env var ignored will now have their preference respected

## Auto-merge readiness
- Ready for review and merge
- All relevant tests pass
- Lint clean
- Scoped to issue #698