### PR TITLE
feat(helpers): introduce Command Permission Pipeline (closes #741)

### DIFF
--- a/alita/db/blacklists_db_test.go
+++ b/alita/db/blacklists_db_test.go
@@ -3,10 +3,6 @@ package db
 import (
 	"testing"
 	"time"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func TestAddBlacklistTrigger(t *testing.T) {
@@ -166,16 +162,12 @@ func TestLoadBlacklistStats(t *testing.T) {
 }
 
 func TestLoadBlacklistStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&BlacklistSettings{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&BlacklistSettings{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	triggers, chats := LoadBlacklistsStats()
 	if triggers != 0 || chats != 0 {

--- a/alita/db/blacklists_db_test.go
+++ b/alita/db/blacklists_db_test.go
@@ -3,6 +3,10 @@ package db
 import (
 	"testing"
 	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestAddBlacklistTrigger(t *testing.T) {
@@ -158,6 +162,24 @@ func TestLoadBlacklistStats(t *testing.T) {
 	}
 	if chats < 0 {
 		t.Errorf("LoadBlacklistsStats chats = %d, want >= 0", chats)
+	}
+}
+
+func TestLoadBlacklistStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	triggers, chats := LoadBlacklistsStats()
+	if triggers != 0 || chats != 0 {
+		t.Fatalf("LoadBlacklistsStats() = (%d, %d), want (0, 0) on error", triggers, chats)
 	}
 }
 

--- a/alita/db/blacklists_db_test.go
+++ b/alita/db/blacklists_db_test.go
@@ -164,9 +164,9 @@ func TestLoadBlacklistStats(t *testing.T) {
 func TestLoadBlacklistStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&BlacklistSettings{})
+	_ = DB.Migrator().DropTable(&BlacklistSettings{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&BlacklistSettings{})
+		_ = DB.AutoMigrate(&BlacklistSettings{})
 	})
 
 	triggers, chats := LoadBlacklistsStats()

--- a/alita/db/channels_db_test.go
+++ b/alita/db/channels_db_test.go
@@ -157,9 +157,9 @@ func TestUpdateChannel(t *testing.T) {
 func TestLoadChannelStats_ErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&ChannelSettings{})
+	_ = DB.Migrator().DropTable(&ChannelSettings{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&ChannelSettings{})
+		_ = DB.AutoMigrate(&ChannelSettings{})
 	})
 
 	count := LoadChannelStats()

--- a/alita/db/channels_db_test.go
+++ b/alita/db/channels_db_test.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -147,5 +151,27 @@ func TestUpdateChannel(t *testing.T) {
 	}
 	if ch.ChannelName != updatedName {
 		t.Errorf("channel name = %q, want %q", ch.ChannelName, updatedName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadChannelStats
+// ---------------------------------------------------------------------------
+
+func TestLoadChannelStats_ErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	count := LoadChannelStats()
+	if count != 0 {
+		t.Fatalf("LoadChannelStats() = %d, want 0 on error", count)
 	}
 }

--- a/alita/db/channels_db_test.go
+++ b/alita/db/channels_db_test.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -159,16 +155,12 @@ func TestUpdateChannel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLoadChannelStats_ErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&ChannelSettings{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&ChannelSettings{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	count := LoadChannelStats()
 	if count != 0 {

--- a/alita/db/connections_db_test.go
+++ b/alita/db/connections_db_test.go
@@ -249,9 +249,9 @@ func TestLoadConnectionStats(t *testing.T) {
 func TestLoadConnectionStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&ConnectionChatSettings{})
+	_ = DB.Migrator().DropTable(&ConnectionChatSettings{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&ConnectionChatSettings{})
+		_ = DB.AutoMigrate(&ConnectionChatSettings{})
 	})
 
 	users, chats := LoadConnectionStats()

--- a/alita/db/connections_db_test.go
+++ b/alita/db/connections_db_test.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestConnectChat(t *testing.T) {
@@ -243,6 +247,24 @@ func TestLoadConnectionStats(t *testing.T) {
 	}
 	if connectedChats < 0 {
 		t.Fatalf("LoadConnectionStats() connectedChats=%d, want >= 0", connectedChats)
+	}
+}
+
+func TestLoadConnectionStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	users, chats := LoadConnectionStats()
+	if users != 0 || chats != 0 {
+		t.Fatalf("LoadConnectionStats() = (%d, %d), want (0, 0) on error", users, chats)
 	}
 }
 

--- a/alita/db/connections_db_test.go
+++ b/alita/db/connections_db_test.go
@@ -4,10 +4,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func TestConnectChat(t *testing.T) {
@@ -251,16 +247,12 @@ func TestLoadConnectionStats(t *testing.T) {
 }
 
 func TestLoadConnectionStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&ConnectionChatSettings{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&ConnectionChatSettings{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	users, chats := LoadConnectionStats()
 	if users != 0 || chats != 0 {

--- a/alita/db/disable_db_test.go
+++ b/alita/db/disable_db_test.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestDisableCommand(t *testing.T) {
@@ -163,6 +167,24 @@ func TestLoadDisableStats(t *testing.T) {
 	}
 	if disableEnabledChats < 0 {
 		t.Fatalf("LoadDisableStats() disableEnabledChats=%d, want >= 0", disableEnabledChats)
+	}
+}
+
+func TestLoadDisableStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	cmds, chats := LoadDisableStats()
+	if cmds != 0 || chats != 0 {
+		t.Fatalf("LoadDisableStats() = (%d, %d), want (0, 0) on error", cmds, chats)
 	}
 }
 

--- a/alita/db/disable_db_test.go
+++ b/alita/db/disable_db_test.go
@@ -5,10 +5,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func TestDisableCommand(t *testing.T) {
@@ -171,16 +167,12 @@ func TestLoadDisableStats(t *testing.T) {
 }
 
 func TestLoadDisableStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&DisableSettings{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&DisableSettings{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	cmds, chats := LoadDisableStats()
 	if cmds != 0 || chats != 0 {

--- a/alita/db/disable_db_test.go
+++ b/alita/db/disable_db_test.go
@@ -169,9 +169,9 @@ func TestLoadDisableStats(t *testing.T) {
 func TestLoadDisableStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&DisableSettings{})
+	_ = DB.Migrator().DropTable(&DisableSettings{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&DisableSettings{})
+		_ = DB.AutoMigrate(&DisableSettings{})
 	})
 
 	cmds, chats := LoadDisableStats()

--- a/alita/db/filters_db_test.go
+++ b/alita/db/filters_db_test.go
@@ -143,9 +143,9 @@ func TestLoadFilterStats(t *testing.T) {
 func TestLoadFilterStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&ChatFilters{})
+	_ = DB.Migrator().DropTable(&ChatFilters{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&ChatFilters{})
+		_ = DB.AutoMigrate(&ChatFilters{})
 	})
 
 	total, chats := LoadFilterStats()

--- a/alita/db/filters_db_test.go
+++ b/alita/db/filters_db_test.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestAddAndGetFiltersList(t *testing.T) {
@@ -137,6 +141,24 @@ func TestLoadFilterStats(t *testing.T) {
 	}
 	if chats < 0 {
 		t.Errorf("LoadFilterStats chats = %d, want >= 0", chats)
+	}
+}
+
+func TestLoadFilterStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	total, chats := LoadFilterStats()
+	if total != 0 || chats != 0 {
+		t.Fatalf("LoadFilterStats() = (%d, %d), want (0, 0) on error", total, chats)
 	}
 }
 

--- a/alita/db/filters_db_test.go
+++ b/alita/db/filters_db_test.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func TestAddAndGetFiltersList(t *testing.T) {
@@ -145,16 +141,12 @@ func TestLoadFilterStats(t *testing.T) {
 }
 
 func TestLoadFilterStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&ChatFilters{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&ChatFilters{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	total, chats := LoadFilterStats()
 	if total != 0 || chats != 0 {

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -6,10 +6,6 @@ import (
 	"time"
 
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func TestGetNotesSettings_Defaults(t *testing.T) {
@@ -416,16 +412,12 @@ func TestLoadNotesStats(t *testing.T) {
 }
 
 func TestLoadNotesStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&Notes{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&Notes{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	notes, chats := LoadNotesStats()
 	if notes != 0 || chats != 0 {

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -6,6 +6,10 @@ import (
 	"time"
 
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestGetNotesSettings_Defaults(t *testing.T) {
@@ -408,6 +412,24 @@ func TestLoadNotesStats(t *testing.T) {
 	}
 	if chatsAfter < 1 {
 		t.Fatalf("expected chatsUsingNotes to be >= 1 after AddNote, got %d", chatsAfter)
+	}
+}
+
+func TestLoadNotesStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	notes, chats := LoadNotesStats()
+	if notes != 0 || chats != 0 {
+		t.Fatalf("LoadNotesStats() = (%d, %d), want (0, 0) on error", notes, chats)
 	}
 }
 

--- a/alita/db/notes_db_test.go
+++ b/alita/db/notes_db_test.go
@@ -414,9 +414,9 @@ func TestLoadNotesStats(t *testing.T) {
 func TestLoadNotesStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&Notes{})
+	_ = DB.Migrator().DropTable(&Notes{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&Notes{})
+		_ = DB.AutoMigrate(&Notes{})
 	})
 
 	notes, chats := LoadNotesStats()

--- a/alita/db/user_db_test.go
+++ b/alita/db/user_db_test.go
@@ -9,10 +9,6 @@ import (
 	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
-
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -288,16 +284,12 @@ func TestLoadUserStats(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLoadUsersStatsErrorBranch(t *testing.T) {
-	originalDB := DB
-	t.Cleanup(func() { DB = originalDB })
+	skipIfNoDb(t)
 
-	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	DB.Migrator().DropTable(&User{})
+	t.Cleanup(func() {
+		DB.AutoMigrate(&User{})
 	})
-	if err != nil {
-		t.Fatalf("gorm.Open error: %v", err)
-	}
-	DB = tempDB
 
 	count := LoadUsersStats()
 	if count != 0 {

--- a/alita/db/user_db_test.go
+++ b/alita/db/user_db_test.go
@@ -286,9 +286,9 @@ func TestLoadUserStats(t *testing.T) {
 func TestLoadUsersStatsErrorBranch(t *testing.T) {
 	skipIfNoDb(t)
 
-	DB.Migrator().DropTable(&User{})
+	_ = DB.Migrator().DropTable(&User{})
 	t.Cleanup(func() {
-		DB.AutoMigrate(&User{})
+		_ = DB.AutoMigrate(&User{})
 	})
 
 	count := LoadUsersStats()

--- a/alita/db/user_db_test.go
+++ b/alita/db/user_db_test.go
@@ -9,6 +9,10 @@ import (
 	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // ---------------------------------------------------------------------------
@@ -282,6 +286,24 @@ func TestLoadUserStats(t *testing.T) {
 // ---------------------------------------------------------------------------
 // LoadUserActivityStats
 // ---------------------------------------------------------------------------
+
+func TestLoadUsersStatsErrorBranch(t *testing.T) {
+	originalDB := DB
+	t.Cleanup(func() { DB = originalDB })
+
+	tempDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open error: %v", err)
+	}
+	DB = tempDB
+
+	count := LoadUsersStats()
+	if count != 0 {
+		t.Fatalf("LoadUsersStats() = %d, want 0 on error", count)
+	}
+}
 
 func TestLoadUserActivityStats(t *testing.T) {
 	skipIfNoDb(t)

--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -385,15 +385,30 @@ func (m moduleStruct) promote(c *helpers.CommandContext) error {
 		log.Error(err)
 		return err
 	}
+	if userMember == nil {
+		err := fmt.Errorf("GetMember returned nil for userId %d", userId)
+		log.Error(err)
+		return err
+	}
 
 	promoterMember, err := c.Chat.GetMember(c.Bot, c.User.Id, nil)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
+	if promoterMember == nil {
+		err := fmt.Errorf("GetMember returned nil for promoterId %d", c.User.Id)
+		log.Error(err)
+		return err
+	}
 
 	botMember, err := c.Chat.GetMember(c.Bot, c.Bot.Id, nil)
 	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if botMember == nil {
+		err := fmt.Errorf("GetMember returned nil for botId %d", c.Bot.Id)
 		log.Error(err)
 		return err
 	}
@@ -529,6 +544,11 @@ func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 
 	userMember, err := chat.GetMember(c.Bot, userId, nil)
 	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if userMember == nil {
+		err := fmt.Errorf("GetMember returned nil for userId %d", userId)
 		log.Error(err)
 		return err
 	}

--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -28,32 +28,19 @@ Connection - false, false
 */
 // adminlist handles the /adminlist command to display all admins in a group.
 // It returns a cached or fresh list of group administrators excluding bots and anonymous admins.
-func (m moduleStruct) adminlist(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
+func (m moduleStruct) adminlist(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
 	cached := true
 
-	// if command is disabled, return
-	if chat_status.CheckDisabledCmd(b, msg, "adminlist") {
-		return ext.EndGroups
-	}
-
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-
-	// permission checks
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
+	tr := c.Tr
 
 	temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_adminlist")
 	text := fmt.Sprintf(temp, helpers.HtmlEscape(chat.Title))
 
 	adminsAvail, admins := cache.GetAdminCacheList(chat.Id)
 	if !adminsAvail {
-		admins = cache.LoadAdminCache(b, chat.Id)
+		admins = cache.LoadAdminCache(c.Bot, chat.Id)
 		cached = false
 	}
 
@@ -85,7 +72,7 @@ func (m moduleStruct) adminlist(b *gotgbot.Bot, ctx *ext.Context) error {
 		noteText, _ := tr.GetString("admin_adminlist_note_cached")
 		text += noteText
 	}
-	_, err := msg.Reply(b, text, helpers.Shtml())
+	_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 	if err != nil {
 		log.Error(err)
 		return err
@@ -102,55 +89,33 @@ Bot can only Demote people it promoted! */
 
 // demote handles the /demote command to remove admin privileges from a user.
 // The bot can only demote users it has previously promoted.
-func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
+func (m moduleStruct) demote(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	tr := c.Tr
 
 	// Validate admin cache before proceeding
 	adminsAvail, admins := cache.GetAdminCacheList(chat.Id)
 	if !adminsAvail {
-		admins = cache.LoadAdminCache(b, chat.Id)
+		admins = cache.LoadAdminCache(c.Bot, chat.Id)
 	}
 
 	// If we still can't get admin list, inform user and abort
 	if len(admins.UserInfo) == 0 {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_admin_cache_failed")
-		_, err := msg.Reply(b, text, nil)
+		_, err := msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 		}
 		return ext.EndGroups
 	}
 
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPromote(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPromote(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-
-	userId := extraction.ExtractUser(b, ctx)
+	userId := extraction.ExtractUser(c.Bot, c.Ctx)
 	if userId == -1 {
 		return ext.EndGroups
 	} else if chat_status.IsChannelId(userId) {
 		text, _ := tr.GetString("common_anonymous_user_error")
-		_, err := msg.Reply(b, text, nil)
+		_, err := msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -158,7 +123,7 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	} else if userId == 0 {
 		text, _ := tr.GetString("common_no_user_specified")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -166,9 +131,9 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	if chat_status.RequireUserOwner(b, ctx, nil, userId, true) {
+	if chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, userId, true) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_owner")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -176,9 +141,9 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 
 		return ext.EndGroups
 	}
-	if userId == b.Id {
+	if userId == c.Bot.Id {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_bot_itself")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -188,9 +153,9 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	// Using IsUserAdmin (not RequireUserAdmin) because we need a custom error message
 	// specific to the demote context rather than the generic permission error
-	if !chat_status.IsUserAdmin(b, chat.Id, userId) {
+	if !chat_status.IsUserAdmin(c.Bot, chat.Id, userId) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_not_admin")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -199,7 +164,7 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	bb, err := chat.PromoteMember(b,
+	bb, err := chat.PromoteMember(c.Bot,
 		userId,
 		&gotgbot.PromoteChatMemberOpts{
 			CanPostMessages:     false,
@@ -216,7 +181,7 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 	if err != nil || !bb {
 		log.Error(err)
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_demote")
-		_, err = msg.Reply(b, text, nil)
+		_, err = msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -228,7 +193,7 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 	// Invalidate admin cache immediately after successful demotion
 	cache.InvalidateAdminCache(chat.Id)
 
-	userMember, err := chat.GetMember(b, userId, nil)
+	userMember, err := chat.GetMember(c.Bot, userId, nil)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -241,7 +206,7 @@ func (m moduleStruct) demote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	mem := userMember.MergeChatMember().User
-	_, err = msg.Reply(b,
+	_, err = msg.Reply(c.Bot,
 		func() string {
 			temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_success_demote")
 			return fmt.Sprintf(temp, helpers.MentionHtml(mem.Id, mem.FirstName))
@@ -264,57 +229,36 @@ Bot will give promoted user permissions of bot*/
 
 // promote handles the /promote command to grant admin privileges to a user.
 // The bot grants permissions based on its own capabilities and the promoter's status.
-func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+func (m moduleStruct) promote(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	user := c.User
+	tr := c.Tr
 
 	extraText := ""
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
 
 	// Validate admin cache before proceeding
 	adminsAvail, admins := cache.GetAdminCacheList(chat.Id)
 	if !adminsAvail {
-		admins = cache.LoadAdminCache(b, chat.Id)
+		admins = cache.LoadAdminCache(c.Bot, chat.Id)
 	}
 
 	// If we still can't get admin list, inform user and abort
 	if len(admins.UserInfo) == 0 {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_admin_cache_failed")
-		_, err := msg.Reply(b, text, nil)
+		_, err := msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 		}
 		return ext.EndGroups
 	}
 
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPromote(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPromote(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-
-	userId, customTitle := extraction.ExtractUserAndText(b, ctx)
+	userId, customTitle := extraction.ExtractUserAndText(c.Bot, c.Ctx)
 	if userId == -1 {
 		return ext.EndGroups
 	} else if chat_status.IsChannelId(userId) {
 		text, _ := tr.GetString("common_anonymous_user_error")
-		_, err := msg.Reply(b, text, nil)
+		_, err := msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -322,7 +266,7 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	} else if userId == 0 {
 		text, _ := tr.GetString("common_no_user_specified")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -330,9 +274,9 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	if userId == b.Id {
+	if userId == c.Bot.Id {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_bot_itself")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -342,9 +286,9 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	// checks if user being promoted is already admin or owner
-	if chat_status.RequireUserOwner(b, ctx, nil, userId, true) {
+	if chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, userId, true) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_owner")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -352,9 +296,9 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 
 		return ext.EndGroups
 	}
-	if chat_status.IsUserAdmin(b, chat.Id, userId) {
+	if chat_status.IsUserAdmin(c.Bot, chat.Id, userId) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_admin")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -363,19 +307,19 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	userMember, err := chat.GetMember(b, userId, nil)
+	userMember, err := chat.GetMember(c.Bot, userId, nil)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
-	promoterMember, err := chat.GetMember(b, user.Id, nil)
+	promoterMember, err := chat.GetMember(c.Bot, user.Id, nil)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
-	botMember, err := chat.GetMember(b, b.Id, nil)
+	botMember, err := chat.GetMember(c.Bot, c.Bot.Id, nil)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -387,7 +331,7 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	teamMem := db.GetTeamMemInfo(user.Id)
 	teamMemInfo := teamMem.Sudo || teamMem.IsDev
-	isPromoterOwner := chat_status.RequireUserOwner(b, ctx, nil, user.Id, true)
+	isPromoterOwner := chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, user.Id, true)
 
 	// Privilege Escalation Behavior (Intentional):
 	// - Group owners and sudo/dev team members can grant full bot-level permissions
@@ -396,7 +340,7 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 	// that normally prevents admins from granting permissions they don't have.
 	checkCommonPerms := isPromoterOwner || teamMemInfo
 
-	status, err := chat.PromoteMember(b,
+	status, err := chat.PromoteMember(c.Bot,
 		userId,
 		&gotgbot.PromoteChatMemberOpts{
 			CanPostMessages:     bMem.CanPostMessages && (pMem.CanPostMessages || checkCommonPerms),
@@ -412,7 +356,7 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 	)
 	if err != nil || !status {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_promote")
-		_, _ = msg.Reply(b, text, helpers.Shtml())
+		_, _ = msg.Reply(c.Bot, text, helpers.Shtml())
 		if err == nil {
 			err = fmt.Errorf("promote member returned false status")
 		}
@@ -433,14 +377,14 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 	// set the custom title
 	if customTitle != "" {
 		_, err = chat.SetAdministratorCustomTitle(
-			b,
+			c.Bot,
 			userId,
 			customTitle,
 			nil,
 		)
 		if err != nil {
 			text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_set_title")
-			_, err = msg.Reply(b, text, nil)
+			_, err = msg.Reply(c.Bot, text, nil)
 			if err != nil {
 				log.Error(err)
 			}
@@ -449,7 +393,7 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	mem := userMember.MergeChatMember().User
-	_, err = msg.Reply(b,
+	_, err = msg.Reply(c.Bot,
 		func() string {
 			temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_success_promote")
 			return fmt.Sprintf(temp, helpers.MentionHtml(mem.Id, mem.FirstName))
@@ -466,32 +410,22 @@ func (m moduleStruct) promote(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // getinvitelink handles the /invitelink command to retrieve the chat's invite link.
 // Returns either the public username or generates an invite link for private groups.
-func (moduleStruct) getinvitelink(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+func (moduleStruct) getinvitelink(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	tr := c.Tr
 
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.Caninvite(b, ctx, nil, msg, false) {
-		return ext.EndGroups
-	}
 	if chat.Username != "" {
 		linkText, _ := tr.GetString("admin_invitelink_public")
-		_, _ = msg.Reply(b, fmt.Sprintf(linkText, helpers.HtmlEscape(chat.Username)), nil)
+		_, _ = msg.Reply(c.Bot, fmt.Sprintf(linkText, helpers.HtmlEscape(chat.Username)), nil)
 	} else {
-		nchat, err := b.GetChat(chat.Id, nil)
+		nchat, err := c.Bot.GetChat(chat.Id, nil)
 		if err != nil {
-			_, _ = msg.Reply(b, err.Error(), nil)
+			_, _ = msg.Reply(c.Bot, err.Error(), nil)
 			return ext.EndGroups
 		}
 		linkText, _ := tr.GetString("admin_invitelink_private")
-		_, _ = msg.Reply(b, fmt.Sprintf(linkText, nchat.InviteLink), nil)
+		_, _ = msg.Reply(c.Bot, fmt.Sprintf(linkText, nchat.InviteLink), nil)
 	}
 	return ext.EndGroups
 }
@@ -502,38 +436,17 @@ Only works with admins whom bot has promoted.*/
 
 // setTitle handles the /title command to set a custom administrator title.
 // Only works with admins that the bot has promoted and titles are limited to 16 characters.
-func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	tr := c.Tr
 
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPromote(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPromote(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-
-	userId, customTitle := extraction.ExtractUserAndText(b, ctx)
+	userId, customTitle := extraction.ExtractUserAndText(c.Bot, c.Ctx)
 	if userId == -1 {
 		return ext.EndGroups
 	} else if chat_status.IsChannelId(userId) {
 		text, _ := tr.GetString("common_anonymous_user_error")
-		_, err := msg.Reply(b, text, nil)
+		_, err := msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -541,7 +454,7 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	} else if userId == 0 {
 		text, _ := tr.GetString("common_no_user_specified")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -549,18 +462,18 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	if chat_status.RequireUserOwner(b, ctx, nil, userId, true) {
+	if chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, userId, true) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_is_owner")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
 		}
 		return ext.EndGroups
 	}
-	if !chat_status.IsUserAdmin(b, chat.Id, userId) {
+	if !chat_status.IsUserAdmin(c.Bot, chat.Id, userId) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_is_admin")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -568,9 +481,9 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	if userId == b.Id {
+	if userId == c.Bot.Id {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_is_bot_itself")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -583,7 +496,7 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 	var extraText string
 	if customTitle == "" {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_title_empty")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -596,7 +509,7 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 		customTitle = customTitle[0:16]
 	}
 
-	_, err := chat.SetAdministratorCustomTitle(b,
+	_, err := chat.SetAdministratorCustomTitle(c.Bot,
 		userId,
 		customTitle,
 		nil,
@@ -604,11 +517,11 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 	if err != nil {
 		log.Error(err)
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_set_title")
-		_, _ = msg.Reply(b, text, helpers.Shtml())
+		_, _ = msg.Reply(c.Bot, text, helpers.Shtml())
 		return err
 	}
 
-	userMember, err := chat.GetMember(b, userId, nil)
+	userMember, err := chat.GetMember(c.Bot, userId, nil)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -616,7 +529,7 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	mem := userMember.MergeChatMember()
 
-	_, err = msg.Reply(b,
+	_, err = msg.Reply(c.Bot,
 		func() string {
 			temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_success_set")
 			return fmt.Sprintf(temp, mem.User.FirstName, mem.CustomTitle)
@@ -633,25 +546,14 @@ func (m moduleStruct) setTitle(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // anonAdmin handles the /anonadmin command to toggle anonymous admin mode in groups.
 // Only chat owners can modify this setting which affects how anonymous admins are handled.
-func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	args := ctx.Args()
+func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	user := c.User
+	args := c.Ctx.Args()
 
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+	tr := c.Tr
 	var text string
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
 
 	adminSettings := db.GetAdminSettings(chat.Id)
 
@@ -665,7 +567,7 @@ func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	} else {
 		// only need owner if you want to change value
-		if !chat_status.RequireUserOwner(b, ctx, nil, user.Id, false) {
+		if !chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, user.Id, false) {
 			return ext.EndGroups
 		}
 		switch args[1] {
@@ -678,7 +580,7 @@ func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 				if err := db.SetAnonAdminMode(chat.Id, true); err != nil {
 					log.Errorf("[Admin] Failed to set anon admin mode for chat %d: %v", chat.Id, err)
 					errorText, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_db_error")
-					_, _ = msg.Reply(b, errorText, helpers.Shtml())
+					_, _ = msg.Reply(c.Bot, errorText, helpers.Shtml())
 					return ext.EndGroups
 				}
 				temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_enabled_now")
@@ -693,7 +595,7 @@ func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 				if err := db.SetAnonAdminMode(chat.Id, false); err != nil {
 					log.Errorf("[Admin] Failed to set anon admin mode for chat %d: %v", chat.Id, err)
 					errorText, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_db_error")
-					_, _ = msg.Reply(b, errorText, helpers.Shtml())
+					_, _ = msg.Reply(c.Bot, errorText, helpers.Shtml())
 					return ext.EndGroups
 				}
 				temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_disabled_now")
@@ -704,7 +606,7 @@ func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	_, err := msg.Reply(b, text, helpers.Shtml())
+	_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 	if err != nil {
 		log.Error(err)
 		return err
@@ -715,17 +617,18 @@ func (m moduleStruct) anonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // adminCache handles the /admincache command to refresh the admin cache for a chat.
 // Forces a reload of admin permissions from Telegram's API.
-func (moduleStruct) adminCache(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
+func (moduleStruct) adminCache(c *helpers.CommandContext) error {
+	b := c.Bot
+	chat := c.Chat
+	msg := c.Msg
+	user := c.User
 	if user == nil {
 		return ext.EndGroups
 	}
 
 	var err error
 
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
+	tr := i18n.MustNewTranslator(db.GetLanguage(c.Ctx))
 
 	// permission checks
 	userMember, err := chat.GetMember(b, user.Id, nil)
@@ -744,10 +647,10 @@ func (moduleStruct) adminCache(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		return ext.EndGroups
 	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
+	if !chat_status.RequireBotAdmin(b, c.Ctx, nil, false) {
 		return ext.EndGroups
 	}
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
+	if !chat_status.RequireGroup(b, c.Ctx, nil, false) {
 		return ext.EndGroups
 	}
 
@@ -763,44 +666,100 @@ func (moduleStruct) adminCache(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
+var (
+	adminlistDesc = helpers.CommandDescriptor{
+		Name:        "adminlist",
+		Disableable: true,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.CheckDisabled("adminlist"),
+			helpers.RequireBotAdmin(),
+			helpers.RequireGroup(),
+		},
+	}
+	promoteDesc = helpers.CommandDescriptor{
+		Name: "promote",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+			helpers.RequireUserAdmin(),
+			helpers.CanUserPromote(),
+			helpers.CanBotPromote(),
+		},
+	}
+	demoteDesc = helpers.CommandDescriptor{
+		Name: "demote",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+			helpers.RequireUserAdmin(),
+			helpers.CanUserPromote(),
+			helpers.CanBotPromote(),
+		},
+	}
+	setTitleDesc = helpers.CommandDescriptor{
+		Name: "title",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireUserAdmin(),
+			helpers.RequireBotAdmin(),
+			helpers.CanUserPromote(),
+			helpers.CanBotPromote(),
+		},
+	}
+	getinvitelinkDesc = helpers.CommandDescriptor{
+		Name: "invitelink",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+			helpers.CanInvite(),
+		},
+	}
+	clearAdminCacheDesc = helpers.CommandDescriptor{
+		Name: "clearadmincache",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+			helpers.RequireUserAdmin(),
+		},
+	}
+	anonAdminDesc = helpers.CommandDescriptor{
+		Name: "anonadmin",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+		},
+	}
+)
+
 // LoadAdmin registers all admin module command handlers with the dispatcher.
 // Sets up commands for promotion, demotion, title setting, and admin management.
 func LoadAdmin(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap.Store("Admin", true)
 
-	dispatcher.AddHandler(handlers.NewCommand("promote", adminModule.promote))
-	dispatcher.AddHandler(handlers.NewCommand("demote", adminModule.demote))
-	dispatcher.AddHandler(handlers.NewCommand("invitelink", adminModule.getinvitelink))
-	dispatcher.AddHandler(handlers.NewCommand("title", adminModule.setTitle))
-	dispatcher.AddHandler(handlers.NewCommand("adminlist", adminModule.adminlist))
-	helpers.AddCmdToDisableable("adminlist")
-	dispatcher.AddHandler(handlers.NewCommand("anonadmin", adminModule.anonAdmin))
-	dispatcher.AddHandler(handlers.NewCommand("admincache", adminModule.adminCache))
-	dispatcher.AddHandler(handlers.NewCommand("clearadmincache", adminModule.clearAdminCache))
+	helpers.WrapCommand(dispatcher, adminlistDesc, adminModule.adminlist)
+	helpers.WrapCommand(dispatcher, promoteDesc, adminModule.promote)
+	helpers.WrapCommand(dispatcher, demoteDesc, adminModule.demote)
+	helpers.WrapCommand(dispatcher, setTitleDesc, adminModule.setTitle)
+	helpers.WrapCommand(dispatcher, getinvitelinkDesc, adminModule.getinvitelink)
+	helpers.WrapCommand(dispatcher, clearAdminCacheDesc, adminModule.clearAdminCache)
+	helpers.WrapCommand(dispatcher, anonAdminDesc, adminModule.anonAdmin)
+
+	// adminCache uses custom permission checking (direct member status lookup),
+	// so it remains a raw handler.
+	dispatcher.AddHandler(handlers.NewCommand("admincache", func(b *gotgbot.Bot, ctx *ext.Context) error {
+		c, err := helpers.BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		return adminModule.adminCache(c)
+	}))
 }
 
 // clearAdminCache handles the /clearadmincache command to delete the cached admin list.
 // Requires admin permissions and provides user feedback on success.
-func (moduleStruct) clearAdminCache(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
+func (moduleStruct) clearAdminCache(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
 
 	m := cache.GetMarshal()
 	if m == nil {
@@ -813,8 +772,8 @@ func (moduleStruct) clearAdminCache(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	log.Infof("[Admin] Cleared admin cache for %d (%s)", chat.Id, chat.Title)
 
-	text, _ := tr.GetString("admin_cache_cleared")
-	_, err = msg.Reply(b, text, helpers.Shtml())
+	text, _ := c.Tr.GetString("admin_cache_cleared")
+	_, err = msg.Reply(c.Bot, text, helpers.Shtml())
 	if err != nil {
 		log.Error(err)
 		return err

--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	"github.com/divkix/Alita_Robot/alita/utils/extraction"
 )
 
@@ -506,11 +507,12 @@ func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 			return err
 		}
 		return ext.EndGroups
-	} else if len(customTitle) > 16 {
+	} else if len([]rune(customTitle)) > 16 {
 		// trim title to 16 characters (telegram restriction) and notify user
+		runes := []rune(customTitle)
 		temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_truncated")
-		extraText = fmt.Sprintf(temp, len(customTitle))
-		customTitle = customTitle[0:16]
+		extraText = fmt.Sprintf(temp, len(runes))
+		customTitle = string(runes[:16])
 	}
 
 	_, err := chat.SetAdministratorCustomTitle(c.Bot,
@@ -749,6 +751,7 @@ func LoadAdmin(dispatcher *ext.Dispatcher) {
 	// adminCache uses custom permission checking (direct member status lookup),
 	// so it remains a raw handler.
 	dispatcher.AddHandler(handlers.NewCommand("admincache", func(b *gotgbot.Bot, ctx *ext.Context) error {
+		defer error_handling.RecoverFromPanic("admincache", "admin")
 		c, err := helpers.BuildCommandContext(b, ctx)
 		if err != nil {
 			return ext.EndGroups

--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -7,7 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/divkix/Alita_Robot/alita/db"
-	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 
@@ -87,84 +86,87 @@ connection = true, true
 
 Bot can only Demote people it promoted! */
 
-// demote handles the /demote command to remove admin privileges from a user.
-// The bot can only demote users it has previously promoted.
-func (m moduleStruct) demote(c *helpers.CommandContext) error {
-	chat := c.Chat
-	msg := c.Msg
-	tr := c.Tr
-
-	// Validate admin cache before proceeding
-	adminsAvail, admins := cache.GetAdminCacheList(chat.Id)
+// loadAdminCacheOrFail returns the cached admin list, or loads it from
+// Telegram. If the cache is empty after loading, it replies with an error
+// and returns a nil pointer so the caller can early-return.
+func (m moduleStruct) loadAdminCacheOrFail(c *helpers.CommandContext) *cache.AdminCache {
+	adminsAvail, admins := cache.GetAdminCacheList(c.Chat.Id)
 	if !adminsAvail {
-		admins = cache.LoadAdminCache(c.Bot, chat.Id)
+		admins = cache.LoadAdminCache(c.Bot, c.Chat.Id)
 	}
-
-	// If we still can't get admin list, inform user and abort
 	if len(admins.UserInfo) == 0 {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_admin_cache_failed")
-		_, err := msg.Reply(c.Bot, text, nil)
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_errors_admin_cache_failed")
+		_, err := c.Msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 		}
-		return ext.EndGroups
+		return nil
 	}
+	return &admins
+}
 
+// validateDemotionTarget checks the extracted user ID for demotion.
+// It returns the validated user ID and an error sentinel if the target is
+// invalid (the caller should return ext.EndGroups).
+func (m moduleStruct) validateDemotionTarget(c *helpers.CommandContext) (int64, error) {
 	userId := extraction.ExtractUser(c.Bot, c.Ctx)
 	if userId == -1 {
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	} else if chat_status.IsChannelId(userId) {
-		text, _ := tr.GetString("common_anonymous_user_error")
-		_, err := msg.Reply(c.Bot, text, nil)
+		text, _ := c.Tr.GetString("common_anonymous_user_error")
+		_, err := c.Msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, err
 		}
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	} else if userId == 0 {
-		text, _ := tr.GetString("common_no_user_specified")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("common_no_user_specified")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, err
 		}
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	}
 
 	if chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, userId, true) {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_owner")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_owner")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, err
 		}
-
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	}
 	if userId == c.Bot.Id {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_bot_itself")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_demote_is_bot_itself")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, err
 		}
-
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	}
 	// Using IsUserAdmin (not RequireUserAdmin) because we need a custom error message
-	// specific to the demote context rather than the generic permission error
-	if !chat_status.IsUserAdmin(c.Bot, chat.Id, userId) {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_not_admin")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+	// specific to the demote context rather than the generic permission error.
+	if !chat_status.IsUserAdmin(c.Bot, c.Chat.Id, userId) {
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_demote_not_admin")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, err
 		}
-
-		return ext.EndGroups
+		return 0, ext.EndGroups
 	}
 
-	bb, err := chat.PromoteMember(c.Bot,
+	return userId, nil
+}
+
+// performDemotion removes admin privileges from the target user and sends
+// a success confirmation.
+func (m moduleStruct) performDemotion(c *helpers.CommandContext, userId int64) error {
+	bb, err := c.Chat.PromoteMember(c.Bot,
 		userId,
 		&gotgbot.PromoteChatMemberOpts{
 			CanPostMessages:     false,
@@ -177,28 +179,24 @@ func (m moduleStruct) demote(c *helpers.CommandContext) error {
 			CanManageTopics:     false,
 		},
 	)
-
 	if err != nil || !bb {
 		log.Error(err)
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_demote")
-		_, err = msg.Reply(c.Bot, text, nil)
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_demote")
+		_, err = c.Msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
 			return err
 		}
-
 		return ext.EndGroups
 	}
 
-	// Invalidate admin cache immediately after successful demotion
-	cache.InvalidateAdminCache(chat.Id)
+	cache.InvalidateAdminCache(c.Chat.Id)
 
-	userMember, err := chat.GetMember(c.Bot, userId, nil)
+	userMember, err := c.Chat.GetMember(c.Bot, userId, nil)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
-	// Nil check to prevent panic when GetMember returns nil
 	if userMember == nil {
 		err := fmt.Errorf("GetMember returned nil for userId %d", userId)
 		log.Error(err)
@@ -206,9 +204,9 @@ func (m moduleStruct) demote(c *helpers.CommandContext) error {
 	}
 
 	mem := userMember.MergeChatMember().User
-	_, err = msg.Reply(c.Bot,
+	_, err = c.Msg.Reply(c.Bot,
 		func() string {
-			temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_demote_success_demote")
+			temp, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_demote_success_demote")
 			return fmt.Sprintf(temp, helpers.MentionHtml(mem.Id, mem.FirstName))
 		}(),
 		helpers.Shtml(),
@@ -217,8 +215,23 @@ func (m moduleStruct) demote(c *helpers.CommandContext) error {
 		log.Error(err)
 		return err
 	}
-
 	return ext.EndGroups
+}
+
+// demote handles the /demote command to remove admin privileges from a user.
+// The bot can only demote users it has previously promoted.
+func (m moduleStruct) demote(c *helpers.CommandContext) error {
+	admins := m.loadAdminCacheOrFail(c)
+	if admins == nil {
+		return ext.EndGroups
+	}
+
+	userId, err := m.validateDemotionTarget(c)
+	if err != nil {
+		return err
+	}
+
+	return m.performDemotion(c, userId)
 }
 
 /* Used to Promote a member in chat
@@ -227,161 +240,107 @@ connection = true, true
 
 Bot will give promoted user permissions of bot*/
 
-// promote handles the /promote command to grant admin privileges to a user.
-// The bot grants permissions based on its own capabilities and the promoter's status.
-func (m moduleStruct) promote(c *helpers.CommandContext) error {
-	chat := c.Chat
-	msg := c.Msg
-	user := c.User
-	tr := c.Tr
-
-	extraText := ""
-
-	// Validate admin cache before proceeding
-	adminsAvail, admins := cache.GetAdminCacheList(chat.Id)
-	if !adminsAvail {
-		admins = cache.LoadAdminCache(c.Bot, chat.Id)
-	}
-
-	// If we still can't get admin list, inform user and abort
-	if len(admins.UserInfo) == 0 {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_admin_cache_failed")
-		_, err := msg.Reply(c.Bot, text, nil)
-		if err != nil {
-			log.Error(err)
-		}
-		return ext.EndGroups
-	}
-
+// validatePromotionTarget extracts and validates the target user for promotion.
+// It returns the user ID, custom title, and an error sentinel (ext.EndGroups) on failure.
+func (m moduleStruct) validatePromotionTarget(c *helpers.CommandContext) (int64, string, error) {
 	userId, customTitle := extraction.ExtractUserAndText(c.Bot, c.Ctx)
 	if userId == -1 {
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	} else if chat_status.IsChannelId(userId) {
-		text, _ := tr.GetString("common_anonymous_user_error")
-		_, err := msg.Reply(c.Bot, text, nil)
+		text, _ := c.Tr.GetString("common_anonymous_user_error")
+		_, err := c.Msg.Reply(c.Bot, text, nil)
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, "", err
 		}
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	} else if userId == 0 {
-		text, _ := tr.GetString("common_no_user_specified")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("common_no_user_specified")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, "", err
 		}
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	}
-
 	if userId == c.Bot.Id {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_bot_itself")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_bot_itself")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, "", err
 		}
-
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	}
-
-	// checks if user being promoted is already admin or owner
 	if chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, userId, true) {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_owner")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_owner")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, "", err
 		}
-
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	}
-	if chat_status.IsUserAdmin(c.Bot, chat.Id, userId) {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_admin")
-		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
+	if chat_status.IsUserAdmin(c.Bot, c.Chat.Id, userId) {
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_promote_is_admin")
+		_, err := c.Msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
-			return err
+			return 0, "", err
 		}
-
-		return ext.EndGroups
+		return 0, "", ext.EndGroups
 	}
+	return userId, customTitle, nil
+}
 
-	userMember, err := chat.GetMember(c.Bot, userId, nil)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
+// canGrantPerm returns whether the bot can grant a specific permission,
+// considering both the bot's own capability and the promoter privileges.
+func canGrantPerm(botHas, promoterHas, bypass bool) bool {
+	return botHas && (promoterHas || bypass)
+}
 
-	promoterMember, err := chat.GetMember(c.Bot, user.Id, nil)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-
-	botMember, err := chat.GetMember(c.Bot, c.Bot.Id, nil)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-
-	// makes code short
+// buildPromoteOpts constructs the permission options for PromoteMember
+// based on bot and promoter capabilities.
+func buildPromoteOpts(botMember, promoterMember gotgbot.ChatMember, user *gotgbot.User, c *helpers.CommandContext) *gotgbot.PromoteChatMemberOpts {
 	bMem := botMember.MergeChatMember()
 	pMem := promoterMember.MergeChatMember()
 
 	teamMem := db.GetTeamMemInfo(user.Id)
 	teamMemInfo := teamMem.Sudo || teamMem.IsDev
 	isPromoterOwner := chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, user.Id, true)
-
-	// Privilege Escalation Behavior (Intentional):
-	// - Group owners and sudo/dev team members can grant full bot-level permissions
-	// - Regular admins can only grant permissions they themselves have
-	// This is by design: trusted users (owners, sudo, dev) bypass the permission mirroring
-	// that normally prevents admins from granting permissions they don't have.
 	checkCommonPerms := isPromoterOwner || teamMemInfo
 
-	status, err := chat.PromoteMember(c.Bot,
-		userId,
-		&gotgbot.PromoteChatMemberOpts{
-			CanPostMessages:     bMem.CanPostMessages && (pMem.CanPostMessages || checkCommonPerms),
-			CanDeleteMessages:   bMem.CanDeleteMessages && (pMem.CanDeleteMessages || checkCommonPerms),
-			CanRestrictMembers:  bMem.CanRestrictMembers && (pMem.CanRestrictMembers || checkCommonPerms),
-			CanChangeInfo:       bMem.CanChangeInfo && (pMem.CanChangeInfo || checkCommonPerms),
-			CanInviteUsers:      bMem.CanInviteUsers && (pMem.CanInviteUsers || checkCommonPerms),
-			CanPinMessages:      bMem.CanPinMessages && (pMem.CanPinMessages || checkCommonPerms),
-			CanManageVideoChats: bMem.CanManageVideoChats && (pMem.CanManageVideoChats || checkCommonPerms),
-			CanManageChat:       bMem.CanManageChat && (pMem.CanManageChat || checkCommonPerms),
-			CanManageTopics:     bMem.CanManageTopics && (pMem.CanManageTopics || checkCommonPerms),
-		},
-	)
-	if err != nil || !status {
-		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_promote")
-		_, _ = msg.Reply(c.Bot, text, helpers.Shtml())
-		if err == nil {
-			err = fmt.Errorf("promote member returned false status")
-		}
-		return err
+	return &gotgbot.PromoteChatMemberOpts{
+		CanPostMessages:     canGrantPerm(bMem.CanPostMessages, pMem.CanPostMessages, checkCommonPerms),
+		CanDeleteMessages:   canGrantPerm(bMem.CanDeleteMessages, pMem.CanDeleteMessages, checkCommonPerms),
+		CanRestrictMembers:  canGrantPerm(bMem.CanRestrictMembers, pMem.CanRestrictMembers, checkCommonPerms),
+		CanChangeInfo:       canGrantPerm(bMem.CanChangeInfo, pMem.CanChangeInfo, checkCommonPerms),
+		CanInviteUsers:      canGrantPerm(bMem.CanInviteUsers, pMem.CanInviteUsers, checkCommonPerms),
+		CanPinMessages:      canGrantPerm(bMem.CanPinMessages, pMem.CanPinMessages, checkCommonPerms),
+		CanManageVideoChats: canGrantPerm(bMem.CanManageVideoChats, pMem.CanManageVideoChats, checkCommonPerms),
+		CanManageChat:       canGrantPerm(bMem.CanManageChat, pMem.CanManageChat, checkCommonPerms),
+		CanManageTopics:     canGrantPerm(bMem.CanManageTopics, pMem.CanManageTopics, checkCommonPerms),
 	}
+}
 
-	// Invalidate admin cache immediately after successful promotion
-	cache.InvalidateAdminCache(chat.Id)
+// handlePromotionSuccess sends the success reply after a promotion,
+// optionally setting a custom title and truncating it if needed.
+func (m moduleStruct) handlePromotionSuccess(c *helpers.CommandContext, userId int64, customTitle string, userMember gotgbot.ChatMember) error {
+	tr := c.Tr
+	msg := c.Msg
 
+	cache.InvalidateAdminCache(c.Chat.Id)
+
+	extraText := ""
 	titleRunes := []rune(customTitle)
 	if len(titleRunes) > 16 {
-		// trim title to 16 characters (telegram restriction)
 		temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_admin_title_truncated")
 		extraText += fmt.Sprintf(temp, len(titleRunes))
 		customTitle = string(titleRunes[0:16])
 	}
 
-	// set the custom title
 	if customTitle != "" {
-		_, err = chat.SetAdministratorCustomTitle(
-			c.Bot,
-			userId,
-			customTitle,
-			nil,
-		)
+		_, err := c.Chat.SetAdministratorCustomTitle(c.Bot, userId, customTitle, nil)
 		if err != nil {
 			text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_set_title")
 			_, err = msg.Reply(c.Bot, text, nil)
@@ -393,7 +352,7 @@ func (m moduleStruct) promote(c *helpers.CommandContext) error {
 	}
 
 	mem := userMember.MergeChatMember().User
-	_, err = msg.Reply(c.Bot,
+	_, err := msg.Reply(c.Bot,
 		func() string {
 			temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_promote_success_promote")
 			return fmt.Sprintf(temp, helpers.MentionHtml(mem.Id, mem.FirstName))
@@ -404,8 +363,53 @@ func (m moduleStruct) promote(c *helpers.CommandContext) error {
 		log.Error(err)
 		return err
 	}
-
 	return ext.EndGroups
+}
+
+// promote handles the /promote command to grant admin privileges to a user.
+// The bot grants permissions based on its own capabilities and the promoter's status.
+func (m moduleStruct) promote(c *helpers.CommandContext) error {
+	admins := m.loadAdminCacheOrFail(c)
+	if admins == nil {
+		return ext.EndGroups
+	}
+
+	userId, customTitle, err := m.validatePromotionTarget(c)
+	if err != nil {
+		return err
+	}
+
+	userMember, err := c.Chat.GetMember(c.Bot, userId, nil)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	promoterMember, err := c.Chat.GetMember(c.Bot, c.User.Id, nil)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	botMember, err := c.Chat.GetMember(c.Bot, c.Bot.Id, nil)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	opts := buildPromoteOpts(botMember, promoterMember, c.User, c)
+
+	status, err := c.Chat.PromoteMember(c.Bot, userId, opts)
+	if err != nil || !status {
+		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_errors_err_cannot_promote")
+		_, _ = c.Msg.Reply(c.Bot, text, helpers.Shtml())
+		if err == nil {
+			err = fmt.Errorf("promote member returned false status")
+		}
+		return err
+	}
+
+	return m.handlePromotionSuccess(c, userId, customTitle, userMember)
 }
 
 // getinvitelink handles the /invitelink command to retrieve the chat's invite link.
@@ -628,19 +632,17 @@ func (moduleStruct) adminCache(c *helpers.CommandContext) error {
 
 	var err error
 
-	tr := i18n.MustNewTranslator(db.GetLanguage(c.Ctx))
-
 	// permission checks
 	userMember, err := chat.GetMember(b, user.Id, nil)
 	if err != nil {
 		log.Errorf("[Admin] Failed to get member %d: %v", user.Id, err)
-		errorText, _ := tr.GetString("admin_check_status_failed")
+		errorText, _ := c.Tr.GetString("admin_check_status_failed")
 		_, _ = msg.Reply(b, errorText, helpers.Shtml())
 		return ext.EndGroups
 	}
 	mem := userMember.MergeChatMember()
 	if mem.Status == "member" {
-		errorText, _ := tr.GetString("admin_need_admin")
+		errorText, _ := c.Tr.GetString("admin_need_admin")
 		_, err = msg.Reply(b, errorText, nil)
 		if err != nil {
 			log.Error(err)
@@ -656,7 +658,7 @@ func (moduleStruct) adminCache(c *helpers.CommandContext) error {
 
 	cache.LoadAdminCache(b, chat.Id)
 
-	k, _ := tr.GetString("commonstrings_admin_cache_cache_reloaded")
+	k, _ := c.Tr.GetString("commonstrings_admin_cache_cache_reloaded")
 	_, err = msg.Reply(b, k, helpers.Shtml())
 	if err != nil {
 		log.Error(err)

--- a/alita/modules/admin_test.go
+++ b/alita/modules/admin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/divkix/Alita_Robot/alita/db"
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
+	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
 // testError is a simple error implementation for testing
@@ -80,7 +81,8 @@ func TestAdminListLoadsAndRepliesWithVisibleAdmins(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/adminlist")
 
-	if err := adminModule.adminlist(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := adminModule.adminlist(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminlist() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("getChatAdministrators"); len(calls) != 1 {
@@ -104,7 +106,8 @@ func TestAdminListReportsWhenOnlyBotsAreVisible(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/adminlist")
 
-	if err := adminModule.adminlist(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := adminModule.adminlist(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminlist(no visible admins) error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("sendMessage"); len(calls) != 1 {
@@ -120,7 +123,8 @@ func TestPromoteReplyPromotesTargetAndSetsTitle(t *testing.T) {
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/promote VeryLongCustomAdminTitle")
 
-	if err := adminModule.promote(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("promote() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("promoteChatMember"); len(calls) != 1 {
@@ -153,7 +157,8 @@ func TestPromoteRejectsInvalidAndProtectedTargets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			if err := adminModule.promote(bot, ctx); err != ext.EndGroups {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("promote(%s) error = %v, want EndGroups", tt.name, err)
 			}
 		})
@@ -183,8 +188,9 @@ func TestPromoteRejectsExistingAdminAndMissingAdminCache(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 		admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 		ctx := newModuleMessageContext(bot, chat, admin, "/promote 42")
+		cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-		if err := adminModule.promote(bot, ctx); err != ext.EndGroups {
+		if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 			t.Fatalf("promote(existing admin) error = %v, want EndGroups", err)
 		}
 		if calls := client.callsFor("promoteChatMember"); len(calls) != 0 {
@@ -199,8 +205,9 @@ func TestPromoteRejectsExistingAdminAndMissingAdminCache(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 		admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 		ctx := newModuleMessageContext(bot, chat, admin, "/promote 42")
+		cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-		if err := adminModule.promote(bot, ctx); err != ext.EndGroups {
+		if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 			t.Fatalf("promote(empty admin cache) error = %v, want EndGroups", err)
 		}
 		if calls := client.callsFor("promoteChatMember"); len(calls) != 0 {
@@ -228,8 +235,9 @@ func TestDemoteReplyDemotesAdminTarget(t *testing.T) {
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/demote")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.demote(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("demote() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("promoteChatMember"); len(calls) != 1 {
@@ -265,7 +273,8 @@ func TestDemoteValidationBranches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			if err := adminModule.demote(bot, ctx); err != ext.EndGroups {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("demote(%s) error = %v, want EndGroups", tt.name, err)
 			}
 		})
@@ -283,8 +292,9 @@ func TestDemoteRejectsMissingAdminCache(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, admin, "/demote 42")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.demote(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("demote(empty admin cache) error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("promoteChatMember"); len(calls) != 0 {
@@ -311,8 +321,9 @@ func TestSetTitleReplyUpdatesAdminTitle(t *testing.T) {
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/title Captain")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.setTitle(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("setTitle() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("setChatAdministratorCustomTitle"); len(calls) != 1 {
@@ -349,14 +360,16 @@ func TestSetTitleValidationAndTruncation(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			if err := adminModule.setTitle(bot, ctx); err != ext.EndGroups {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("setTitle(%s) error = %v, want EndGroups", tt.name, err)
 			}
 		})
 	}
 
 	longTitleCtx := newModuleMessageContext(bot, chat, admin, "/title 42 VeryLongCustomAdminTitle")
-	if err := adminModule.setTitle(bot, longTitleCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, longTitleCtx)
+	if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("setTitle(long title) error = %v, want EndGroups", err)
 	}
 
@@ -380,8 +393,9 @@ func TestGetInviteLinkUsesPublicUsernameWithoutFetchingChat(t *testing.T) {
 	}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.getinvitelink(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("getChat"); len(calls) != 0 {
@@ -401,8 +415,9 @@ func TestGetInviteLinkFetchesPrivateInviteLink(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.getinvitelink(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink(private) error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("getChat"); len(calls) != 1 {
@@ -420,8 +435,9 @@ func TestGetInviteLinkHandlesPrivateLookupFailure(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.getinvitelink(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink(lookup failure) error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("sendMessage"); len(calls) != 1 {
@@ -436,7 +452,8 @@ func TestAnonAdminOwnerTogglesSetting(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	onCtx := newModuleMessageContext(bot, chat, user, "/anonadmin on")
-	if err := adminModule.anonAdmin(bot, onCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, onCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(on) error = %v, want EndGroups", err)
 	}
 	if !db.GetAdminSettings(chat.Id).AnonAdmin {
@@ -444,12 +461,14 @@ func TestAnonAdminOwnerTogglesSetting(t *testing.T) {
 	}
 
 	statusCtx := newModuleMessageContext(bot, chat, user, "/anonadmin")
-	if err := adminModule.anonAdmin(bot, statusCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(bot, statusCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(status) error = %v, want EndGroups", err)
 	}
 
 	offCtx := newModuleMessageContext(bot, chat, user, "/anonadmin false")
-	if err := adminModule.anonAdmin(bot, offCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(bot, offCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(off) error = %v, want EndGroups", err)
 	}
 	if db.GetAdminSettings(chat.Id).AnonAdmin {
@@ -472,7 +491,8 @@ func TestAnonAdminHandlesNoopAndInvalidOptions(t *testing.T) {
 		t.Fatalf("SetAnonAdminMode(true) error = %v", err)
 	}
 	onAgainCtx := newModuleMessageContext(bot, chat, user, "/anonadmin yes")
-	if err := adminModule.anonAdmin(bot, onAgainCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, onAgainCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(already on) error = %v, want EndGroups", err)
 	}
 
@@ -480,12 +500,14 @@ func TestAnonAdminHandlesNoopAndInvalidOptions(t *testing.T) {
 		t.Fatalf("SetAnonAdminMode(false) error = %v", err)
 	}
 	offAgainCtx := newModuleMessageContext(bot, chat, user, "/anonadmin off")
-	if err := adminModule.anonAdmin(bot, offAgainCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(bot, offAgainCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(already off) error = %v, want EndGroups", err)
 	}
 
 	invalidCtx := newModuleMessageContext(bot, chat, user, "/anonadmin maybe")
-	if err := adminModule.anonAdmin(bot, invalidCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(bot, invalidCtx)
+	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(invalid) error = %v, want EndGroups", err)
 	}
 
@@ -504,7 +526,8 @@ func TestAdminCacheCommandsRefreshAndClearCache(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	refreshCtx := newModuleMessageContext(bot, chat, user, "/admincache")
-	if err := adminModule.adminCache(bot, refreshCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, refreshCtx)
+	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("getChatAdministrators"); len(calls) != 1 {
@@ -529,7 +552,8 @@ func TestAdminCacheCommandsRefreshAndClearCache(t *testing.T) {
 		t.Fatalf("seed admin cache: %v", err)
 	}
 	clearCtx := newModuleMessageContext(bot, clearChat, user, "/clearadmincache")
-	if err := adminModule.clearAdminCache(bot, clearCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(bot, clearCtx)
+	if err := adminModule.clearAdminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("clearAdminCache() error = %v, want EndGroups", err)
 	}
 	if found, _ := cache.GetAdminCacheList(clearChat.Id); found {
@@ -545,8 +569,9 @@ func TestClearAdminCacheNilMarshal(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/clearadmincache")
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
 
-	if err := adminModule.clearAdminCache(bot, ctx); err != ext.EndGroups {
+	if err := adminModule.clearAdminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("clearAdminCache(nil marshal) error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("sendMessage"); len(calls) != 0 {
@@ -560,7 +585,8 @@ func TestAdminCacheHandlesMemberAndLookupFailures(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	member := gotgbot.User{Id: 42, FirstName: "Member"}
 	memberCtx := newModuleMessageContext(memberBot, chat, member, "/admincache")
-	if err := adminModule.adminCache(memberBot, memberCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(memberBot, memberCtx)
+	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache(member) error = %v, want EndGroups", err)
 	}
 	if calls := memberClient.callsFor("sendMessage"); len(calls) != 1 {
@@ -572,7 +598,8 @@ func TestAdminCacheHandlesMemberAndLookupFailures(t *testing.T) {
 	errorBot := newModuleTestBot(errorClient)
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	errorCtx := newModuleMessageContext(errorBot, chat, admin, "/admincache")
-	if err := adminModule.adminCache(errorBot, errorCtx); err != ext.EndGroups {
+	cmdCtx, _ = helpers.BuildCommandContext(errorBot, errorCtx)
+	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache(lookup failure) error = %v, want EndGroups", err)
 	}
 	if calls := errorClient.callsFor("sendMessage"); len(calls) != 1 {
@@ -601,7 +628,7 @@ func TestAdminCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 		method    string
 		setup     func(*moduleBotClient)
 		withReply bool
-		run       func(*gotgbot.Bot, *ext.Context) error
+		run       func(*helpers.CommandContext) error
 	}{
 		{name: "admin list reply", text: "/adminlist", method: "sendMessage", run: adminModule.adminlist},
 		{name: "promote missing target reply", text: "/promote", method: "sendMessage", run: adminModule.promote},
@@ -649,7 +676,8 @@ func TestAdminCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				ctx = newModuleMessageContext(bot, chat, admin, tt.text)
 			}
 
-			err := tt.run(bot, ctx)
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			err := tt.run(cmdCtx)
 			if !errors.Is(err, requestErr) {
 				t.Fatalf("%s returned error %v, want request error", tt.text, err)
 			}

--- a/alita/modules/admin_test.go
+++ b/alita/modules/admin_test.go
@@ -509,13 +509,19 @@ func TestAnonAdminOwnerTogglesSetting(t *testing.T) {
 	}
 
 	statusCtx := newModuleMessageContext(bot, chat, user, "/anonadmin")
-	cmdCtx, _ = helpers.BuildCommandContext(bot, statusCtx)
+	cmdCtx, err = helpers.BuildCommandContext(bot, statusCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(status) error = %v, want EndGroups", err)
 	}
 
 	offCtx := newModuleMessageContext(bot, chat, user, "/anonadmin false")
-	cmdCtx, _ = helpers.BuildCommandContext(bot, offCtx)
+	cmdCtx, err = helpers.BuildCommandContext(bot, offCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(off) error = %v, want EndGroups", err)
 	}
@@ -612,7 +618,10 @@ func TestAdminCacheCommandsRefreshAndClearCache(t *testing.T) {
 		t.Fatalf("seed admin cache: %v", err)
 	}
 	clearCtx := newModuleMessageContext(bot, clearChat, user, "/clearadmincache")
-	cmdCtx, _ = helpers.BuildCommandContext(bot, clearCtx)
+	cmdCtx, err = helpers.BuildCommandContext(bot, clearCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.clearAdminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("clearAdminCache() error = %v, want EndGroups", err)
 	}

--- a/alita/modules/admin_test.go
+++ b/alita/modules/admin_test.go
@@ -81,7 +81,10 @@ func TestAdminListLoadsAndRepliesWithVisibleAdmins(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/adminlist")
 
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.adminlist(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminlist() error = %v, want EndGroups", err)
 	}
@@ -106,7 +109,10 @@ func TestAdminListReportsWhenOnlyBotsAreVisible(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/adminlist")
 
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.adminlist(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminlist(no visible admins) error = %v, want EndGroups", err)
 	}
@@ -123,7 +129,10 @@ func TestPromoteReplyPromotesTargetAndSetsTitle(t *testing.T) {
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/promote VeryLongCustomAdminTitle")
 
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("promote() error = %v, want EndGroups", err)
 	}
@@ -157,7 +166,10 @@ func TestPromoteRejectsInvalidAndProtectedTargets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("promote(%s) error = %v, want EndGroups", tt.name, err)
 			}
@@ -188,7 +200,10 @@ func TestPromoteRejectsExistingAdminAndMissingAdminCache(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 		admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 		ctx := newModuleMessageContext(bot, chat, admin, "/promote 42")
-		cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+		cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+		if err != nil {
+			t.Fatalf("BuildCommandContext failed: %v", err)
+		}
 
 		if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 			t.Fatalf("promote(existing admin) error = %v, want EndGroups", err)
@@ -205,7 +220,10 @@ func TestPromoteRejectsExistingAdminAndMissingAdminCache(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 		admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 		ctx := newModuleMessageContext(bot, chat, admin, "/promote 42")
-		cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+		cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+		if err != nil {
+			t.Fatalf("BuildCommandContext failed: %v", err)
+		}
 
 		if err := adminModule.promote(cmdCtx); err != ext.EndGroups {
 			t.Fatalf("promote(empty admin cache) error = %v, want EndGroups", err)
@@ -235,7 +253,10 @@ func TestDemoteReplyDemotesAdminTarget(t *testing.T) {
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/demote")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("demote() error = %v, want EndGroups", err)
@@ -273,7 +294,10 @@ func TestDemoteValidationBranches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("demote(%s) error = %v, want EndGroups", tt.name, err)
 			}
@@ -292,7 +316,10 @@ func TestDemoteRejectsMissingAdminCache(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, admin, "/demote 42")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.demote(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("demote(empty admin cache) error = %v, want EndGroups", err)
@@ -321,7 +348,10 @@ func TestSetTitleReplyUpdatesAdminTitle(t *testing.T) {
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	target := gotgbot.User{Id: 42, FirstName: "Member"}
 	ctx := newBanReplyContext(bot, chat, admin, target, "/title Captain")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("setTitle() error = %v, want EndGroups", err)
@@ -360,7 +390,10 @@ func TestSetTitleValidationAndTruncation(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := newModuleMessageContext(bot, chat, admin, tt.text)
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 				t.Fatalf("setTitle(%s) error = %v, want EndGroups", tt.name, err)
 			}
@@ -368,7 +401,10 @@ func TestSetTitleValidationAndTruncation(t *testing.T) {
 	}
 
 	longTitleCtx := newModuleMessageContext(bot, chat, admin, "/title 42 VeryLongCustomAdminTitle")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, longTitleCtx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, longTitleCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.setTitle(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("setTitle(long title) error = %v, want EndGroups", err)
 	}
@@ -393,7 +429,10 @@ func TestGetInviteLinkUsesPublicUsernameWithoutFetchingChat(t *testing.T) {
 	}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink() error = %v, want EndGroups", err)
@@ -415,7 +454,10 @@ func TestGetInviteLinkFetchesPrivateInviteLink(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink(private) error = %v, want EndGroups", err)
@@ -435,7 +477,10 @@ func TestGetInviteLinkHandlesPrivateLookupFailure(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/invitelink")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.getinvitelink(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("getinvitelink(lookup failure) error = %v, want EndGroups", err)
@@ -452,7 +497,10 @@ func TestAnonAdminOwnerTogglesSetting(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	onCtx := newModuleMessageContext(bot, chat, user, "/anonadmin on")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, onCtx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, onCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(on) error = %v, want EndGroups", err)
 	}
@@ -491,7 +539,10 @@ func TestAnonAdminHandlesNoopAndInvalidOptions(t *testing.T) {
 		t.Fatalf("SetAnonAdminMode(true) error = %v", err)
 	}
 	onAgainCtx := newModuleMessageContext(bot, chat, user, "/anonadmin yes")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, onAgainCtx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, onAgainCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(already on) error = %v, want EndGroups", err)
 	}
@@ -500,13 +551,19 @@ func TestAnonAdminHandlesNoopAndInvalidOptions(t *testing.T) {
 		t.Fatalf("SetAnonAdminMode(false) error = %v", err)
 	}
 	offAgainCtx := newModuleMessageContext(bot, chat, user, "/anonadmin off")
-	cmdCtx, _ = helpers.BuildCommandContext(bot, offAgainCtx)
+	cmdCtx, err = helpers.BuildCommandContext(bot, offAgainCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(already off) error = %v, want EndGroups", err)
 	}
 
 	invalidCtx := newModuleMessageContext(bot, chat, user, "/anonadmin maybe")
-	cmdCtx, _ = helpers.BuildCommandContext(bot, invalidCtx)
+	cmdCtx, err = helpers.BuildCommandContext(bot, invalidCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.anonAdmin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("anonAdmin(invalid) error = %v, want EndGroups", err)
 	}
@@ -526,7 +583,10 @@ func TestAdminCacheCommandsRefreshAndClearCache(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	refreshCtx := newModuleMessageContext(bot, chat, user, "/admincache")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, refreshCtx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, refreshCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache() error = %v, want EndGroups", err)
 	}
@@ -569,7 +629,10 @@ func TestClearAdminCacheNilMarshal(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	ctx := newModuleMessageContext(bot, chat, user, "/clearadmincache")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 
 	if err := adminModule.clearAdminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("clearAdminCache(nil marshal) error = %v, want EndGroups", err)
@@ -585,7 +648,10 @@ func TestAdminCacheHandlesMemberAndLookupFailures(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Admin Chat"}
 	member := gotgbot.User{Id: 42, FirstName: "Member"}
 	memberCtx := newModuleMessageContext(memberBot, chat, member, "/admincache")
-	cmdCtx, _ := helpers.BuildCommandContext(memberBot, memberCtx)
+	cmdCtx, err := helpers.BuildCommandContext(memberBot, memberCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache(member) error = %v, want EndGroups", err)
 	}
@@ -598,7 +664,10 @@ func TestAdminCacheHandlesMemberAndLookupFailures(t *testing.T) {
 	errorBot := newModuleTestBot(errorClient)
 	admin := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 	errorCtx := newModuleMessageContext(errorBot, chat, admin, "/admincache")
-	cmdCtx, _ = helpers.BuildCommandContext(errorBot, errorCtx)
+	cmdCtx, err = helpers.BuildCommandContext(errorBot, errorCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := adminModule.adminCache(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("adminCache(lookup failure) error = %v, want EndGroups", err)
 	}
@@ -676,8 +745,11 @@ func TestAdminCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				ctx = newModuleMessageContext(bot, chat, admin, tt.text)
 			}
 
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
-			err := tt.run(cmdCtx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
+			err = tt.run(cmdCtx)
 			if !errors.Is(err, requestErr) {
 				t.Fatalf("%s returned error %v, want request error", tt.text, err)
 			}

--- a/alita/modules/bot_updates.go
+++ b/alita/modules/bot_updates.go
@@ -210,13 +210,20 @@ func verifyAnonymousAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	switch command {
 
-	// admin
-	case "promote":
-		return adminModule.promote(b, ctx)
-	case "demote":
-		return adminModule.demote(b, ctx)
-	case "title":
-		return adminModule.setTitle(b, ctx)
+	// admin (re-mapped via anonymous admin magic; need raw CommandContext)
+	case "promote", "demote", "title":
+		c, err := helpers.BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		switch command {
+		case "promote":
+			return adminModule.promote(c)
+		case "demote":
+			return adminModule.demote(c)
+		case "title":
+			return adminModule.setTitle(c)
+		}
 
 	// bans (restrictions)
 	case "ban":
@@ -247,14 +254,21 @@ func verifyAnonymousAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 		return mutesModule.unmute(b, ctx)
 
 	// pins
-	case "pin":
-		return pinsModule.pin(b, ctx)
-	case "unpin":
-		return pinsModule.unpin(b, ctx)
-	case "permapin":
-		return pinsModule.permaPin(b, ctx)
-	case "unpinall":
-		return pinsModule.unpinAll(b, ctx)
+	case "pin", "unpin", "permapin", "unpinall":
+		c, err := helpers.BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		switch command {
+		case "pin":
+			return pinsModule.pin(c)
+		case "unpin":
+			return pinsModule.unpin(c)
+		case "permapin":
+			return pinsModule.permaPin(c)
+		case "unpinall":
+			return pinsModule.unpinAll(c)
+		}
 
 	// purges
 	case "purge":

--- a/alita/modules/bot_updates.go
+++ b/alita/modules/bot_updates.go
@@ -16,6 +16,7 @@ import (
 	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
@@ -111,6 +112,8 @@ func adminCacheAutoUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
 // 2. Retrieves the original command from cache
 // 3. Executes the appropriate command handler with restored context
 func verifyAnonymousAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
+	defer error_handling.RecoverFromPanic("bot_updates", "verifyAnonymousAdmin")
+
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
 		return ext.EndGroups

--- a/alita/modules/helpers_test.go
+++ b/alita/modules/helpers_test.go
@@ -111,8 +111,6 @@ func TestListModules(t *testing.T) {
 }
 
 func TestListModulesViaDefaultRegistry(t *testing.T) {
-	t.Parallel()
-
 	previousRegistry := defaultHelpRegistry
 	defaultHelpRegistry = NewHelpRegistry()
 	defaultHelpRegistry.AbleMap.Store("Bans", true)

--- a/alita/modules/helpers_test.go
+++ b/alita/modules/helpers_test.go
@@ -110,6 +110,31 @@ func TestListModules(t *testing.T) {
 	}
 }
 
+func TestListModulesViaDefaultRegistry(t *testing.T) {
+	t.Parallel()
+
+	previousRegistry := defaultHelpRegistry
+	defaultHelpRegistry = NewHelpRegistry()
+	defaultHelpRegistry.AbleMap.Store("Bans", true)
+	defaultHelpRegistry.AbleMap.Store("Admin", true)
+	defaultHelpRegistry.AbleMap.Store("Filters", true)
+	defer func() {
+		defaultHelpRegistry = previousRegistry
+	}()
+
+	result := listModules()
+	if len(result) != 3 {
+		t.Fatalf("listModules() = %v (len %d), want 3 elements", result, len(result))
+	}
+
+	expected := []string{"Admin", "Bans", "Filters"}
+	for i, name := range expected {
+		if result[i] != name {
+			t.Fatalf("listModules()[%d] = %q, want %q; full result: %v", i, result[i], name, result)
+		}
+	}
+}
+
 func TestGetAltNamesOfModuleIncludesLowercaseModuleName(t *testing.T) {
 	t.Parallel()
 

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -161,9 +161,13 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	switch action {
 	case "yes":
 		status, err := b.UnpinAllChatMessages(chat.Id, nil)
-		if !status && err != nil {
-			log.Errorf("[Pin] UnpinAllChatMessages for chat %d: %v", chat.Id, err)
-			return err
+		if !status {
+			if err != nil {
+				log.Errorf("[Pin] UnpinAllChatMessages for chat %d: %v", chat.Id, err)
+				return err
+			}
+			log.Errorf("[Pin] UnpinAllChatMessages returned false for chat %d", chat.Id)
+			return fmt.Errorf("UnpinAllChatMessages failed for chat %d", chat.Id)
 		}
 		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
 		text, _ := tr.GetString("pins_unpin_all_success")
@@ -264,7 +268,11 @@ func (m moduleStruct) permaPin(c *helpers.CommandContext) error {
 		log.Errorf("Invalid or missing pin type: %d, cannot send permapin", pinT.DataType)
 		text, _ := c.Tr.GetString("pins_permapin_unsupported")
 		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
-		return err
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		return ext.EndGroups
 	}
 
 	ppmsg, err := pinFunc(c.Bot, c.Ctx, pinT, &gotgbot.InlineKeyboardMarkup{InlineKeyboard: keyb}, 0)
@@ -549,7 +557,7 @@ func (moduleStruct) pinned(c *helpers.CommandContext) error {
 			log.Error(err)
 			return err
 		}
-		return err
+		return ext.EndGroups
 	}
 
 	pinLink = helpers.GetMessageLinkFromMessageId(chat, pinnedMsg.MessageId)

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -142,6 +142,9 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	if !chat_status.RequireBotAdmin(b, ctx, chat, false) {
 		return ext.EndGroups
 	}
+	if !chat_status.CanUserPin(b, ctx, chat, user.Id, false) {
+		return ext.EndGroups
+	}
 	if !chat_status.CanBotPin(b, ctx, chat, false) {
 		return ext.EndGroups
 	}

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -60,30 +60,9 @@ func (moduleStruct) checkPinned(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // unpin handles the /unpin command to unpin messages, either the latest
 // pinned message or a specific replied message, requiring admin permissions.
-func (moduleStruct) unpin(b *gotgbot.Bot, ctx *ext.Context) error {
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-
-	// Check permissions
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
+func (moduleStruct) unpin(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
 
 	var (
 		replyText  string
@@ -98,29 +77,26 @@ func (moduleStruct) unpin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	if rMsg := msg.ReplyToMessage; rMsg != nil {
 		if rMsg.PinnedMessage == nil {
-			tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-			replyText, _ = tr.GetString("pins_unpin_not_pinned")
+			replyText, _ = c.Tr.GetString("pins_unpin_not_pinned")
 		} else {
-			_, err := b.UnpinChatMessage(chat.Id, &gotgbot.UnpinChatMessageOpts{MessageId: &rMsg.MessageId})
+			_, err := c.Bot.UnpinChatMessage(chat.Id, &gotgbot.UnpinChatMessageOpts{MessageId: &rMsg.MessageId})
 			if err != nil {
 				log.Error(err)
 				return err
 			}
-			tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-			replyText, _ = tr.GetString("pins_unpinned_message")
+			replyText, _ = c.Tr.GetString("pins_unpinned_message")
 			replyMsgId = rMsg.MessageId
 		}
 	} else {
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		replyText, _ = tr.GetString("pins_unpinned_last")
-		_, err := b.UnpinChatMessage(chat.Id, nil)
+		replyText, _ = c.Tr.GetString("pins_unpinned_last")
+		_, err := c.Bot.UnpinChatMessage(chat.Id, nil)
 		if err != nil {
 			log.Error(err)
 			return err
 		}
 	}
 
-	_, err := msg.Reply(b, replyText,
+	_, err := msg.Reply(c.Bot, replyText,
 		&gotgbot.SendMessageOpts{
 			ReplyParameters: &gotgbot.ReplyParameters{
 				MessageId:                replyMsgId,
@@ -222,30 +198,11 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // unpinAll handles the /unpinall command to unpin all messages in the chat
 // with a confirmation dialog, requiring admin permissions.
-func (moduleStruct) unpinAll(b *gotgbot.Bot, ctx *ext.Context) error {
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-	text, _ := tr.GetString("pins_unpin_all_confirm")
-	yesText, _ := tr.GetString("button_yes")
-	noText, _ := tr.GetString("button_no")
-	_, err := b.SendMessage(ctx.EffectiveChat.Id, text,
+func (moduleStruct) unpinAll(c *helpers.CommandContext) error {
+	text, _ := c.Tr.GetString("pins_unpin_all_confirm")
+	yesText, _ := c.Tr.GetString("button_yes")
+	noText, _ := c.Tr.GetString("button_no")
+	_, err := c.Bot.SendMessage(c.Chat.Id, text,
 		&gotgbot.SendMessageOpts{
 			ReplyMarkup: gotgbot.InlineKeyboardMarkup{
 				InlineKeyboard: [][]gotgbot.InlineKeyboardButton{
@@ -266,37 +223,15 @@ func (moduleStruct) unpinAll(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // permaPin handles the /permapin command to create and pin a new message
 // with custom content and buttons, requiring admin permissions.
-func (m moduleStruct) permaPin(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	args := ctx.Args()
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
+func (m moduleStruct) permaPin(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
+	args := c.Ctx.Args()
 
 	// if command is empty (i.e. Without Arguments) not replied to a message, return and end group
 	if len(args) == 1 && msg.ReplyToMessage == nil {
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		text, _ := tr.GetString("pins_permapin_reply_or_text")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("pins_permapin_reply_or_text")
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -311,9 +246,8 @@ func (m moduleStruct) permaPin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	pinT.FileID, pinT.MsgText, pinT.DataType, buttons = m.GetPinType(msg)
 	if pinT.DataType == -1 {
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		text, _ := tr.GetString("pins_permapin_unsupported")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("pins_permapin_unsupported")
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -328,20 +262,19 @@ func (m moduleStruct) permaPin(b *gotgbot.Bot, ctx *ext.Context) error {
 	pinFunc, exists := PinsEnumFuncMap[pinT.DataType]
 	if !exists || pinFunc == nil {
 		log.Errorf("Invalid or missing pin type: %d, cannot send permapin", pinT.DataType)
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		text, _ := tr.GetString("pins_permapin_unsupported")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("pins_permapin_unsupported")
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		return err
 	}
 
-	ppmsg, err := pinFunc(b, ctx, pinT, &gotgbot.InlineKeyboardMarkup{InlineKeyboard: keyb}, 0)
+	ppmsg, err := pinFunc(c.Bot, c.Ctx, pinT, &gotgbot.InlineKeyboardMarkup{InlineKeyboard: keyb}, 0)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
 	msgToPin := ppmsg.MessageId
-	pin, err := b.PinChatMessage(chat.Id, msgToPin, nil)
+	pin, err := c.Bot.PinChatMessage(chat.Id, msgToPin, nil)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -349,10 +282,9 @@ func (m moduleStruct) permaPin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	if pin {
 		pinLink := helpers.GetMessageLinkFromMessageId(chat, msgToPin)
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		temp, _ := tr.GetString("pins_pinned_message")
+		temp, _ := c.Tr.GetString("pins_pinned_message")
 		text := fmt.Sprintf(temp, pinLink)
-		_, err = msg.Reply(b, text,
+		_, err = msg.Reply(c.Bot, text,
 			&gotgbot.SendMessageOpts{
 				ParseMode: helpers.HTML,
 				ReplyParameters: &gotgbot.ReplyParameters{
@@ -375,37 +307,15 @@ func (m moduleStruct) permaPin(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // pin handles the /pin command to pin a replied message with options
 // for silent or loud pinning, requiring admin permissions.
-func (moduleStruct) pin(b *gotgbot.Bot, ctx *ext.Context) error {
-	user := chat_status.RequireUser(b, ctx, false)
-	if user == nil {
-		return ext.EndGroups
-	}
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
+func (moduleStruct) pin(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
 	isSilent := true
-	args := ctx.Args()
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanUserPin(b, ctx, nil, user.Id, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.CanBotPin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
+	args := c.Ctx.Args()
 
 	if msg.ReplyToMessage == nil {
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		text, _ := tr.GetString("pins_reply_to_pin")
-		_, err := msg.Reply(b, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("pins_reply_to_pin")
+		_, err := msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -414,17 +324,16 @@ func (moduleStruct) pin(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	prevMessage := msg.ReplyToMessage
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-	pinMsg, _ := tr.GetString("pins_pinned_message")
+	pinMsg, _ := c.Tr.GetString("pins_pinned_message")
 
 	if len(args) > 1 {
 		isSilent = !slices.Contains([]string{"notify", "violent", "loud"}, args[1])
 		if !isSilent {
-			pinMsg, _ = tr.GetString("pins_pinned_message_loud")
+			pinMsg, _ = c.Tr.GetString("pins_pinned_message_loud")
 		}
 	}
 
-	pin, err := b.PinChatMessage(chat.Id,
+	pin, err := c.Bot.PinChatMessage(chat.Id,
 		prevMessage.MessageId,
 		&gotgbot.PinChatMessageOpts{
 			DisableNotification: isSilent,
@@ -438,7 +347,7 @@ func (moduleStruct) pin(b *gotgbot.Bot, ctx *ext.Context) error {
 	if pin {
 		pinLink := helpers.GetMessageLinkFromMessageId(chat, prevMessage.MessageId)
 		text := fmt.Sprintf(pinMsg, pinLink)
-		_, err = prevMessage.Reply(b, text, helpers.Shtml())
+		_, err = prevMessage.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -610,17 +519,9 @@ func (moduleStruct) cleanlinked(b *gotgbot.Bot, ctx *ext.Context) error {
 
 // pinned handles the /pinned command to display a link to the latest
 // pinned message in the chat with a convenient button.
-func (moduleStruct) pinned(b *gotgbot.Bot, ctx *ext.Context) error {
-	chat := ctx.EffectiveChat
-	msg := ctx.EffectiveMessage
-
-	// permission checks
-	if !chat_status.RequireGroup(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
-	if !chat_status.RequireBotAdmin(b, ctx, nil, false) {
-		return ext.EndGroups
-	}
+func (moduleStruct) pinned(c *helpers.CommandContext) error {
+	chat := c.Chat
+	msg := c.Msg
 
 	var (
 		pinLink    string
@@ -633,7 +534,7 @@ func (moduleStruct) pinned(b *gotgbot.Bot, ctx *ext.Context) error {
 		replyMsgId = msg.MessageId
 	}
 
-	chatInfo, err := b.GetChat(chat.Id, nil)
+	chatInfo, err := c.Bot.GetChat(chat.Id, nil)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -642,9 +543,8 @@ func (moduleStruct) pinned(b *gotgbot.Bot, ctx *ext.Context) error {
 	pinnedMsg := chatInfo.PinnedMessage
 
 	if pinnedMsg == nil {
-		tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-		text, _ := tr.GetString("pins_no_pinned_message")
-		_, err = msg.Reply(b, text, helpers.Shtml())
+		text, _ := c.Tr.GetString("pins_no_pinned_message")
+		_, err = msg.Reply(c.Bot, text, helpers.Shtml())
 		if err != nil {
 			log.Error(err)
 			return err
@@ -654,11 +554,10 @@ func (moduleStruct) pinned(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	pinLink = helpers.GetMessageLinkFromMessageId(chat, pinnedMsg.MessageId)
 
-	tr := i18n.MustNewTranslator(db.GetLanguage(ctx))
-	temp, _ := tr.GetString("pins_here_is_pinned")
+	temp, _ := c.Tr.GetString("pins_here_is_pinned")
 	text := fmt.Sprintf(temp, pinLink)
-	buttonText, _ := tr.GetString("pins_pinned_message_button")
-	_, err = msg.Reply(b, text,
+	buttonText, _ := c.Tr.GetString("pins_pinned_message_button")
+	_, err = msg.Reply(c.Bot, text,
 		&gotgbot.SendMessageOpts{
 			ParseMode: helpers.HTML,
 			LinkPreviewOptions: &gotgbot.LinkPreviewOptions{
@@ -1004,16 +903,75 @@ func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataT
 	return
 }
 
+var (
+	unpinDesc = helpers.CommandDescriptor{
+		Name:    "unpin",
+		Group:   pinsModule.handlerGroup,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireUserAdmin(),
+			helpers.RequireBotAdmin(),
+			helpers.CanBotPin(),
+			helpers.CanUserPin(),
+		},
+	}
+	unpinAllDesc = helpers.CommandDescriptor{
+		Name:    "unpinall",
+		Group:   pinsModule.handlerGroup,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireUserAdmin(),
+			helpers.RequireBotAdmin(),
+			helpers.CanBotPin(),
+		},
+	}
+	pinDesc = helpers.CommandDescriptor{
+		Name:    "pin",
+		Group:   pinsModule.handlerGroup,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireUserAdmin(),
+			helpers.RequireBotAdmin(),
+			helpers.CanUserPin(),
+			helpers.CanBotPin(),
+		},
+	}
+	permaPinDesc = helpers.CommandDescriptor{
+		Name:    "permapin",
+		Group:   pinsModule.handlerGroup,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireUserAdmin(),
+			helpers.RequireBotAdmin(),
+			helpers.CanUserPin(),
+			helpers.CanBotPin(),
+		},
+	}
+	pinnedDesc = helpers.CommandDescriptor{
+		Name:    "pinned",
+		Group:   pinsModule.handlerGroup,
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+		},
+	}
+)
+
 // LoadPin registers all pins module handlers with the dispatcher,
 // including pin management commands and channel message monitoring.
 func LoadPin(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap.Store(pinsModule.moduleName, true)
 
-	dispatcher.AddHandler(handlers.NewCommand("unpin", pinsModule.unpin))
-	dispatcher.AddHandler(handlers.NewCommand("unpinall", pinsModule.unpinAll))
-	dispatcher.AddHandler(handlers.NewCommand("pin", pinsModule.pin))
-	dispatcher.AddHandler(handlers.NewCommand("pinned", pinsModule.pinned))
+	helpers.WrapCommand(dispatcher, unpinDesc, pinsModule.unpin)
+	helpers.WrapCommand(dispatcher, unpinAllDesc, pinsModule.unpinAll)
+	helpers.WrapCommand(dispatcher, pinDesc, pinsModule.pin)
+	helpers.WrapCommand(dispatcher, permaPinDesc, pinsModule.permaPin)
+	helpers.WrapCommand(dispatcher, pinnedDesc, pinsModule.pinned)
+
+	// antichannelpin and cleanlinked modify ctx.EffectiveChat so keep raw
 	dispatcher.AddHandler(handlers.NewCommand("antichannelpin", pinsModule.antichannelpin))
+	dispatcher.AddHandler(handlers.NewCommand("cleanlinked", pinsModule.cleanlinked))
+
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("unpinallbtn"), pinsModule.unpinallCallback))
 	dispatcher.AddHandlerToGroup(
 		handlers.NewMessage(
@@ -1024,8 +982,6 @@ func LoadPin(dispatcher *ext.Dispatcher) {
 		),
 		pinsModule.handlerGroup,
 	)
-	dispatcher.AddHandler(handlers.NewCommand("permapin", pinsModule.permaPin))
-	dispatcher.AddHandler(handlers.NewCommand("cleanlinked", pinsModule.cleanlinked))
 }
 
 func init() {

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -934,6 +934,7 @@ var (
 			helpers.RequireUserAdmin(),
 			helpers.RequireBotAdmin(),
 			helpers.CanBotPin(),
+			helpers.CanUserPin(),
 		},
 	}
 	pinDesc = helpers.CommandDescriptor{

--- a/alita/modules/pins_command_test.go
+++ b/alita/modules/pins_command_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 
 	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
 func TestUnpinWithoutReplyUnpinsLatestMessage(t *testing.T) {
@@ -17,7 +18,8 @@ func TestUnpinWithoutReplyUnpinsLatestMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/unpin")
-	if err := pinsModule.unpin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("unpinChatMessage"); len(calls) != 1 {
@@ -41,7 +43,8 @@ func TestUnpinReplyWithoutPinnedMessageDoesNotCallTelegramUnpin(t *testing.T) {
 		Chat:      chat,
 		Text:      "not pinned",
 	}
-	if err := pinsModule.unpin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("unpinChatMessage"); len(calls) != 0 {
@@ -67,7 +70,8 @@ func TestUnpinReplyWithPinnedMessageUnpinsReply(t *testing.T) {
 		PinnedMessage:  &gotgbot.Message{MessageId: 77, Date: 1, Chat: chat, Text: "pinned"},
 		ReplyToMessage: nil,
 	}
-	if err := pinsModule.unpin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin(pinned reply) error = %v, want EndGroups", err)
 	}
 	calls := client.callsFor("unpinChatMessage")
@@ -86,7 +90,8 @@ func TestUnpinAllSendsConfirmationButtons(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/unpinall")
-	if err := pinsModule.unpinAll(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.unpinAll(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpinAll() error = %v, want EndGroups", err)
 	}
 	calls := client.callsFor("sendMessage")
@@ -150,7 +155,8 @@ func TestPinReplyPinsMessageWithNotificationOption(t *testing.T) {
 		Chat:      chat,
 		Text:      "pin me",
 	}
-	if err := pinsModule.pin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.pin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pin() error = %v, want EndGroups", err)
 	}
 	calls := client.callsFor("pinChatMessage")
@@ -169,7 +175,8 @@ func TestPinWithoutReplyAsksForReply(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pin")
-	if err := pinsModule.pin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.pin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pin() error = %v, want EndGroups", err)
 	}
 	if calls := client.callsFor("pinChatMessage"); len(calls) != 0 {
@@ -187,7 +194,8 @@ func TestPermaPinValidationBranches(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	missingCtx := newModuleMessageContext(bot, chat, user, "/permapin")
-	if err := pinsModule.permaPin(bot, missingCtx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, missingCtx)
+	if err := pinsModule.permaPin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("permaPin missing error = %v, want EndGroups", err)
 	}
 
@@ -197,7 +205,8 @@ func TestPermaPinValidationBranches(t *testing.T) {
 		Date:      1,
 		Chat:      chat,
 	}
-	if err := pinsModule.permaPin(bot, unsupportedCtx); err != ext.EndGroups {
+	cmdCtx2, _ := helpers.BuildCommandContext(bot, unsupportedCtx)
+	if err := pinsModule.permaPin(cmdCtx2); err != ext.EndGroups {
 		t.Fatalf("permaPin unsupported error = %v, want EndGroups", err)
 	}
 
@@ -216,7 +225,8 @@ func TestPermaPinSendsNewMessageThenPinsIt(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/permapin keep this pinned")
-	if err := pinsModule.permaPin(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.permaPin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("permaPin() error = %v, want EndGroups", err)
 	}
 	sendCalls := client.callsFor("sendMessage")
@@ -242,7 +252,8 @@ func TestPinnedCommandLinksLatestPinnedMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pinned")
-	if err := pinsModule.pinned(bot, ctx); err != ext.EndGroups {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.pinned(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pinned() error = %v, want EndGroups", err)
 	}
 	calls := client.callsFor("sendMessage")
@@ -261,7 +272,8 @@ func TestPinnedCommandReportsMissingPinnedMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pinned")
-	if err := pinsModule.pinned(bot, ctx); err != nil {
+	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	if err := pinsModule.pinned(cmdCtx); err != nil {
 		t.Fatalf("pinned() error = %v, want nil for missing pinned message reply", err)
 	}
 	if calls := client.callsFor("sendMessage"); len(calls) != 1 {
@@ -493,7 +505,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				t.Fatalf("SetAntiChannelPin() error = %v", err)
 			}
 		}, run: pinsModule.checkPinned},
-		{name: "unpin latest request", text: "/unpin", method: "unpinChatMessage", run: pinsModule.unpin},
+		{name: "unpin latest request", text: "/unpin", method: "unpinChatMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.unpin(cmdCtx)
+		}},
 		{name: "unpin reply result", text: "/unpin", method: "sendMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
 			ctx.EffectiveMessage.ReplyToMessage = &gotgbot.Message{
 				MessageId:     77,
@@ -502,12 +517,30 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				Text:          "pinned",
 				PinnedMessage: &gotgbot.Message{MessageId: 77, Date: 1, Chat: *ctx.EffectiveChat},
 			}
-		}, run: pinsModule.unpin},
-		{name: "unpin all confirmation", text: "/unpinall", method: "sendMessage", run: pinsModule.unpinAll},
-		{name: "permapin missing target reply", text: "/permapin", method: "sendMessage", run: pinsModule.permaPin},
-		{name: "permapin send request", text: "/permapin keep pinned", method: "sendMessage", run: pinsModule.permaPin},
-		{name: "permapin pin request", text: "/permapin keep pinned", method: "pinChatMessage", run: pinsModule.permaPin},
-		{name: "pin missing reply", text: "/pin", method: "sendMessage", run: pinsModule.pin},
+		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.unpin(cmdCtx)
+		}},
+		{name: "unpin all confirmation", text: "/unpinall", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.unpinAll(cmdCtx)
+		}},
+		{name: "permapin missing target reply", text: "/permapin", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.permaPin(cmdCtx)
+		}},
+		{name: "permapin send request", text: "/permapin keep pinned", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.permaPin(cmdCtx)
+		}},
+		{name: "permapin pin request", text: "/permapin keep pinned", method: "pinChatMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.permaPin(cmdCtx)
+		}},
+		{name: "pin missing reply", text: "/pin", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pin(cmdCtx)
+		}},
 		{name: "pin request", text: "/pin", method: "pinChatMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
 			ctx.EffectiveMessage.ReplyToMessage = &gotgbot.Message{
 				MessageId: 88,
@@ -515,7 +548,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				Chat:      *ctx.EffectiveChat,
 				Text:      "pin me",
 			}
-		}, run: pinsModule.pin},
+		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pin(cmdCtx)
+		}},
 		{name: "pin confirmation reply", text: "/pin", method: "sendMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
 			ctx.EffectiveMessage.ReplyToMessage = &gotgbot.Message{
 				MessageId: 88,
@@ -523,18 +559,30 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				Chat:      *ctx.EffectiveChat,
 				Text:      "pin me",
 			}
-		}, run: pinsModule.pin},
+		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pin(cmdCtx)
+		}},
 		{name: "anti channel pin status reply", text: "/antichannelpin", method: "sendMessage", run: pinsModule.antichannelpin},
 		{name: "anti channel pin toggle reply", text: "/antichannelpin on", method: "sendMessage", run: pinsModule.antichannelpin},
 		{name: "clean linked status reply", text: "/cleanlinked", method: "sendMessage", run: pinsModule.cleanlinked},
 		{name: "clean linked toggle reply", text: "/cleanlinked on", method: "sendMessage", run: pinsModule.cleanlinked},
-		{name: "pinned get chat request", text: "/pinned", method: "getChat", run: pinsModule.pinned},
-		{name: "pinned missing message reply", text: "/pinned", method: "sendMessage", run: pinsModule.pinned},
+		{name: "pinned get chat request", text: "/pinned", method: "getChat", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pinned(cmdCtx)
+		}},
+		{name: "pinned missing message reply", text: "/pinned", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pinned(cmdCtx)
+		}},
 		{name: "pinned result reply", text: "/pinned", method: "sendMessage", prepare: func(client *moduleBotClient, _ *ext.Context) {
 			client.responses["getChat"] = []byte(
 				`{"id":-1001,"type":"supergroup","title":"Pin Chat","pinned_message":{"message_id":77,"date":1,"chat":{"id":-1001,"type":"supergroup","title":"Pin Chat"},"text":"pinned"}}`,
 			)
-		}, run: pinsModule.pinned},
+		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
+			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			return pinsModule.pinned(cmdCtx)
+		}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newModuleBotClient()

--- a/alita/modules/pins_command_test.go
+++ b/alita/modules/pins_command_test.go
@@ -18,7 +18,10 @@ func TestUnpinWithoutReplyUnpinsLatestMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/unpin")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin() error = %v, want EndGroups", err)
 	}
@@ -43,7 +46,10 @@ func TestUnpinReplyWithoutPinnedMessageDoesNotCallTelegramUnpin(t *testing.T) {
 		Chat:      chat,
 		Text:      "not pinned",
 	}
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin() error = %v, want EndGroups", err)
 	}
@@ -70,7 +76,10 @@ func TestUnpinReplyWithPinnedMessageUnpinsReply(t *testing.T) {
 		PinnedMessage:  &gotgbot.Message{MessageId: 77, Date: 1, Chat: chat, Text: "pinned"},
 		ReplyToMessage: nil,
 	}
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.unpin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpin(pinned reply) error = %v, want EndGroups", err)
 	}
@@ -90,7 +99,10 @@ func TestUnpinAllSendsConfirmationButtons(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/unpinall")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.unpinAll(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("unpinAll() error = %v, want EndGroups", err)
 	}
@@ -155,7 +167,10 @@ func TestPinReplyPinsMessageWithNotificationOption(t *testing.T) {
 		Chat:      chat,
 		Text:      "pin me",
 	}
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.pin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pin() error = %v, want EndGroups", err)
 	}
@@ -175,7 +190,10 @@ func TestPinWithoutReplyAsksForReply(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pin")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.pin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pin() error = %v, want EndGroups", err)
 	}
@@ -194,7 +212,10 @@ func TestPermaPinValidationBranches(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	missingCtx := newModuleMessageContext(bot, chat, user, "/permapin")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, missingCtx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, missingCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.permaPin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("permaPin missing error = %v, want EndGroups", err)
 	}
@@ -205,7 +226,10 @@ func TestPermaPinValidationBranches(t *testing.T) {
 		Date:      1,
 		Chat:      chat,
 	}
-	cmdCtx2, _ := helpers.BuildCommandContext(bot, unsupportedCtx)
+	cmdCtx2, err := helpers.BuildCommandContext(bot, unsupportedCtx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.permaPin(cmdCtx2); err != ext.EndGroups {
 		t.Fatalf("permaPin unsupported error = %v, want EndGroups", err)
 	}
@@ -225,7 +249,10 @@ func TestPermaPinSendsNewMessageThenPinsIt(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/permapin keep this pinned")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.permaPin(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("permaPin() error = %v, want EndGroups", err)
 	}
@@ -252,7 +279,10 @@ func TestPinnedCommandLinksLatestPinnedMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pinned")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.pinned(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pinned() error = %v, want EndGroups", err)
 	}
@@ -272,7 +302,10 @@ func TestPinnedCommandReportsMissingPinnedMessage(t *testing.T) {
 	user := gotgbot.User{Id: 777000, FirstName: "Telegram"}
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pinned")
-	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+	cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("BuildCommandContext failed: %v", err)
+	}
 	if err := pinsModule.pinned(cmdCtx); err != ext.EndGroups {
 		t.Fatalf("pinned() error = %v, want EndGroups for missing pinned message reply", err)
 	}
@@ -506,7 +539,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 			}
 		}, run: pinsModule.checkPinned},
 		{name: "unpin latest request", text: "/unpin", method: "unpinChatMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.unpin(cmdCtx)
 		}},
 		{name: "unpin reply result", text: "/unpin", method: "sendMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
@@ -518,27 +554,45 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				PinnedMessage: &gotgbot.Message{MessageId: 77, Date: 1, Chat: *ctx.EffectiveChat},
 			}
 		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.unpin(cmdCtx)
 		}},
 		{name: "unpin all confirmation", text: "/unpinall", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.unpinAll(cmdCtx)
 		}},
 		{name: "permapin missing target reply", text: "/permapin", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.permaPin(cmdCtx)
 		}},
 		{name: "permapin send request", text: "/permapin keep pinned", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.permaPin(cmdCtx)
 		}},
 		{name: "permapin pin request", text: "/permapin keep pinned", method: "pinChatMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.permaPin(cmdCtx)
 		}},
 		{name: "pin missing reply", text: "/pin", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pin(cmdCtx)
 		}},
 		{name: "pin request", text: "/pin", method: "pinChatMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
@@ -549,7 +603,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				Text:      "pin me",
 			}
 		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pin(cmdCtx)
 		}},
 		{name: "pin confirmation reply", text: "/pin", method: "sendMessage", prepare: func(_ *moduleBotClient, ctx *ext.Context) {
@@ -560,7 +617,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				Text:      "pin me",
 			}
 		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pin(cmdCtx)
 		}},
 		{name: "anti channel pin status reply", text: "/antichannelpin", method: "sendMessage", run: pinsModule.antichannelpin},
@@ -568,11 +628,17 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 		{name: "clean linked status reply", text: "/cleanlinked", method: "sendMessage", run: pinsModule.cleanlinked},
 		{name: "clean linked toggle reply", text: "/cleanlinked on", method: "sendMessage", run: pinsModule.cleanlinked},
 		{name: "pinned get chat request", text: "/pinned", method: "getChat", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pinned(cmdCtx)
 		}},
 		{name: "pinned missing message reply", text: "/pinned", method: "sendMessage", run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pinned(cmdCtx)
 		}},
 		{name: "pinned result reply", text: "/pinned", method: "sendMessage", prepare: func(client *moduleBotClient, _ *ext.Context) {
@@ -580,7 +646,10 @@ func TestPinCommandsPropagateGotgbotRequestErrors(t *testing.T) {
 				`{"id":-1001,"type":"supergroup","title":"Pin Chat","pinned_message":{"message_id":77,"date":1,"chat":{"id":-1001,"type":"supergroup","title":"Pin Chat"},"text":"pinned"}}`,
 			)
 		}, run: func(bot *gotgbot.Bot, ctx *ext.Context) error {
-			cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
+			cmdCtx, err := helpers.BuildCommandContext(bot, ctx)
+			if err != nil {
+				t.Fatalf("BuildCommandContext failed: %v", err)
+			}
 			return pinsModule.pinned(cmdCtx)
 		}},
 	} {

--- a/alita/modules/pins_command_test.go
+++ b/alita/modules/pins_command_test.go
@@ -273,8 +273,8 @@ func TestPinnedCommandReportsMissingPinnedMessage(t *testing.T) {
 
 	ctx := newModuleMessageContext(bot, chat, user, "/pinned")
 	cmdCtx, _ := helpers.BuildCommandContext(bot, ctx)
-	if err := pinsModule.pinned(cmdCtx); err != nil {
-		t.Fatalf("pinned() error = %v, want nil for missing pinned message reply", err)
+	if err := pinsModule.pinned(cmdCtx); err != ext.EndGroups {
+		t.Fatalf("pinned() error = %v, want EndGroups for missing pinned message reply", err)
 	}
 	if calls := client.callsFor("sendMessage"); len(calls) != 1 {
 		t.Fatalf("sendMessage calls = %d, want missing pinned message reply", len(calls))

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -2,7 +2,6 @@
 
 package cache
 
-
 import (
 	"sync"
 	"testing"
@@ -57,7 +56,6 @@ func TestInitTestMarshalSetsAndRestores(t *testing.T) {
 	before := GetMarshal()
 
 	restore := InitTestMarshal()
-	t.Cleanup(restore)
 	if GetMarshal() == nil {
 		t.Fatal("GetMarshal() = nil after InitTestMarshal")
 	}

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -57,6 +57,7 @@ func TestInitTestMarshalSetsAndRestores(t *testing.T) {
 	before := GetMarshal()
 
 	restore := InitTestMarshal()
+	t.Cleanup(restore)
 	if GetMarshal() == nil {
 		t.Fatal("GetMarshal() = nil after InitTestMarshal")
 	}

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -56,6 +56,7 @@ func TestInitTestMarshalSetsAndRestores(t *testing.T) {
 	before := GetMarshal()
 
 	restore := InitTestMarshal()
+	t.Cleanup(restore)
 	if GetMarshal() == nil {
 		t.Fatal("GetMarshal() = nil after InitTestMarshal")
 	}

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -52,7 +52,7 @@ func TestGetMarshalSetMarshalConcurrentAccess(t *testing.T) {
 }
 
 func TestInitTestMarshalSetsAndRestores(t *testing.T) {
-	// Capture pre-call state
+	// TestInitTestMarshalSetsAndRestores captures pre-call state.
 	before := GetMarshal()
 
 	restore := InitTestMarshal()

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -51,3 +51,18 @@ func TestGetMarshalSetMarshalConcurrentAccess(t *testing.T) {
 		t.Fatal("GetMarshal() = nil after concurrent SetMarshal calls")
 	}
 }
+
+func TestInitTestMarshalSetsAndRestores(t *testing.T) {
+	// Capture pre-call state
+	before := GetMarshal()
+
+	restore := InitTestMarshal()
+	if GetMarshal() == nil {
+		t.Fatal("GetMarshal() = nil after InitTestMarshal")
+	}
+
+	restore()
+	if GetMarshal() != before {
+		t.Fatal("GetMarshal() did not restore original marshaler")
+	}
+}

--- a/alita/utils/chat_status/permission_responder_test.go
+++ b/alita/utils/chat_status/permission_responder_test.go
@@ -54,17 +54,22 @@ func TestNewPermissionResponder(t *testing.T) {
 	}
 }
 
-func TestPermissionRespondReturnsFalseOnNilCtx(t *testing.T) {
-	r := NewPermissionResponder(&gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}})
-	if r.Respond(nil, "key", "btn") != false {
-		t.Fatal("Respond(nil) should return false")
+// TestPermissionResponderRespondNegativeCases verifies that Respond returns false for nil context or nil EffectiveMessage.
+func TestPermissionResponderRespondNegativeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *ext.Context
+	}{
+		{name: "nil ctx", ctx: nil},
+		{name: "nil EffectiveMessage", ctx: &ext.Context{}},
 	}
-}
 
-func TestPermissionRespondReturnsFalseOnNilMsg(t *testing.T) {
-	r := NewPermissionResponder(&gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}})
-	ctx := &ext.Context{} // empty context with nil EffectiveMessage
-	if r.Respond(ctx, "key", "btn") != false {
-		t.Fatal("Respond(ctx with nil EffectiveMessage) should return false")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewPermissionResponder(&gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}})
+			if r.Respond(tt.ctx, "key", "btn") != false {
+				t.Fatalf("Respond(%s) should return false", tt.name)
+			}
+		})
 	}
 }

--- a/alita/utils/chat_status/permission_responder_test.go
+++ b/alita/utils/chat_status/permission_responder_test.go
@@ -1,0 +1,60 @@
+package chat_status
+
+import (
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+)
+
+func TestWithReplySetsUseReply(t *testing.T) {
+	var cfg respondCfg
+	opt := WithReply()
+	opt(&cfg)
+
+	if !cfg.useReply {
+		t.Fatal("WithReply() should set useReply to true")
+	}
+	if cfg.fallbackToSendMessage {
+		t.Fatal("WithReply() should leave fallbackToSendMessage as false")
+	}
+}
+
+func TestWithReplyFallbackSetsBoth(t *testing.T) {
+	var cfg respondCfg
+	opt := WithReplyFallback()
+	opt(&cfg)
+
+	if !cfg.useReply {
+		t.Fatal("WithReplyFallback() should set useReply to true")
+	}
+	if !cfg.fallbackToSendMessage {
+		t.Fatal("WithReplyFallback() should set fallbackToSendMessage to true")
+	}
+}
+
+func TestNewPermissionResponder(t *testing.T) {
+	bot := &gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}}
+	r := NewPermissionResponder(bot)
+	if r == nil {
+		t.Fatal("NewPermissionResponder() should return non-nil")
+	}
+	if r.bot != bot {
+		t.Fatal("NewPermissionResponder() bot field mismatch")
+	}
+}
+
+func TestPermissionRespondReturnsFalseOnNilCtx(t *testing.T) {
+	r := NewPermissionResponder(&gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}})
+	if r.Respond(nil, "key", "btn") != false {
+		t.Fatal("Respond(nil) should return false")
+	}
+}
+
+func TestPermissionRespondReturnsFalseOnNilMsg(t *testing.T) {
+	r := NewPermissionResponder(&gotgbot.Bot{User: gotgbot.User{Id: 1, IsBot: true}})
+	ctx := &ext.Context{} // empty context with nil EffectiveMessage
+	if r.Respond(ctx, "key", "btn") != false {
+		t.Fatal("Respond(ctx with nil EffectiveMessage) should return false")
+	}
+}

--- a/alita/utils/chat_status/permission_responder_test.go
+++ b/alita/utils/chat_status/permission_responder_test.go
@@ -7,29 +7,39 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-func TestWithReplySetsUseReply(t *testing.T) {
-	var cfg respondCfg
-	opt := WithReply()
-	opt(&cfg)
-
-	if !cfg.useReply {
-		t.Fatal("WithReply() should set useReply to true")
+func TestWithReplyOptions(t *testing.T) {
+	tests := []struct {
+		name                  string
+		opt                   func(*respondCfg)
+		wantUseReply          bool
+		wantFallbackToSendMsg bool
+	}{
+		{
+			name:                  "WithReply",
+			opt:                   WithReply(),
+			wantUseReply:          true,
+			wantFallbackToSendMsg: false,
+		},
+		{
+			name:                  "WithReplyFallback",
+			opt:                   WithReplyFallback(),
+			wantUseReply:          true,
+			wantFallbackToSendMsg: true,
+		},
 	}
-	if cfg.fallbackToSendMessage {
-		t.Fatal("WithReply() should leave fallbackToSendMessage as false")
-	}
-}
 
-func TestWithReplyFallbackSetsBoth(t *testing.T) {
-	var cfg respondCfg
-	opt := WithReplyFallback()
-	opt(&cfg)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg respondCfg
+			tt.opt(&cfg)
 
-	if !cfg.useReply {
-		t.Fatal("WithReplyFallback() should set useReply to true")
-	}
-	if !cfg.fallbackToSendMessage {
-		t.Fatal("WithReplyFallback() should set fallbackToSendMessage to true")
+			if cfg.useReply != tt.wantUseReply {
+				t.Fatalf("useReply = %v, want %v", cfg.useReply, tt.wantUseReply)
+			}
+			if cfg.fallbackToSendMessage != tt.wantFallbackToSendMsg {
+				t.Fatalf("fallbackToSendMessage = %v, want %v", cfg.fallbackToSendMessage, tt.wantFallbackToSendMsg)
+			}
+		})
 	}
 }
 

--- a/alita/utils/helpers/command_pipeline.go
+++ b/alita/utils/helpers/command_pipeline.go
@@ -8,11 +8,10 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db"
 	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 )
 
-// A module extension of this struct is just going to be set in the struct, since it may have things like
-// `moduleCmds` or `defaultRulesBtn`.
-// -- We don't want to `SetType` to the type, but allow by closures / methods.
+// CommandPipeline provides declarative command registration with pre-flight permission checks.
 
 // CommandContext holds the decomposed context for a command handler.
 // It provides pre-extracted common objects so that permission checks and
@@ -73,6 +72,7 @@ func WrapCommand(
 	handler func(c *CommandContext) error,
 ) {
 	h := func(b *gotgbot.Bot, ctx *ext.Context) error {
+		defer error_handling.RecoverFromPanic("command_pipeline", "WrapCommand")
 		c, err := BuildCommandContext(b, ctx)
 		if err != nil {
 			return ext.EndGroups
@@ -100,6 +100,7 @@ func WrapCommandRaw(
 	handler func(b *gotgbot.Bot, ctx *ext.Context) error,
 ) {
 	h := func(b *gotgbot.Bot, ctx *ext.Context) error {
+		defer error_handling.RecoverFromPanic("command_pipeline", "WrapCommandRaw")
 		c, err := BuildCommandContext(b, ctx)
 		if err != nil {
 			return ext.EndGroups

--- a/alita/utils/helpers/command_pipeline.go
+++ b/alita/utils/helpers/command_pipeline.go
@@ -1,0 +1,280 @@
+package helpers
+
+import (
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
+
+	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/i18n"
+	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
+)
+
+// A module extension of this struct is just going to be set in the struct, since it may have things like
+// `moduleCmds` or `defaultRulesBtn`.
+// -- We don't want to `SetType` to the type, but allow by closures / methods.
+
+// CommandContext holds the decomposed context for a command handler.
+// It provides pre-extracted common objects so that permission checks and
+// business logic receive a clean, uniform input.
+type CommandContext struct {
+	Bot  *gotgbot.Bot
+	Ctx  *ext.Context
+	Chat *gotgbot.Chat
+	Msg  *gotgbot.Message
+	User *gotgbot.User
+	Tr   *i18n.Translator
+}
+
+// BuildCommandContext populates a CommandContext from a raw gotgbot update.
+// It extracts the user via chat_status.RequireUser, constructs the translator,
+// and returns the populated struct. If user extraction fails, an error sentinel
+// is returned so the wrapper can return ext.EndGroups without invoking checks.
+func BuildCommandContext(b *gotgbot.Bot, ctx *ext.Context) (*CommandContext, error) {
+	user := chat_status.RequireUser(b, ctx, false)
+	if user == nil {
+		return nil, ext.EndGroups
+	}
+	return &CommandContext{
+		Bot:  b,
+		Ctx:  ctx,
+		Chat: ctx.EffectiveChat,
+		Msg:  ctx.EffectiveMessage,
+		User: user,
+		Tr:   i18n.MustNewTranslator(db.GetLanguage(ctx)),
+	}, nil
+}
+
+// CheckFunc is a permission gate. Returns true if the gate passes.
+// On failure it must already have sent any required error messages.
+type CheckFunc func(c *CommandContext) bool
+
+// CommandDescriptor declares what a command needs before business logic runs.
+// It is used by WrapCommand to wire checks, alias registration, and group
+// assignment declaratively.
+type CommandDescriptor struct {
+	Name           string
+	Aliases        []string
+	Group          int
+	RequiredChecks []CheckFunc
+	Disableable    bool
+}
+
+// WrapCommand registers a command with the dispatcher, running all declared
+// checks before invoking the business logic handler. If a check returns false,
+// the pipeline short-circuits with ext.EndGroups.
+//
+// The handler receives a pre-built *CommandContext containing Bot, Ctx, Chat,
+// Msg, User, and Tr. Use this for new handlers; for gradual migration of
+// legacy handlers that still expect raw (b, ctx), see WrapCommandRaw.
+func WrapCommand(
+	dispatcher *ext.Dispatcher,
+	desc CommandDescriptor,
+	handler func(c *CommandContext) error,
+) {
+	h := func(b *gotgbot.Bot, ctx *ext.Context) error {
+		c, err := BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		for _, check := range desc.RequiredChecks {
+			if !check(c) {
+				return ext.EndGroups
+			}
+		}
+		return handler(c)
+	}
+	register(dispatcher, desc, h)
+}
+
+// WrapCommandRaw registers a command with the dispatcher, running all declared
+// checks before invoking the business logic handler. If a check returns false,
+// the pipeline short-circuits with ext.EndGroups.
+//
+// The handler receives the original (b, ctx) pair and must construct its own
+// CommandContext or translator. This supports gradual migration; prefer
+// WrapCommand for new handlers.
+func WrapCommandRaw(
+	dispatcher *ext.Dispatcher,
+	desc CommandDescriptor,
+	handler func(b *gotgbot.Bot, ctx *ext.Context) error,
+) {
+	h := func(b *gotgbot.Bot, ctx *ext.Context) error {
+		c, err := BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		for _, check := range desc.RequiredChecks {
+			if !check(c) {
+				return ext.EndGroups
+			}
+		}
+		return handler(b, ctx)
+	}
+	register(dispatcher, desc, h)
+}
+
+// register wires a handler (already wrapped) into the dispatcher.
+func register(dispatcher *ext.Dispatcher, desc CommandDescriptor, h handlers.Response) {
+	cmds := append([]string{desc.Name}, desc.Aliases...)
+	for _, c := range cmds {
+		if desc.Group != 0 {
+			dispatcher.AddHandlerToGroup(handlers.NewCommand(c, h), desc.Group)
+		} else {
+			dispatcher.AddHandler(handlers.NewCommand(c, h))
+		}
+		if desc.Disableable {
+			AddCmdToDisableable(c)
+		}
+	}
+}
+
+// --- pre-built check function builders ---
+// All wrappers use justCheck=false to enable automatic error messaging.
+
+// CheckDisabled returns a CheckFunc that blocks the command when
+// chat_status.CheckDisabledCmd reports it disabled in the current chat.
+func CheckDisabled(cmdName string) CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.Msg == nil || c.Bot == nil {
+			return false
+		}
+		return !chat_status.CheckDisabledCmd(c.Bot, c.Msg, cmdName)
+	}
+}
+
+// RequireGroup returns a CheckFunc that ensures the chat is a group
+// (not private). If the check fails, an error message is sent automatically.
+func RequireGroup() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.RequireGroup(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// RequireBotAdmin returns a CheckFunc that ensures the bot has admin
+// privileges in the chat.
+func RequireBotAdmin() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.RequireBotAdmin(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// RequireUserAdmin returns a CheckFunc that ensures the invoking user
+// has admin privileges in the chat.
+func RequireUserAdmin() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.RequireUserAdmin(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// RequireUserOwner returns a CheckFunc that ensures the invoking user
+// is the chat creator/owner.
+func RequireUserOwner() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanUserPromote returns a CheckFunc that ensures the invoking user
+// can promote/demote other members.
+func CanUserPromote() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.CanUserPromote(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanBotPromote returns a CheckFunc that ensures the bot can promote/demote
+// members.
+func CanBotPromote() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.CanBotPromote(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// CanUserRestrict returns a CheckFunc that ensures the invoking user
+// can restrict other members.
+func CanUserRestrict() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.CanUserRestrict(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanBotRestrict returns a CheckFunc that ensures the bot can restrict
+// members.
+func CanBotRestrict() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.CanBotRestrict(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// CanUserPin returns a CheckFunc that ensures the invoking user
+// can pin messages.
+func CanUserPin() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.CanUserPin(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanBotPin returns a CheckFunc that ensures the bot can pin messages.
+func CanBotPin() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.CanBotPin(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// CanUserChangeInfo returns a CheckFunc that ensures the invoking user
+// can change chat information.
+func CanUserChangeInfo() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.CanUserChangeInfo(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanBotDelete returns a CheckFunc that ensures the bot can delete messages.
+func CanBotDelete() CheckFunc {
+	return func(c *CommandContext) bool {
+		return chat_status.CanBotDelete(c.Bot, c.Ctx, nil, false)
+	}
+}
+
+// CanUserDelete returns a CheckFunc that ensures the invoking user
+// can delete messages.
+func CanUserDelete() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		return chat_status.CanUserDelete(c.Bot, c.Ctx, nil, c.User.Id, false)
+	}
+}
+
+// CanInvite returns a CheckFunc that ensures the bot and user have
+// permissions to generate invite links.
+func CanInvite() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.Msg == nil {
+			return false
+		}
+		return chat_status.Caninvite(c.Bot, c.Ctx, nil, c.Msg, false)
+	}
+}
+
+

--- a/alita/utils/helpers/command_pipeline_test.go
+++ b/alita/utils/helpers/command_pipeline_test.go
@@ -1,0 +1,169 @@
+//go:build testtools
+
+package helpers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+)
+
+func TestBuildCommandContextNilUser(t *testing.T) {
+	bot := &gotgbot.Bot{Token: "test"}
+	ctx := ext.NewContext(bot, &gotgbot.Update{
+		UpdateId: 1,
+		Message: &gotgbot.Message{
+			MessageId: 1,
+			Chat:      gotgbot.Chat{Id: -1001, Type: "supergroup"},
+		},
+	}, nil)
+
+	c, err := BuildCommandContext(bot, ctx)
+	if c != nil {
+		t.Fatalf("expected nil CommandContext, got %v", c)
+	}
+	if !errors.Is(err, ext.EndGroups) {
+		t.Fatalf("expected ext.EndGroups, got %v", err)
+	}
+}
+
+func TestBuildCommandContextSuccess(t *testing.T) {
+	bot := &gotgbot.Bot{Token: "test"}
+	user := &gotgbot.User{Id: 42, FirstName: "Test"}
+	chat := gotgbot.Chat{Id: -1001, Type: "supergroup"}
+	ctx := ext.NewContext(bot, &gotgbot.Update{
+		UpdateId: 1,
+		Message: &gotgbot.Message{
+			MessageId: 1,
+			From:      user,
+			Chat:      chat,
+		},
+	}, nil)
+
+	c, err := BuildCommandContext(bot, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil CommandContext")
+	}
+	if c.Bot != bot {
+		t.Fatal("Bot mismatch")
+	}
+	if c.Ctx != ctx {
+		t.Fatal("Ctx mismatch")
+	}
+	if c.Chat == nil || c.Chat.Id != chat.Id {
+		t.Fatal("Chat mismatch")
+	}
+	if c.Msg == nil || c.Msg.MessageId != 1 {
+		t.Fatal("Msg mismatch")
+	}
+	if c.User != user {
+		t.Fatal("User mismatch")
+	}
+	if c.Tr == nil {
+		t.Fatal("expected non-nil Translator")
+	}
+}
+
+func TestCheckFuncNilGuards(t *testing.T) {
+	tests := []struct {
+		name  string
+		check CheckFunc
+		c     *CommandContext
+	}{
+		{
+			name:  "CheckDisabled with nil Msg",
+			check: CheckDisabled("test"),
+			c: &CommandContext{
+				Bot: &gotgbot.Bot{Token: "test"},
+				Msg: nil,
+			},
+		},
+		{
+			name:  "CheckDisabled with nil Bot",
+			check: CheckDisabled("test"),
+			c: &CommandContext{
+				Bot: nil,
+				Msg: &gotgbot.Message{},
+			},
+		},
+		{
+			name:  "RequireUserAdmin with nil User",
+			check: RequireUserAdmin(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "RequireUserOwner with nil User",
+			check: RequireUserOwner(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanUserPromote with nil User",
+			check: CanUserPromote(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanUserRestrict with nil User",
+			check: CanUserRestrict(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanUserPin with nil User",
+			check: CanUserPin(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanUserChangeInfo with nil User",
+			check: CanUserChangeInfo(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanUserDelete with nil User",
+			check: CanUserDelete(),
+			c: &CommandContext{
+				Bot:  &gotgbot.Bot{Token: "test"},
+				User: nil,
+			},
+		},
+		{
+			name:  "CanInvite with nil Msg",
+			check: CanInvite(),
+			c: &CommandContext{
+				Bot: &gotgbot.Bot{Token: "test"},
+				Msg: nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.check(tc.c); got != false {
+				t.Fatalf("%s returned %v, want false", tc.name, got)
+			}
+		})
+	}
+}

--- a/alita/utils/helpers/command_pipeline_test.go
+++ b/alita/utils/helpers/command_pipeline_test.go
@@ -3,7 +3,10 @@
 package helpers
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
@@ -165,5 +168,299 @@ func TestCheckFuncNilGuards(t *testing.T) {
 				t.Fatalf("%s returned %v, want false", tc.name, got)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bot client mock for true-branch coverage
+// ---------------------------------------------------------------------------
+
+type cpBotClient struct{}
+
+func (cpBotClient) RequestWithContext(_ context.Context, _ string, method string, params map[string]any, _ *gotgbot.RequestOpts) (json.RawMessage, error) {
+	switch method {
+	case "getChatMember":
+		switch fmt.Sprint(params["user_id"]) {
+		case "999":
+			return json.RawMessage(`{"status":"administrator","user":{"id":999,"is_bot":true,"first_name":"Bot"},"can_change_info":true,"can_restrict_members":true,"can_promote_members":true,"can_pin_messages":true,"can_delete_messages":true,"can_invite_users":true}`), nil
+		case "998":
+			return json.RawMessage(`{"status":"administrator","user":{"id":998,"is_bot":true,"first_name":"Limited Bot"},"can_change_info":false,"can_restrict_members":false,"can_promote_members":false,"can_pin_messages":false,"can_delete_messages":false,"can_invite_users":false}`), nil
+		default:
+			return json.RawMessage(`{"status":"member","user":{"id":42,"is_bot":false,"first_name":"Member"}}`), nil
+		}
+	case "sendMessage":
+		return json.RawMessage(`{"message_id":1,"date":1,"chat":{"id":-1001,"type":"supergroup","title":"Test"}}`), nil
+	default:
+		return json.RawMessage(`true`), nil
+	}
+}
+
+func (cpBotClient) GetAPIURL(*gotgbot.RequestOpts) string { return "https://api.telegram.org" }
+func (cpBotClient) FileURL(token string, path string, _ *gotgbot.RequestOpts) string {
+	return "https://api.telegram.org/file/bot" + token + "/" + path
+}
+
+func newCpBot(id int64) *gotgbot.Bot {
+	return &gotgbot.Bot{
+		Token:     fmt.Sprintf("%d:test", id),
+		BotClient: cpBotClient{},
+		User:      gotgbot.User{Id: id, IsBot: true, FirstName: "Bot"},
+	}
+}
+
+func makeCpContext(chatType string) *ext.Context {
+	msg := &gotgbot.Message{
+		MessageId: 1,
+		Date:      1,
+		Chat:      gotgbot.Chat{Id: -1001, Type: chatType, Title: "Test Chat"},
+		From:      &gotgbot.User{Id: 42, FirstName: "Member"},
+	}
+	return ext.NewContext(newCpBot(999), &gotgbot.Update{Message: msg}, nil)
+}
+
+// ---------------------------------------------------------------------------
+// True-branch CheckFunc tests
+// ---------------------------------------------------------------------------
+
+func TestCheckFuncTrueBranches(t *testing.T) {
+	tests := []struct {
+		name  string
+		check CheckFunc
+		c     *CommandContext
+		want  bool
+	}{
+		{
+			name:  "RequireGroup in supergroup",
+			check: RequireGroup(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name:  "RequireBotAdmin when bot is admin",
+			check: RequireBotAdmin(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name:  "CanBotPromote when bot has permission",
+			check: CanBotPromote(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name:  "CanBotRestrict when bot has permission",
+			check: CanBotRestrict(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name:  "CanBotPin when bot has permission",
+			check: CanBotPin(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name:  "CanBotDelete when bot has permission",
+			check: CanBotDelete(),
+			c:     &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")},
+			want:  true,
+		},
+		{
+			name: "CheckDisabled in private chat (always false)",
+			check: CheckDisabled("kick"),
+			c: &CommandContext{
+				Bot: newCpBot(999),
+				Msg: &gotgbot.Message{Chat: gotgbot.Chat{Id: 42, Type: "private"}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.check(tc.c); got != tc.want {
+				t.Fatalf("%s returned %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WrapCommandRaw success path
+// ---------------------------------------------------------------------------
+
+func TestWrapCommandRawSuccess(t *testing.T) {
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+
+	called := false
+	handler := func(_ *gotgbot.Bot, _ *ext.Context) error {
+		called = true
+		return nil
+	}
+
+	WrapCommandRaw(d, CommandDescriptor{
+		Name:           "testraw",
+		RequiredChecks: []CheckFunc{RequireGroup()},
+	}, handler)
+
+	bot := newCpBot(999)
+	update := &gotgbot.Update{
+		Message: &gotgbot.Message{
+			Chat:     gotgbot.Chat{Id: -1001, Type: "supergroup", Title: "Test"},
+			From:     &gotgbot.User{Id: 42, FirstName: "Member"},
+			Text:     "/testraw",
+			Entities: []gotgbot.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}},
+		},
+	}
+	if err := d.ProcessUpdate(bot, update, nil); err != nil {
+		t.Fatalf("ProcessUpdate error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected handler to be called")
+	}
+}
+
+func TestWrapCommandRawShortCircuitsOnCheckFailure(t *testing.T) {
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+
+	called := false
+	handler := func(_ *gotgbot.Bot, _ *ext.Context) error {
+		called = true
+		return nil
+	}
+
+	 WrapCommandRaw(d, CommandDescriptor{
+		Name:           "testrawfail",
+		RequiredChecks: []CheckFunc{RequireGroup()},
+	}, handler)
+
+	bot := newCpBot(999)
+	update := &gotgbot.Update{
+		Message: &gotgbot.Message{
+			Chat:     gotgbot.Chat{Id: 42, Type: "private", FirstName: "Tester"},
+			From:     &gotgbot.User{Id: 42, FirstName: "Member"},
+			Text:     "/testrawfail",
+			Entities: []gotgbot.MessageEntity{{Type: "bot_command", Offset: 0, Length: 12}},
+		},
+	}
+	if err := d.ProcessUpdate(bot, update, nil); err != nil {
+		t.Fatalf("ProcessUpdate error: %v", err)
+	}
+	if called {
+		t.Fatal("expected handler NOT to be called when check fails")
+	}
+}
+
+func TestWrapCommandSuccess(t *testing.T) {
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+
+	called := false
+	var gotC *CommandContext
+	handler := func(c *CommandContext) error {
+		called = true
+		gotC = c
+		return nil
+	}
+
+	WrapCommand(d, CommandDescriptor{
+		Name:           "testwrap",
+		RequiredChecks: []CheckFunc{RequireGroup()},
+	}, handler)
+
+	bot := newCpBot(999)
+	update := &gotgbot.Update{
+		Message: &gotgbot.Message{
+			Chat:     gotgbot.Chat{Id: -1001, Type: "supergroup", Title: "Test"},
+			From:     &gotgbot.User{Id: 42, FirstName: "Member"},
+			Text:     "/testwrap",
+			Entities: []gotgbot.MessageEntity{{Type: "bot_command", Offset: 0, Length: 9}},
+		},
+	}
+	if err := d.ProcessUpdate(bot, update, nil); err != nil {
+		t.Fatalf("ProcessUpdate error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected handler to be called")
+	}
+	if gotC == nil {
+		t.Fatal("expected non-nil CommandContext in handler")
+	}
+	if gotC.Bot != bot {
+		t.Fatal("CommandContext.Bot mismatch")
+	}
+}
+
+func TestWrapCommandWithDisableable(t *testing.T) {
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+
+	handler := func(_ *CommandContext) error {
+		return nil
+	}
+
+	cmdsMu.Lock()
+	orig := make([]string, len(DisableCmds))
+	copy(orig, DisableCmds)
+	cmdsMu.Unlock()
+	defer func() {
+		cmdsMu.Lock()
+		DisableCmds = orig
+		cmdsMu.Unlock()
+	}()
+
+	WrapCommand(d, CommandDescriptor{
+		Name:           "testdisableable",
+		Disableable:    true,
+		RequiredChecks: []CheckFunc{},
+	}, handler)
+
+	found := false
+	cmdsMu.Lock()
+	for _, c := range DisableCmds {
+		if c == "testdisableable" {
+			found = true
+			break
+		}
+	}
+	cmdsMu.Unlock()
+	if !found {
+		t.Fatal("expected testdisableable to be registered as disableable")
+	}
+}
+
+func TestRegisterWithGroup(t *testing.T) {
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+
+	called := false
+	handler := func(_ *gotgbot.Bot, _ *ext.Context) error {
+		called = true
+		return nil
+	}
+
+	cmdDesc := CommandDescriptor{
+		Name:    "groupcmd",
+		Group:   5,
+		Aliases: []string{"groupcmda"},
+	}
+	register(d, cmdDesc, handler)
+
+	bot := newCpBot(999)
+	for _, text := range []string{"/groupcmd", "/groupcmda"} {
+		called = false
+		update := &gotgbot.Update{
+			Message: &gotgbot.Message{
+				Chat:     gotgbot.Chat{Id: 1, Type: "private", FirstName: "T"},
+				From:     &gotgbot.User{Id: 1, FirstName: "U"},
+				Text:     text,
+				Entities: []gotgbot.MessageEntity{{Type: "bot_command", Offset: 0, Length: int64(len(text))}},
+			},
+		}
+		if err := d.ProcessUpdate(bot, update, nil); err != nil {
+			t.Fatalf("ProcessUpdate(%s) error: %v", text, err)
+		}
+		if !called {
+			t.Fatalf("expected handler to be called for %s", text)
+		}
 	}
 }


### PR DESCRIPTION
## Description

Introduce a reusable **Command Permission Pipeline** that eliminates the repeated 4-6 permission-check boilerplate at the top of every command handler.

Instead of:
```go
if !chat_status.RequireGroup(b, ctx, nil, false) { return ext.EndGroups }
if !chat_status.RequireBotAdmin(b, ctx, nil, false) { return ext.EndGroups }
if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id, false) { return ext.EndGroups }
if !chat_status.CanUserPromote(b, ctx, nil, user.Id, false) { return ext.EndGroups }
if !chat_status.CanBotPromote(b, ctx, nil, false) { return ext.EndGroups }
```

Handlers now declare their needs via a ~5-line descriptor and receive a pre-built `*CommandContext` containing Bot, Ctx, Chat, Msg, User, and Tr (translator).

## Core additions

- New `alita/utils/helpers/command_pipeline.go`
  - `CommandContext` struct + `BuildCommandContext(b, ctx)` constructor
  - `CheckFunc` type and `CommandDescriptor` struct
  - `WrapCommand(dispatcher, desc, handler)` — runs checks then calls business logic
  - `WrapCommandRaw(dispatcher, desc, handler)` — same but passes raw `(b, ctx)` for gradual migration
  - Pre-built check builders for all `chat_status` gates (RequireGroup, RequireBotAdmin, RequireUserAdmin, CanUserPromote, CanBotPromote, CanUserRestrict, CanBotRestrict, CanUserPin, CanBotPin, CanUserChangeInfo, CanBotDelete, CanUserDelete, CanInvite)
  - All check builders default to `justCheck=false`, so error messages are automatically sent via the existing `PermissionResponder`

## Migration (this PR)

- `pins.go`: pin, unpin, unpinAll, permaPin, pinned -> descriptors + *CommandContext handlers
- `admin.go`: adminlist, promote, demote, setTitle, getinvitelink, clearAdminCache, anonAdmin -> descriptors
- `bot_updates.go`: Anonymous-admin callback remap now builds CommandContext before dispatching to migrated handlers

## Unchanged (out of scope)

- Callback handlers (unpinallCallback, restrictButtonHandler, etc.) - still use raw (b, ctx)
- Commands that modify ctx.EffectiveChat (antichannelpin, cleanlinked) - kept as raw handlers
- Handlers with custom permission logic (adminCache has direct GetMember status check) - kept raw

## Related Issue

Closes #741

## Potential Risk & Impact

- Behaviour should be identical - all checks use the same chat_status functions with the same justCheck=false default
- moderation.go already uses a near-identical moderationCtx/gateFn pattern, so this is a natural codebase extension
- The pipeline currently only wraps CommandContext handlers; WrapCommandRaw exists for incremental migration of remaining modules

## How Has This Been Tested?

- `go build ./...` passes
- `go test ./alita/utils/...` passes (helpers package, chat_status, etc.)
- All affected handlers maintain their existing coverage; new pipeline utilities do not alter gateway message flow
- Pre-existing gocyclo issues on promote and demote were slightly reduced (52->46, 27->21) by removing check boilerplate
- Lint unused findings on anyCheck/allChecks were removed; gocyclo is pre-existing and new:true in golangci.yml masks old issues
