### PR TITLE
fix(migrations): ignore rollback SQL files

### DIFF
--- a/alita/db/migrations.go
+++ b/alita/db/migrations.go
@@ -134,6 +134,10 @@ func (m *MigrationRunner) getMigrationFiles() ([]string, error) {
 		return nil, err
 	}
 
+	files = slices.DeleteFunc(files, func(file string) bool {
+		return strings.HasSuffix(filepath.Base(file), ".rollback.sql")
+	})
+
 	// Sort files to ensure consistent order
 	slices.Sort(files)
 	return files, nil

--- a/alita/db/migrations_test.go
+++ b/alita/db/migrations_test.go
@@ -468,6 +468,34 @@ func TestGetMigrationFiles(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("rollback sql files are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		names := []string{
+			"001_create_table.sql",
+			"001_create_table.rollback.sql",
+			"002_add_column.sql",
+		}
+		for _, name := range names {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("SELECT 1;"), 0o600); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+		}
+
+		runner := &MigrationRunner{db: nil, migrationsPath: dir, cleanSQL: true}
+		files, err := runner.getMigrationFiles()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(files) != 2 {
+			t.Fatalf("expected 2 executable migration files, got %d: %v", len(files), files)
+		}
+		for _, f := range files {
+			if strings.HasSuffix(filepath.Base(f), ".rollback.sql") {
+				t.Fatalf("rollback migration should not be executable: %s", f)
+			}
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The automatic migration runner currently discovers every `*.sql` file under `migrations`. That also includes manual rollback scripts named `*.rollback.sql` if they are stored next to forward migrations.

This patch keeps normal `*.sql` migrations unchanged, but skips files ending in `.rollback.sql`, and adds a regression test to ensure rollback scripts are not treated as executable forward migrations.

Verification:
- `go test -tags testtools ./alita/db -run 'TestGetMigrationFiles' -count=1`
- `git diff --check`