### PR TITLE
fix(db): remove Enabled field from ConnectionChatSettings struct

### DIFF
--- a/alita/db/db.go
+++ b/alita/db/db.go
@@ -443,7 +443,6 @@ func (ConnectionSettings) TableName() string {
 type ConnectionChatSettings struct {
 	ID           uint      `gorm:"primaryKey;autoIncrement" json:"-"`
 	ChatId       int64     `gorm:"column:chat_id;uniqueIndex;not null" json:"chat_id,omitempty"`
-	Enabled      bool      `gorm:"column:enabled;default:true" json:"enabled,omitempty"` // Connection enabled
 	AllowConnect bool      `gorm:"column:allow_connect;default:true" json:"allow_connect,omitempty"`
 	CreatedAt    time.Time `gorm:"column:created_at" json:"created_at,omitempty"`
 	UpdatedAt    time.Time `gorm:"column:updated_at" json:"updated_at,omitempty"`


### PR DESCRIPTION
## Summary

Fixes #690 - Removes the orphaned `Enabled` field from `ConnectionChatSettings` struct that was referencing a dropped database column.

## Problem

Migration `20251231131415_drop_connection_settings_enabled_column.sql` dropped the `enabled` column from the `connection_settings` table, but the `ConnectionChatSettings` struct in `alita/db/db.go` still mapped to it. This caused query errors in production:

```
ERROR: column "enabled" does not exist
```

## Solution

Removed the `Enabled` field from the struct. The codebase already uses `AllowConnect` as the authoritative field for connection functionality.

## Verification

- Build passes: `go build ./...` succeeds
- Lint clean: `golangci-lint` reports 0 issues  
- Tests pass: `go test ./alita/db` passes (exit code 0)

## Changes

```diff
alita/db/db.go | 1 -
1 file changed, 1 deletion(-)
```

## Acceptance Criteria

- [x] `Enabled` field removed from `ConnectionChatSettings`
- [x] No code references `ConnectionChatSettings.Enabled`
- [x] Build passes without errors
- [x] Tests pass
- [x] Lint passes

Fixes #690