### PR TITLE
fix: repair moderation callbacks and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=main
-          cache-to: type=gha,mode=max,scope=main
+          cache-to: type=gha,mode=max,scope=main,ignore-error=true
           provenance: true
           sbom: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,23 @@ jobs:
           set -euo pipefail
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
+          git fetch origin refs/heads/main:refs/remotes/origin/main
+          git merge --ff-only origin/main
           bash scripts/bump_version.sh "$TAG"
           if [ -n "$(git status --porcelain)" ]; then
             git commit -am "chore(release): set BotVersion to ${TAG}"
-            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+            for attempt in 1 2 3; do
+              if git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::main kept advancing; failed to push release version after 3 attempts" >&2
+                exit 1
+              fi
+              echo "main advanced during release; rebasing and retrying push"
+              git fetch origin refs/heads/main:refs/remotes/origin/main
+              git rebase origin/main
+            done
           else
             echo "BotVersion already at ${TAG}; nothing to commit"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Parallel jobs (no `needs`), then aggregation:
 | `test` | Service containers **postgres:16** + **redis:7**; `CGO_ENABLED=1`; `make test`; then coverage gate **≥78%** | Yes |
 | `docs-check` | `make check-translations` + `make check-docs` (translation + docs drift gate) | Yes |
 | `docker-verify` | single-arch `docker build -f docker/alpine` (no push) | Yes |
-| `docker-publish` | main-push only; multi-arch `linux/amd64,linux/arm64` → GHCR tags `dev`, `dev-<sha7>`, `<sha7>` (NOT `latest`), with `provenance:true` + `sbom:true`; `needs: [security,lint,build,test,docker-verify]` (NOT docs-check) | Yes (on main push) |
+| `docker-publish` | main-push only; multi-arch `linux/amd64,linux/arm64` → GHCR tags `dev`, `dev-<sha7>`, `<sha7>` (NOT `latest`), with `provenance:true` + `sbom:true`; GHA cache export is best-effort (`ignore-error=true`) while image build/push remains gating; `needs: [security,lint,build,test,docker-verify]` (NOT docs-check) | Yes (on main push) |
 | `ci-success` | `if: always()`; re-checks each result; enforces `docker-publish` only on main-push | Final gate |
 
 ### `release.yml` (tag push `*` or manual dispatch with `tag` input)
@@ -202,12 +202,15 @@ GoReleaser's `dockers_v2` publishes GHCR `{{.Tag}}`, `{{.Version}}`, **`latest`*
 prefix and strictly validates `vMAJOR.MINOR.PATCH[-prerelease]` (on tag-push it
 passes `github.ref_name` through), exposing `steps.tag.outputs.tag`. On
 `workflow_dispatch` it then runs `scripts/bump_version.sh <tag>` to patch the
-version (commits to `main` and pushes), tags that commit, and pushes the tag — all
-git pushes use a token-in-URL (`https://x-access-token:$GITHUB_TOKEN@…`) because
-checkout keeps `persist-credentials: false`. `GITHUB_TOKEN` pushes don't re-trigger
-workflows, so there's no double release. `--version` reads
-`config.AppConfig.BotVersion` (patched by the bump script; currently `"2.19.6"`),
-with a hard-coded local fallback `version = "v2.19.6"` in `main.go` (used only when
+version from current `origin/main`, commits, and pushes it. If `main` advances
+during the bump, the workflow fetches, rebases, and retries up to three times
+without force-pushing; a conflict fails safely. It then tags that commit and
+pushes the tag — all git pushes use a token-in-URL
+(`https://x-access-token:$GITHUB_TOKEN@…`) because checkout keeps
+`persist-credentials: false`. `GITHUB_TOKEN` pushes don't re-trigger workflows,
+so there's no double release. `--version` reads `config.AppConfig.BotVersion`
+(patched by the bump script; currently `"2.19.7"`), with a hard-coded local
+fallback `version = "v2.19.7"` in `main.go` (used only when
 config didn't load). There are **no** `-X main.version/commit/date` ldflags anymore
 (they were no-ops — `package main` declares no such vars). ⚠️ After the bump step,
 `goreleaser` runs a **"Verify BotVersion matches tag"** gate that `grep`s **both**
@@ -367,12 +370,14 @@ uses `RegisterLegacyModule`.
   case-insensitively. Never `strings.Split` raw data. The module wrapper
   `encodeCallbackData` returns `""` on overflow (broken button) — for user-supplied
   values use the **token pattern** (store payload in Redis, put a short hex token
-  in the callback; see filters/notes overwrite flows). `EncodeOrFallback` emits a
-  legacy dot-notation string when encoding overflows; legacy dot-notation is still
-  decoded for backward compat.
+  in the callback; see filters/notes overwrite flows). Decoding is strict:
+  deprecated dot-notation callbacks are intentionally rejected.
 - **`callbackQueryFromContext(ctx)`** is the nil-safe guard at the top of every
   callback handler (duplicated verbatim in `chat_status` because Go can't share
-  unexported helpers). Always nil-check `query.Message`.
+  unexported helpers). Always nil-check `query.Message`. gotgbot unmarshals an
+  accessible `CallbackQuery.Message` as a `gotgbot.Message` value, not a pointer;
+  use its interface methods to edit/delete and `ctx.EffectiveMessage` to read
+  concrete message fields rather than asserting `*gotgbot.Message`.
 - **Anonymous-admin flow**: on a `GroupAnonymousBot` sender, `chat_status.checkAnonAdmin`
   either bypasses (if the chat's `AnonAdmin` DB setting is on) or caches the
   original message (`alita:anonAdmin:<chat>:<msg>`, **20s TTL**) and shows a "prove
@@ -800,8 +805,8 @@ and `env:` struct tags are decorative — `ValidateConfig` is hand-written):
   `DROP_PENDING_UPDATES`, `ENABLE_PPROF`, `METRICS_AUTH_TOKEN`, `DEBUG`.
 - `OTEL_*` (service name, sample rate, OTLP endpoint, console/insecure) are read via
   raw `os.Getenv`, not config, and are intentionally not in `sample.env`.
