### PR TITLE
chore: code cleanup phase 2 (REVIEW)

### DIFF
--- a/alita/modules/backup.go
+++ b/alita/modules/backup.go
@@ -630,13 +630,15 @@ func (m moduleStruct) handleConfirmImport(b *gotgbot.Bot, ctx *ext.Context, tr *
 	return ext.EndGroups
 }
 
-func (m moduleStruct) handleCancelImport(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery) error {
+// handleCancelPending clears the chat's pending state via clear and acknowledges
+// the cancelled backup callback using the cancelKey confirmation message.
+func (m moduleStruct) handleCancelPending(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery, clear func(int64), cancelKey string) error {
 	chat := ctx.EffectiveChat
 
 	// Clean up
-	clearPendingImport(chat.Id)
+	clear(chat.Id)
 
-	text, _ := tr.GetString("backup_import_cancelled")
+	text, _ := tr.GetString(cancelKey)
 	_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{
 		Text: text,
 	})
@@ -649,6 +651,10 @@ func (m moduleStruct) handleCancelImport(b *gotgbot.Bot, ctx *ext.Context, tr *i
 	}
 
 	return ext.EndGroups
+}
+
+func (m moduleStruct) handleCancelImport(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery) error {
+	return m.handleCancelPending(b, ctx, tr, query, clearPendingImport, "backup_import_cancelled")
 }
 
 func (m moduleStruct) handleConfirmReset(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, chat *gotgbot.Chat) error {
@@ -691,24 +697,7 @@ func (m moduleStruct) handleConfirmReset(b *gotgbot.Bot, ctx *ext.Context, tr *i
 }
 
 func (m moduleStruct) handleCancelReset(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery) error {
-	chat := ctx.EffectiveChat
-
-	// Clean up
-	clearPendingReset(chat.Id)
-
-	text, _ := tr.GetString("backup_reset_cancelled")
-	_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{
-		Text: text,
-	})
-
-	msg := ctx.EffectiveMessage
-	if msg != nil {
-		_, _, _ = msg.EditText(b, text, &gotgbot.EditMessageTextOpts{
-			ParseMode: "HTML",
-		})
-	}
-
-	return ext.EndGroups
+	return m.handleCancelPending(b, ctx, tr, query, clearPendingReset, "backup_reset_cancelled")
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary

Repo-wide code-cleanup sweep (REVIEW tier). After full research the repo was already clean — **no dead code, no import cycles, no debug prints, no commented-out code, no stale TODOs, no unsafe weak types**. (Every `deadcode`/`staticcheck` U1000 was a `testtools` build-tag false positive — staticcheck *with* the tag reports zero.)

The only actionable item was one duplication finding.

## Change

`alita/modules/backup.go` — extract `handleCancelPending` helper; `handleCancelImport`/`handleCancelReset` now delegate to it (resolves `dupl` 633-652 vs 693-712). Net −21/+10 lines.

- Method signatures unchanged → dispatcher call sites and tests untouched.
- Behavior identical (same cleanup fn + i18n key threaded through).

## Deliberately kept

Other `dupl` hits evaluated and kept: `media/sender.go` per-type senders (distinct gotgbot `Send*Opts` types) and the backup importers / `blacklists↔approvals↔connections` patterns (cross-domain; backup importers already carry maintainer `//nolint:dupl`). Merging would couple unrelated domains or need reflection on a hot path.

## Validation

Local (Postgres/Redis unavailable → full `make test` deferred to CI):

- `CGO_ENABLED=0 go build ./...` — OK
- `go vet -tags testtools ./...` — OK
- `go test -tags testtools` compile (`modules`, `db/backup`) — OK
- `golangci-lint` `dupl` — cleared on the cancel handlers
- `gofmt -l` — clean

> Note: 15 files are gofmt-dirty on `main` already (pre-existing version drift); left untouched, out of scope for this sweep.