### PR TITLE
fix: remove dead code defer Stop() calls on monitoring systems

### DIFF
--- a/main.go
+++ b/main.go
@@ -262,19 +262,16 @@ func main() {
 		error_handling.SetOnErrorCallback(monitoring.GlobalRecordError)
 		tracing.SetOnProcessUpdateCallback(monitoring.GlobalRecordMessage)
 		statsCollector.Start()
-		defer statsCollector.Stop()
 	}
 
 	if config.AppConfig.EnablePerformanceMonitoring {
 		autoRemediation = monitoring.NewAutoRemediationManager(statsCollector)
 		autoRemediation.Start()
-		defer autoRemediation.Stop()
 	}
 
 	// Initialize activity monitoring for automatic group activity tracking
 	activityMonitor = monitoring.NewActivityMonitor()
 	activityMonitor.Start()
-	defer activityMonitor.Stop()
 
 	// Setup graceful shutdown
 	shutdownManager := shutdown.NewManager()


### PR DESCRIPTION
Fixes #700

## Summary
Remove three `defer Stop()` calls that are dead code because the shutdown path uses `os.Exit(0)` which bypasses deferred functions. The shutdown manager already handles stopping these systems correctly.

### Changes
- Removed `defer statsCollector.Stop()` (was line 265)
- Removed `defer autoRemediation.Stop()` (was line 271)
- Removed `defer activityMonitor.Stop()` (was line 277)

### Rationale
These deferred calls were never executed since `os.Exit(0)` bypasses deferred functions. The shutdown manager at lines 282-294 already handles proper cleanup by registering handlers that stop these monitoring systems during graceful shutdown.

## TDD Exception
This is a dead code removal with no behavioral changes. The existing shutdown manager already handles the cleanup, so no new tests were needed.

## Validation
- `go build`: Pass
- `golangci-lint run --timeout=5m`: No issues found
- `go test ./...`: 579 tests passed in 24 packages

## Risk
- **Level**: Low
- **Reason**: Dead code removal only. No functional changes. Shutdown path already handles cleanup via shutdown manager.

## Auto-merge readiness
- [x] All tests passing
- [x] Linting clean
- [x] Build successful
- [x] No breaking changes
- Ready for review and merge
