### PR TITLE
fix(build): adapt gotgbot v2.0.0-rc.35 *bool API changes

### DIFF
--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -172,7 +172,7 @@ func (m moduleStruct) performDemotion(c *helpers.CommandContext, userId int64) e
 		&gotgbot.PromoteChatMemberOpts{
 			CanPostMessages:     false,
 			CanDeleteMessages:   false,
-			CanRestrictMembers:  false,
+			CanRestrictMembers:  helpers.Ptr(false),
 			CanChangeInfo:       false,
 			CanInviteUsers:      false,
 			CanPinMessages:      false,
@@ -314,7 +314,7 @@ func buildPromoteOpts(botMember, promoterMember gotgbot.ChatMember, user *gotgbo
 	return &gotgbot.PromoteChatMemberOpts{
 		CanPostMessages:     canGrantPerm(bMem.CanPostMessages, pMem.CanPostMessages, checkCommonPerms),
 		CanDeleteMessages:   canGrantPerm(bMem.CanDeleteMessages, pMem.CanDeleteMessages, checkCommonPerms),
-		CanRestrictMembers:  canGrantPerm(bMem.CanRestrictMembers, pMem.CanRestrictMembers, checkCommonPerms),
+		CanRestrictMembers:  helpers.Ptr(canGrantPerm(bMem.CanRestrictMembers, pMem.CanRestrictMembers, checkCommonPerms)),
 		CanChangeInfo:       canGrantPerm(bMem.CanChangeInfo, pMem.CanChangeInfo, checkCommonPerms),
 		CanInviteUsers:      canGrantPerm(bMem.CanInviteUsers, pMem.CanInviteUsers, checkCommonPerms),
 		CanPinMessages:      canGrantPerm(bMem.CanPinMessages, pMem.CanPinMessages, checkCommonPerms),

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -1402,7 +1402,7 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 			CanChangeInfo:         false,
 			CanInviteUsers:        true,
 			CanPinMessages:        false,
-			CanManageTopics:       false,
+			CanManageTopics:       helpers.Ptr(false),
 			CanSendPolls:          true,
 			CanSendOtherMessages:  true,
 		}, nil)
@@ -1980,7 +1980,7 @@ func unmuteExpiredCaptchaUsers() {
 			CanChangeInfo:         false, // Match success unmute permissions
 			CanInviteUsers:        true,
 			CanPinMessages:        false, // Match success unmute permissions
-			CanManageTopics:       false, // Match success unmute permissions
+			CanManageTopics:       helpers.Ptr(false), // Match success unmute permissions
 		}, nil)
 		if err != nil {
 			if isPermanentUnmuteError(err) {

--- a/alita/modules/chat_permissions.go
+++ b/alita/modules/chat_permissions.go
@@ -1,6 +1,10 @@
 package modules
 
-import "github.com/PaulSonOfLars/gotgbot/v2"
+import (
+	"github.com/PaulSonOfLars/gotgbot/v2"
+
+	"github.com/divkix/Alita_Robot/alita/utils/helpers"
+)
 
 // MutedPermissions represents a fully restricted user - all sending capabilities disabled
 var MutedPermissions = gotgbot.ChatPermissions{
@@ -15,7 +19,7 @@ var MutedPermissions = gotgbot.ChatPermissions{
 	CanChangeInfo:         false,
 	CanInviteUsers:        false,
 	CanPinMessages:        false,
-	CanManageTopics:       false,
+	CanManageTopics:       helpers.Ptr(false),
 	CanSendPolls:          false,
 	CanSendOtherMessages:  false,
 }
@@ -34,7 +38,7 @@ func defaultUnmutePermissions() gotgbot.ChatPermissions {
 		CanChangeInfo:         false,
 		CanInviteUsers:        true,
 		CanPinMessages:        false,
-		CanManageTopics:       false,
+		CanManageTopics:       helpers.Ptr(false),
 		CanSendPolls:          true,
 		CanSendOtherMessages:  true,
 	}

--- a/alita/modules/chat_permissions_test.go
+++ b/alita/modules/chat_permissions_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
+// derefBool safely dereferences a *bool, returning defaultVal if nil.
+func derefBool(ptr *bool, defaultVal bool) bool {
+	if ptr == nil {
+		return defaultVal
+	}
+	return *ptr
+}
+
 func TestDefaultUnmutePermissions(t *testing.T) {
 	t.Parallel()
 
@@ -44,7 +52,7 @@ func TestDefaultUnmutePermissions(t *testing.T) {
 	if perms.CanPinMessages {
 		t.Errorf("CanPinMessages = true, want false")
 	}
-	if perms.CanManageTopics {
+	if derefBool(perms.CanManageTopics, false) {
 		t.Errorf("CanManageTopics = true, want false")
 	}
 	if !perms.CanSendPolls {
@@ -140,8 +148,8 @@ func TestResolveUnmutePermissions(t *testing.T) {
 			if got.CanPinMessages != tc.wantPerm.CanPinMessages {
 				t.Errorf("CanPinMessages = %v, want %v", got.CanPinMessages, tc.wantPerm.CanPinMessages)
 			}
-			if got.CanManageTopics != tc.wantPerm.CanManageTopics {
-				t.Errorf("CanManageTopics = %v, want %v", got.CanManageTopics, tc.wantPerm.CanManageTopics)
+			if derefBool(got.CanManageTopics, false) != derefBool(tc.wantPerm.CanManageTopics, false) {
+				t.Errorf("CanManageTopics = %v, want %v", derefBool(got.CanManageTopics, false), derefBool(tc.wantPerm.CanManageTopics, false))
 			}
 			if got.CanSendPolls != tc.wantPerm.CanSendPolls {
 				t.Errorf("CanSendPolls = %v, want %v", got.CanSendPolls, tc.wantPerm.CanSendPolls)

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -805,7 +805,7 @@ func (moduleStruct) newMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 					CanChangeInfo:         false,
 					CanInviteUsers:        true,
 					CanPinMessages:        false,
-					CanManageTopics:       false,
+					CanManageTopics:       helpers.Ptr(false),
 					CanSendPolls:          true,
 					CanSendOtherMessages:  true,
 				}, nil)
@@ -927,7 +927,7 @@ func processSingleNewMember(bot *gotgbot.Bot, ctx *ext.Context, newMember gotgbo
 					CanChangeInfo:         false,
 					CanInviteUsers:        true,
 					CanPinMessages:        false,
-					CanManageTopics:       false,
+					CanManageTopics:       helpers.Ptr(false),
 					CanSendPolls:          true,
 					CanSendOtherMessages:  true,
 				}, nil)

--- a/alita/utils/helpers/ptr.go
+++ b/alita/utils/helpers/ptr.go
@@ -1,0 +1,8 @@
+package helpers
+
+// Ptr returns a pointer to the given value.
+// Used for converting bool constants and other literals to pointer types
+// required by gotgbot API structs (e.g., *bool fields).
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This PR fixes the broken release build for `v2.17.31`.

**Problem:**
gotgbot v2.0.0-rc.35 ([dependabot #747](https://github.com/divkix/Alita_Robot/pull/747)) changed two struct fields from `bool` to `*bool`:
- `ChatPermissions.CanManageTopics`
- `PromoteChatMemberOpts.CanRestrictMembers`

This caused 8 compile errors across `admin.go`, `chat_permissions.go`, `captcha.go`, and `greetings.go` in the release CI run [26436141797](https://github.com/divkix/Alita_Robot/actions/runs/26436141797).

**Fix:**
- Wrap affected literal and expression assignments with the new `helpers.Ptr[T]` helper.
- Update `chat_permissions_test.go` to safely dereference pointer fields.

Verified locally: `make lint` and `CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o alita_robot .` both pass.