### PR TITLE
feat(cache): add Redis cache layer for NotesSettings with write invalidation (#735)

### DIFF
--- a/alita/db/cache_helpers.go
+++ b/alita/db/cache_helpers.go
@@ -21,6 +21,7 @@ const (
 	CacheTTLBlacklist       = 30 * time.Minute
 	CacheTTLGreetings       = 30 * time.Minute
 	CacheTTLNotesList       = 30 * time.Minute
+	CacheTTLNotesSettings   = 30 * time.Minute
 	CacheTTLWarnSettings    = 30 * time.Minute
 	CacheTTLAntiflood       = 30 * time.Minute
 	CacheTTLDisabledCmds    = 30 * time.Minute

--- a/alita/db/notes_db.go
+++ b/alita/db/notes_db.go
@@ -10,29 +10,37 @@ import (
 // getNotesSettings retrieves or creates default notes settings for a chat.
 // Used internally before performing any notes-related operation.
 // Returns default settings if the chat doesn't exist in the database.
-func getNotesSettings(chatID int64) (noteSrc *NotesSettings) {
-	noteSrc = &NotesSettings{}
-	err := GetRecord(noteSrc, NotesSettings{ChatId: chatID})
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		// Ensure chat exists before creating notes settings
-		if !ChatExists(chatID) {
-			// Chat doesn't exist, return default settings without creating record
-			log.Warnf("[Database][getNotesSettings]: Chat %d doesn't exist, returning default settings", chatID)
-			return &NotesSettings{ChatId: chatID, Private: false}
-		}
+// Results are cached with stampede protection for performance.
+func getNotesSettings(chatID int64) *NotesSettings {
+	settings, err := getFromCacheOrLoad(CacheKey("notes_settings", chatID), CacheTTLNotesSettings, func() (*NotesSettings, error) {
+		noteSrc := &NotesSettings{}
+		err := GetRecord(noteSrc, NotesSettings{ChatId: chatID})
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Ensure chat exists before creating notes settings
+			if !ChatExists(chatID) {
+				// Chat doesn't exist, return default settings without creating record
+				log.Warnf("[Database][getNotesSettings]: Chat %d doesn't exist, returning default settings", chatID)
+				return &NotesSettings{ChatId: chatID, Private: false}, nil
+			}
 
-		// Create default settings only if chat exists
-		noteSrc = &NotesSettings{ChatId: chatID, Private: false}
-		err := CreateRecord(noteSrc)
-		if err != nil {
-			log.Errorf("[Database][getNotesSettings]: %d - %v", chatID, err)
+			// Create default settings only if chat exists
+			noteSrc = &NotesSettings{ChatId: chatID, Private: false}
+			err := CreateRecord(noteSrc)
+			if err != nil {
+				log.Errorf("[Database][getNotesSettings]: %d - %v", chatID, err)
+			}
+		} else if err != nil {
+			// Return default on error
+			log.Errorf("[Database] getNotesSettings: %v - %d", err, chatID)
+			return &NotesSettings{ChatId: chatID, Private: false}, nil
 		}
-	} else if err != nil {
-		// Return default on error
-		noteSrc = &NotesSettings{ChatId: chatID, Private: false}
-		log.Errorf("[Database] getNotesSettings: %v - %d", err, chatID)
+		return noteSrc, nil
+	})
+	if err != nil {
+		log.Errorf("[Database][getNotesSettings]: cache load error %d - %v", chatID, err)
+		return &NotesSettings{ChatId: chatID, Private: false}
 	}
-	return
+	return settings
 }
 
 // getAllChatNotes retrieves all notes for a specific chat ID from the database.
@@ -200,6 +208,9 @@ func TooglePrivateNote(chatID int64, pref bool) error {
 		log.Errorf("[Database][TooglePrivateNote]: %d - %v", chatID, err)
 		return err
 	}
+
+	// Invalidate cache after update
+	deleteCache(CacheKey("notes_settings", chatID))
 	return nil
 }
 

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -16,8 +16,14 @@ func TestGetNotesSettings_Defaults(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	settings := GetNotes(chatID)
@@ -38,8 +44,14 @@ func TestSaveNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	buttons := ButtonArray{{Name: "click", Url: "https://example.com", SameLine: false}}
@@ -78,8 +90,14 @@ func TestGetAllNotes(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	noteNames := []string{"alpha", "beta", "gamma"}
@@ -114,8 +132,14 @@ func TestRemoveNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	if err := AddNote(chatID, "to-delete", "will be removed", "", ButtonArray{}, TEXT, false, false, false, false, false, false); err != nil {
@@ -145,8 +169,14 @@ func TestTogglePrivateNoteCreatesSettingsWhenMissing(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	if err := TooglePrivateNote(chatID, true); err != nil {
@@ -166,8 +196,14 @@ func TestToggleNotesPrivate(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	// Ensure settings record is created
@@ -199,8 +235,14 @@ func TestNoteUpsertBehavior(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	// First add
@@ -234,7 +276,10 @@ func TestGetAllNotes_EmptyChat(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	list := GetNotesList(chatID, false)
@@ -252,7 +297,10 @@ func TestRemoveNonExistentNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	// Removing a non-existent note should not return an error
@@ -270,8 +318,14 @@ func TestDoesNoteExists(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	if DoesNoteExists(chatID, "new-note") {
@@ -296,8 +350,14 @@ func TestLoadNotesStats(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	notesBefore, chatsBefore := LoadNotesStats()
@@ -344,8 +404,14 @@ func TestRemoveAllNotes(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	for _, name := range []string{"n1", "n2", "n3"} {
@@ -373,8 +439,14 @@ func TestAddNoteWithAdminOnly(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	// Add a note with adminOnly=true
@@ -404,8 +476,14 @@ func TestSaveNoteTwice_Overwrites(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 	})
 
 	// Save note v1
@@ -450,8 +528,14 @@ func TestNotesSettingsCacheInvalidation(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 		if m := cache.GetMarshal(); m != nil {
 			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
 		}
@@ -522,8 +606,14 @@ func TestNotesSettingsCacheDefaultsForMissingChat(t *testing.T) {
 	chatID := time.Now().UnixNano()
 	// Do NOT create the chat — chat does not exist.
 	t.Cleanup(func() {
-		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
-		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
+		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		if err != nil {
+			t.Fatalf("cleanup NotesSettings failed: %v", err)
+		}
+		err = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err != nil {
+			t.Fatalf("cleanup Chat failed: %v", err)
+		}
 		if m := cache.GetMarshal(); m != nil {
 			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
 		}

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -43,7 +43,9 @@ func TestSaveNote(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -89,7 +91,9 @@ func TestGetAllNotes(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -131,7 +135,9 @@ func TestRemoveNote(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -234,7 +240,9 @@ func TestNoteUpsertBehavior(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -275,7 +283,9 @@ func TestGetAllNotes_EmptyChat(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
 		if err != nil {
 			t.Fatalf("cleanup Chat failed: %v", err)
@@ -296,7 +306,9 @@ func TestRemoveNonExistentNote(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
 		if err != nil {
 			t.Fatalf("cleanup Chat failed: %v", err)
@@ -317,7 +329,9 @@ func TestDoesNoteExists(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -349,7 +363,9 @@ func TestLoadNotesStats(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -403,7 +419,9 @@ func TestRemoveAllNotes(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -438,7 +456,9 @@ func TestAddNoteWithAdminOnly(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)
@@ -475,7 +495,9 @@ func TestSaveNoteTwice_Overwrites(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error; err != nil {
+			t.Fatalf("cleanup Notes failed: %v", err)
+		}
 		err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
 		if err != nil {
 			t.Fatalf("cleanup NotesSettings failed: %v", err)

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/divkix/Alita_Robot/alita/utils/cache"
 )
 
 func TestGetNotesSettings_Defaults(t *testing.T) {
@@ -436,5 +438,107 @@ func TestSaveNoteTwice_Overwrites(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected 1 entry for 'my-note', got %d; list: %v", count, list)
+	}
+}
+
+func TestNotesSettingsCacheInvalidation(t *testing.T) {
+	skipIfNoDb(t)
+	cache.SetupTestMemoryMarshaler(t)
+
+	chatID := time.Now().UnixNano()
+	if err := EnsureChatInDb(chatID, "test-cache-invalidation"); err != nil {
+		t.Fatalf("EnsureChatInDb() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if m := cache.GetMarshal(); m != nil {
+			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
+		}
+	})
+
+	// Establish baseline: default settings (Private=false) are read from DB
+	// and cached by getFromCacheOrLoad.
+	settings := GetNotes(chatID)
+	if settings == nil {
+		t.Fatalf("GetNotes() returned nil")
+	}
+	if settings.Private {
+		t.Fatalf("expected default Private=false")
+	}
+
+	// Corrupt the cache with a stale value.
+	// If TooglePrivateNote forgets to invalidate cache, the next GetNotes
+	// will serve this stale false instead of the DB truth.
+	stale := &NotesSettings{ChatId: chatID, Private: false}
+	if err := cache.GetMarshal().Set(cache.Context, CacheKey("notes_settings", chatID), stale); err != nil {
+		t.Fatalf("failed to seed stale cache: %v", err)
+	}
+
+	// Toggle private notes on — must invalidate cache.
+	if err := TooglePrivateNote(chatID, true); err != nil {
+		t.Fatalf("TooglePrivateNote(true) error = %v", err)
+	}
+
+	// Verify the stale cache entry was evicted.
+	var cached NotesSettings
+	_, cacheErr := cache.GetMarshal().Get(cache.Context, CacheKey("notes_settings", chatID), &cached)
+	if cacheErr == nil && !cached.Private {
+		t.Fatalf("cache was not invalidated after TooglePrivateNote(true)")
+	}
+
+	// GetNotes must reflect the toggled value, not a stale cache entry.
+	settings = GetNotes(chatID)
+	if settings == nil || !settings.Private {
+		t.Fatalf("expected Private=true after toggle, got %+v", settings)
+	}
+
+	// Corrupt cache again to test toggle(false) invalidation.
+	stale = &NotesSettings{ChatId: chatID, Private: true}
+	if err := cache.GetMarshal().Set(cache.Context, CacheKey("notes_settings", chatID), stale); err != nil {
+		t.Fatalf("failed to seed stale cache for false toggle: %v", err)
+	}
+
+	// Toggle back to false.
+	if err := TooglePrivateNote(chatID, false); err != nil {
+		t.Fatalf("TooglePrivateNote(false) error = %v", err)
+	}
+
+	_, cacheErr = cache.GetMarshal().Get(cache.Context, CacheKey("notes_settings", chatID), &cached)
+	if cacheErr == nil && cached.Private {
+		t.Fatalf("cache was not invalidated after TooglePrivateNote(false)")
+	}
+
+	settings = GetNotes(chatID)
+	if settings == nil || settings.Private {
+		t.Fatalf("expected Private=false after toggle back, got %+v", settings)
+	}
+}
+
+func TestNotesSettingsCacheDefaultsForMissingChat(t *testing.T) {
+	skipIfNoDb(t)
+	cache.SetupTestMemoryMarshaler(t)
+
+	chatID := time.Now().UnixNano()
+	// Do NOT create the chat — chat does not exist.
+	t.Cleanup(func() {
+		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
+		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if m := cache.GetMarshal(); m != nil {
+			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
+		}
+	})
+
+	settings := GetNotes(chatID)
+	if settings == nil {
+		t.Fatalf("GetNotes() returned nil")
+	}
+	if settings.Private {
+		t.Fatalf("expected default Private=false for non-existent chat")
+	}
+
+	// Ensure the call was safe even when chat does not exist.
+	if settings.ChatId != chatID {
+		t.Fatalf("expected ChatId=%d, got %d", chatID, settings.ChatId)
 	}
 }

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -16,8 +16,8 @@ func TestGetNotesSettings_Defaults(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	settings := GetNotes(chatID)
@@ -38,8 +38,8 @@ func TestSaveNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	buttons := ButtonArray{{Name: "click", Url: "https://example.com", SameLine: false}}
@@ -78,8 +78,8 @@ func TestGetAllNotes(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	noteNames := []string{"alpha", "beta", "gamma"}
@@ -114,8 +114,8 @@ func TestRemoveNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	if err := AddNote(chatID, "to-delete", "will be removed", "", ButtonArray{}, TEXT, false, false, false, false, false, false); err != nil {
@@ -145,8 +145,8 @@ func TestTogglePrivateNoteCreatesSettingsWhenMissing(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	if err := TooglePrivateNote(chatID, true); err != nil {
@@ -166,8 +166,8 @@ func TestToggleNotesPrivate(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	// Ensure settings record is created
@@ -199,8 +199,8 @@ func TestNoteUpsertBehavior(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	// First add
@@ -234,7 +234,7 @@ func TestGetAllNotes_EmptyChat(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	list := GetNotesList(chatID, false)
@@ -252,7 +252,7 @@ func TestRemoveNonExistentNote(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	// Removing a non-existent note should not return an error
@@ -270,8 +270,8 @@ func TestDoesNoteExists(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	if DoesNoteExists(chatID, "new-note") {
@@ -296,8 +296,8 @@ func TestLoadNotesStats(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	notesBefore, chatsBefore := LoadNotesStats()
@@ -344,8 +344,8 @@ func TestRemoveAllNotes(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	for _, name := range []string{"n1", "n2", "n3"} {
@@ -373,8 +373,8 @@ func TestAddNoteWithAdminOnly(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	// Add a note with adminOnly=true
@@ -404,8 +404,8 @@ func TestSaveNoteTwice_Overwrites(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = DB.Where("chat_id = ?", chatID).Delete(&Notes{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 	})
 
 	// Save note v1
@@ -450,8 +450,8 @@ func TestNotesSettingsCacheInvalidation(t *testing.T) {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 		if m := cache.GetMarshal(); m != nil {
 			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
 		}
@@ -522,8 +522,8 @@ func TestNotesSettingsCacheDefaultsForMissingChat(t *testing.T) {
 	chatID := time.Now().UnixNano()
 	// Do NOT create the chat — chat does not exist.
 	t.Cleanup(func() {
-		_ = DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error
-		_ = DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error
+		if err := DB.Where("chat_id = ?", chatID).Delete(&NotesSettings{}).Error; err != nil { t.Fatalf("cleanup NotesSettings failed: %v", err) }
+		if err := DB.Where("chat_id = ?", chatID).Delete(&Chat{}).Error; err != nil { t.Fatalf("cleanup Chat failed: %v", err) }
 		if m := cache.GetMarshal(); m != nil {
 			_ = m.Delete(cache.Context, CacheKey("notes_settings", chatID))
 		}


### PR DESCRIPTION
## Description

This PR resolves the architectural inconsistency noted in #735: notes settings were the only per-chat settings module reading directly from PostgreSQL via `GetRecord` without a Redis cache layer, while peers (captcha, filters, greetings, antiraid, etc.) all use `getFromCacheOrLoad` with stampede protection and invalidate on write.

### Changes

1. **`alita/db/cache_helpers.go`** — Added `CacheTTLNotesSettings = 30 * time.Minute` alongside existing TTL constants.

2. **`alita/db/notes_db.go`** — Two changes:
   - Wrapped `getNotesSettings` with `getFromCacheOrLoad(CacheKey("notes_settings", chatID), CacheTTLNotesSettings, loader)`. The loader preserves all existing behavior: chat missing → defaults; chat exists but no settings row → create defaults; DB error → defaults. Returns `*NotesSettings` (never nil).
   - Added `deleteCache(CacheKey("notes_settings", chatID))` at the end of `TooglePrivateNote`, after the successful `UpdateRecordWithZeroValues`.

3. **`alita/db/notes_db_test.go`** — Two new TDD tests:
   - `TestNotesSettingsCacheInvalidation` — seeds stale cache values, asserts `TooglePrivateNote(true/false)` evicts them, and verifies the next `GetNotes` reads fresh DB state.
   - `TestNotesSettingsCacheDefaultsForMissingChat` — verifies `getNotesSettings` loader correctly returns defaults when the chat does not exist (cached path).

### Edge cases handled

- Chat does not exist yet: loader returns defaults, cached. Future `TooglePrivateNote` triggers `ensureNotesSettingsRecord` (creates chat + settings) then `deleteCache`, invalidating the stale default.
- Transient DB error: loader returns defaults, cached. Next write invalidates and loads fresh.
- `getNotesSettings` internally creates record: valid data cached immediately.
- `ensureNotesSettingsRecord` inside `TooglePrivateNote` writes, then final `deleteCache` covers both that and the `UpdateRecordWithZeroValues`.

## Related Issue

Closes #735

## How Has This Been Tested?

- `go test -tags testtools -run "^Test.*[Nn]ote" ./alita/db/` — all 19 notes tests pass (existing + 2 new)
- `make test` — full suite green (race detection, coverage)
- `make lint` — 0 issues