-- `BotVersion` lives in `config.go` (currently `"2.19.6"`), mirrored by a CLI
-  fallback `version = "v2.19.6"` in `main.go`. **Don't hand-edit it** —
+- `BotVersion` lives in `config.go` (currently `"2.19.7"`), mirrored by a CLI
+  fallback `version = "v2.19.7"` in `main.go`. **Don't hand-edit it** —
   `scripts/bump_version.sh <vX.Y.Z>` patches both, and the release workflow runs it
   automatically on `workflow_dispatch`; the `goreleaser` job then re-greps both files
   and fails on mismatch. For a manual tag-push release, run the script (or

--- a/alita/modules/bans.go
+++ b/alita/modules/bans.go
@@ -1012,21 +1012,17 @@ func (moduleStruct) unrestrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) er
 		helpText = fmt.Sprintf(temp, formatting.MentionHtml(user.Id, user.FirstName))
 	}
 
-	// type assertion to get the message
-	_updatedMsg, ok := msg.(*gotgbot.Message)
-	if !ok || _updatedMsg == nil {
-		log.Warn("[Bans] Could not cast message for strikethrough formatting")
-		return ext.EndGroups
+	updatedText := ""
+	if ctx.EffectiveMessage != nil {
+		updatedText = ctx.EffectiveMessage.Text
 	}
-
-	// only strikethrough if msg.Text is non-empty
-	if _updatedMsg.Text != "" {
-		_updatedMsg.Text = fmt.Sprint("<s>", _updatedMsg.Text, "</s>", "\n\n")
+	if updatedText != "" {
+		updatedText = "<s>" + updatedText + "</s>\n\n"
 	}
 
 	_, _, err = msg.EditText(
 		b,
-		fmt.Sprint(_updatedMsg.Text, helpText),
+		updatedText+helpText,
 		&gotgbot.EditMessageTextOpts{
 			ParseMode: formatting.HTML,
 		},

--- a/alita/modules/bans_command_test.go
+++ b/alita/modules/bans_command_test.go
@@ -687,8 +687,8 @@ func TestRestrictCallbacksRejectMalformedAndNonAdminUsers(t *testing.T) {
 	if calls := client.callsFor("restrictChatMember"); len(calls) != 0 {
 		t.Fatalf("restrictChatMember calls = %d, want none for rejected callbacks", len(calls))
 	}
-	if calls := client.callsFor("answerCallbackQuery"); len(calls) != 2 {
-		t.Fatalf("answerCallbackQuery calls = %d, want malformed callback answers", len(calls))
+	if calls := client.callsFor("answerCallbackQuery"); len(calls) != 3 {
+		t.Fatalf("answerCallbackQuery calls = %d, want malformed and non-admin callback answers", len(calls))
 	}
 }
 

--- a/alita/modules/test_harness_test.go
+++ b/alita/modules/test_harness_test.go
@@ -187,10 +187,11 @@ func newModuleCallbackContext(
 		From:      &from,
 		Text:      "callback source",
 	}
+	// Match gotgbot's JSON decoder, which stores Message as a value.
 	query := &gotgbot.CallbackQuery{
 		Id:           "callback-1",
 		From:         from,
-		Message:      msg,
+		Message:      *msg,
 		Data:         data,
 		ChatInstance: "test-chat-instance",
 	}


### PR DESCRIPTION
## Summary

- fix Unmute and Unban callbacks by handling gotgbot's production message shape
- make manual releases sync with current `main` and safely retry non-fast-forward pushes
- keep Docker image publishing gating while making optional GHA cache export best-effort
- document the load-bearing callback and workflow behavior

## Root causes

- gotgbot unmarshals `CallbackQuery.Message` as a `gotgbot.Message` value, but the unrestrict handler asserted `*gotgbot.Message` and returned before editing or acknowledging the callback
- a manual release committed from the workflow's stale event SHA, so a concurrent `main` update caused its version push to be rejected
- Docker images were successfully published, but a transient BuildKit GHA cache export error failed the entire publish job

## Validation

- `go test -tags testtools -count=1 ./alita/modules`
- focused moderation callback regression tests
- `make lint`
- `make check-duplicates`
- `actionlint` and YAML parsing for both changed workflows
- `CGO_ENABLED=0 go build` and `--version` smoke test
- `make check-translations`
- `make check-docs`
- `go mod tidy -diff`, formatting, and `git diff --check`

No application configuration changes are required.