### PR TITLE
fix: fix: callback parsing bugs — missing answers and ignored parse errors

### DIFF
--- a/alita/modules/backup.go
+++ b/alita/modules/backup.go
@@ -459,6 +459,9 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 	// Decode callback data
 	decoded, ok := decodeCallbackData(query.Data, "backup")
 	if !ok {
+		tempTr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+		text, _ := tempTr.GetString("common_callback_invalid_request")
+		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
 		return ext.EndGroups
 	}
 

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -1110,7 +1110,14 @@ func (moduleStruct) joinRequestHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
 		return ext.EndGroups
 	}
-	joinUserId, _ := strconv.ParseInt(joinUserIDRaw, 10, 64)
+	joinUserId, err := strconv.ParseInt(joinUserIDRaw, 10, 64)
+	if err != nil {
+		log.Errorf("[Greetings] Failed to parse join user ID '%s': %v", joinUserIDRaw, err)
+		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+		text, _ := tr.GetString("common_callback_invalid_request")
+		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
+		return ext.EndGroups
+	}
 	joinUser, err := b.GetChat(joinUserId, nil)
 	if err != nil {
 		log.Error(err)

--- a/alita/modules/warns.go
+++ b/alita/modules/warns.go
@@ -580,7 +580,13 @@ func (moduleStruct) rmWarnButton(b *gotgbot.Bot, ctx *ext.Context) error {
 		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
 		return ext.EndGroups
 	}
-	userId, _ := strconv.Atoi(userMatch)
+	userId, parseErr := strconv.Atoi(userMatch)
+	if parseErr != nil {
+		log.Errorf("[Warns] Failed to parse user ID from callback: %v", parseErr)
+		text, _ := tr.GetString("common_callback_invalid_request")
+		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
+		return ext.EndGroups
+	}
 	var replyText string
 
 	res := db.RemoveWarn(int64(userId), chat.Id)


### PR DESCRIPTION
Fixes #695

## Summary
This PR fixes three callback parsing bugs in the bot:

1. **backup.go**: When `decodeCallbackData(query.Data, "backup")` fails, the handler now answers the callback with "Invalid request" before returning. Previously it returned without answering, leaving a loading spinner until Telegram's ~30s timeout.

2. **greetings.go**: Now checks the error from `strconv.ParseInt` when parsing join user ID. If parsing fails, it answers the callback with an error message and returns. Previously ignored the error, which could cause `b.GetChat(0, nil)` to be called and leave the callback unanswered.

3. **warns.go**: Now checks the error from `strconv.Atoi` when parsing user ID for warn removal. If parsing fails, it answers the callback with an error message and returns. Previously ignored the error, which could silently remove the wrong user's warns if user 0 had any.

## TDD
- Red: Identified three callback parsing bugs via code review per issue #695
- Green: All fixes implemented with proper error handling and callback answers
- Refactor: Used existing translation key `common_callback_invalid_request` for consistency

## Validation
- `make lint`: Pass (0 issues)
- `make test`: Pass (all tests green)

## Risk
- **Low**: Small, focused changes to error handling only
- No API changes or breaking changes
- Uses existing translation key for error messages
- Callback handlers only; no core logic changes

## Auto-merge readiness
- Ready for auto-merge upon approval and passing checks
