### PR TITLE
fix(tests,i18n): add missing testtools build tags and clean up orphaned backup keys (#725)

### DIFF
--- a/alita/modules/backup_test.go
+++ b/alita/modules/backup_test.go
@@ -1,3 +1,5 @@
+//go:build testtools
+
 package modules
 
 import (

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -1,3 +1,5 @@
+//go:build testtools
+
 package modules
 
 import (

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -2442,10 +2442,6 @@ backup_module_purges: "Configuración de Purga"
 backup_module_reports: "Reportes"
 backup_module_rules: "Reglas"
 backup_module_warns: "Advertencias"
-backup_no_data: "❌ No hay datos disponibles para exportar."
-backup_reset_button: "⚠️ Restablecer"
-backup_text_header: "📦 Copia de Seguridad y Restauración\n\nExporta o importa la configuración de tu grupo."
-backup_upload_prompt: "Por favor sube tu archivo de copia de seguridad o haz clic en Cancelar."
 
 # Callback validation strings (previously hardcoded)
 common_callback_invalid_request: "Solicitud inválida."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2342,18 +2342,6 @@ backup_module_reports: "Signalements"
 backup_module_rules: "Règles"
 backup_module_warns: "Avertissements"
 
-# Additional backup keys mentioned in requirements
-backup_import_text_header: "📥 Importer les Paramètres\n\nTéléchargez un fichier de sauvegarde pour restaurer les paramètres."
-backup_invalid_file: "❌ Format de fichier invalide. Veuillez télécharger un fichier de sauvegarde JSON valide."
-backup_import_no_file: "❌ Veuillez télécharger un fichier de sauvegarde valide."
-backup_import_no_modules: "❌ Aucun module à importer trouvé dans le fichier de sauvegarde."
-backup_no_data: "❌ Aucune donnée disponible à exporter."
-backup_text_header: "📦 Sauvegarde & Restauration\n\nExportez ou importez les paramètres de votre groupe."
-backup_upload_prompt: "Veuillez télécharger votre fichier de sauvegarde ou cliquer sur Annuler."
-backup_module_bans: "Bannissements et Restrictions"
-backup_module_purges: "Paramètres de Purge"
-backup_module_disabled: "Commandes Désactivées"
-
 # Callback validation strings (previously hardcoded)
 common_callback_invalid_request: "Demande invalide."
 common_callback_message_unavailable: "Message n'est plus disponible."


### PR DESCRIPTION
## Description

This PR fixes two issues with the backup/test infrastructure:

1. **Missing `testtools` build tags**: `backup_test.go` and `captcha_math_image_test.go` both call `i18n.NewTestTranslator()`, which is guarded by `//go:build testtools`. These test files must also declare the same build tag, otherwise `go test` fails to compile when run without `-tags testtools`.

2. **Orphaned i18n keys in es.yml and fr.yml**: Removed unused backup translation keys that were added speculatively but never referenced in Go code, making locales consistent across all 7 supported languages.

## Related Issue

Closes #725

## How Has This Been Tested?

- `go test ./alita/modules/` - compiles and passes without `-tags testtools`
- `make test` - all tests pass with `-tags testtools`
- `make lint` - 0 issues
- `make check-translations` - all 7 locales consistent
