### PR TITLE
fix: CI duplicate code detection step runs only dupl linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
         with:
           version: v2.9.0
           install-mode: binary
-          # Only run dupl linter, disable gocyclo from config
-          args: --disable gocyclo --timeout 10m
+          # Only run dupl linter, disable all other linters
+          args: --disable-all --enable dupl --timeout 10m
           # Only report new issues to allow gradual improvement
           only-new-issues: true
 


### PR DESCRIPTION
Fixes #701

## Summary
The duplicate code detection step was supposed to run only the `dupl` linter, but was only disabling `gocyclo`. This caused all default linters to still run, duplicating work from the main lint step.

## Changes
- Changed args from `--disable gocyclo` to `--disable-all --enable dupl`
- Updated comment to accurately reflect the intent

## TDD
- **TDD exception:** Configuration-only change (CI workflow YAML)
- **Alternative validation:** YAML syntax check passed

## Validation
- YAML syntax validated with Python yaml.safe_load
- `git diff` confirms minimal, targeted change (2 lines modified)

## Risk
- **Low:** Simple CI configuration change with no runtime impact
- Only affects the duplicate code detection step in CI
- No changes to application code

## Auto-merge readiness
- Ready: Low-risk configuration fix with clear scope