### PR TITLE
fix: add shutdown handler for async processor

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,7 +206,8 @@ func main() {
 	// Initialize async processing system
 	if config.AppConfig.EnableAsyncProcessing {
 		async.InitializeAsyncProcessor()
-		defer async.StopAsyncProcessor()
+		// Note: defer async.StopAsyncProcessor() removed - shutdown happens via os.Exit()
+		// The stop is now handled by the shutdown manager registered below
 	}
 
 	// Create dispatcher with limited max routines and proper error recovery
@@ -275,6 +276,15 @@ func main() {
 
 	// Setup graceful shutdown
 	shutdownManager := shutdown.NewManager()
+
+	// Register async processor shutdown handler (if enabled)
+	if config.AppConfig.EnableAsyncProcessing {
+		shutdownManager.RegisterHandler(func() error {
+			log.Info("[Shutdown] Stopping async processor...")
+			async.StopAsyncProcessor()
+			return nil
+		})
+	}
 
 	shutdownManager.RegisterHandler(func() error {
 		log.Info("[Shutdown] Stopping monitoring systems...")


### PR DESCRIPTION
## Summary

Fixes #711

The defer async.StopAsyncProcessor() at line 209 was dead code because os.Exit() bypasses deferred functions during shutdown. All shutdown paths in the bot use os.Exit() via shutdown/shutdown.go or log.Fatalf calls.

## Changes

- Remove dead defer async.StopAsyncProcessor() call
- Register shutdown manager handler to properly stop the async processor during graceful shutdown
- The handler is registered conditionally when EnableAsyncProcessing is true

## Validation

- [x] Build passes: go build succeeds
- [x] All tests pass: 588 tests pass in 24 packages
- [x] Code is properly formatted with gofmt

## Implementation Details

The fix follows the same pattern used for monitoring systems (lines 289-301 in main.go), registering a handler with the shutdown manager that executes during graceful shutdown in LIFO order. This ensures the async processor is properly signaled to stop when the bot exits, preventing resource leaks.