### PR TITLE
antispam: defer Unlock so a panic in the cleanup loop can't deadlock

### DIFF
--- a/alita/modules/antispam.go
+++ b/alita/modules/antispam.go
@@ -26,21 +26,23 @@ func antiSpamCleanupLoop() {
 	defer ticker.Stop()
 
 	for range ticker.C {
-		antiSpamMutex.Lock()
-		now := time.Now()
-		for key, info := range antiSpamMap {
-			allExpired := true
-			for _, level := range info.Levels {
-				if now.Sub(level.CurrTime) < level.Expiry*2 {
-					allExpired = false
-					break
+		func() {
+			antiSpamMutex.Lock()
+			defer antiSpamMutex.Unlock()
+			now := time.Now()
+			for key, info := range antiSpamMap {
+				allExpired := true
+				for _, level := range info.Levels {
+					if now.Sub(level.CurrTime) < level.Expiry*2 {
+						allExpired = false
+						break
+					}
+				}
+				if allExpired {
+					delete(antiSpamMap, key)
 				}
 			}
-			if allExpired {
-				delete(antiSpamMap, key)
-			}
-		}
-		antiSpamMutex.Unlock()
+		}()
 	}
 }
 


### PR DESCRIPTION
Closes #696. `antiSpamCleanupLoop` had a manual `Unlock()` after the body — a panic anywhere in the cleanup leaves the mutex held forever. Wrap the body in a closure with a deferred Unlock.