### PR TITLE
chore: add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "name": "Alita Robot",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "ports": [8080, 5432, 6379]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Idempotent repository bootstrap for the Alita Robot Cloud Agent environment.
+# Installs the system services (PostgreSQL, Redis), the pinned linter, and Go
+# module dependencies. Services themselves are started per-boot in start.sh.
+set -euo pipefail
+
+GOLANGCI_LINT_VERSION="v2.11.4" # keep in sync with .pre-commit-config.yaml / CI
+
+echo "==> [install] Installing system packages (PostgreSQL, Redis, tooling)"
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  postgresql \
+  postgresql-client \
+  redis-server \
+  ca-certificates \
+  perl \
+  git
+
+echo "==> [install] Installing golangci-lint ${GOLANGCI_LINT_VERSION}"
+if ! golangci-lint version 2>/dev/null | grep -q "${GOLANGCI_LINT_VERSION#v}"; then
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    | sudo sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
+fi
+
+echo "==> [install] Downloading Go modules"
+go mod download
+
+echo "==> [install] Warming the build cache (go build ./...)"
+go build ./...
+
+echo "==> [install] Done"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Per-boot startup for the Alita Robot Cloud Agent environment.
+# Starts PostgreSQL and Redis, ensures the application database exists, applies
+# SQL migrations (idempotent), and writes a local .env with local service
+# defaults. Secrets (BOT_TOKEN, OWNER_ID, MESSAGE_DUMP) are injected by Cursor
+# as environment variables and are NOT written here.
+set -euo pipefail
+
+DB_NAME="alita_robot"
+DB_USER="postgres"
+DB_PASSWORD="password"
+DB_PORT="5432"
+
+echo "==> [start] Starting PostgreSQL"
+PG_VER="$(ls /etc/postgresql 2>/dev/null | sort -V | tail -1 || true)"
+if [ -z "${PG_VER}" ]; then
+  echo "!! PostgreSQL is not installed; run .cursor/install.sh first" >&2
+  exit 1
+fi
+if ! sudo pg_ctlcluster "${PG_VER}" main status >/dev/null 2>&1; then
+  sudo pg_ctlcluster "${PG_VER}" main start
+fi
+# Wait for the server to accept connections.
+for _ in $(seq 1 30); do
+  if pg_isready -h localhost -p "${DB_PORT}" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "==> [start] Ensuring database role and database exist"
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c "ALTER USER ${DB_USER} PASSWORD '${DB_PASSWORD}';"
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+  sudo -u postgres createdb "${DB_NAME}"
+fi
+
+echo "==> [start] Starting Redis"
+if ! redis-cli ping >/dev/null 2>&1; then
+  sudo redis-server /etc/redis/redis.conf --daemonize yes
+  for _ in $(seq 1 15); do
+    if redis-cli ping >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+fi
+
+echo "==> [start] Applying database migrations (idempotent)"
+PSQL_DB_HOST=localhost \
+PSQL_DB_PORT="${DB_PORT}" \
+PSQL_DB_NAME="${DB_NAME}" \
+PSQL_DB_USER="${DB_USER}" \
+PSQL_DB_PASSWORD="${DB_PASSWORD}" \
+PSQL_DB_SSLMODE=disable \
+  bash scripts/migrate_psql.sh
+
+echo "==> [start] Writing local .env with service defaults (if missing)"
+if [ ! -f .env ]; then
+  cat > .env <<EOF
+# Local development defaults written by .cursor/start.sh.
+# Real secrets (BOT_TOKEN, OWNER_ID, MESSAGE_DUMP) come from Cursor-injected env
+# vars, which take precedence over these values (godotenv does not override).
+DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}?sslmode=disable
+REDIS_ADDRESS=localhost:6379
+REDIS_DB=1
+HTTP_PORT=8080
+AUTO_MIGRATE=false
+DEBUG=true
+DROP_PENDING_UPDATES=true
+ENABLED_LOCALES=en
+EOF
+fi
+
+echo "==> [start] Ready. Postgres + Redis are up and migrations are applied."
+echo "    Run the bot with: make run   (requires BOT_TOKEN/OWNER_ID/MESSAGE_DUMP secrets)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a repository-managed Cloud Agent development environment so agents (and contributors using Cursor Cloud) get a working PostgreSQL + Redis + Go toolchain out of the box. There was previously no `.cursor/environment.json`, so Cloud Agents started with no database, no cache, and no linter.

New files under `.cursor/`:
- `environment.json` — points `install`/`start` at the scripts below and exposes ports `8080` (HTTP), `5432` (Postgres), `6379` (Redis).
- `install.sh` — idempotent bootstrap: installs PostgreSQL, Redis, and the pinned `golangci-lint v2.11.4` (matching CI / pre-commit), runs `go mod download`, and warms the build cache with `go build ./...`.
- `start.sh` — per-boot: starts Postgres + Redis, ensures the `alita_robot` role/database exist, applies the SQL migrations via `scripts/migrate_psql.sh` (idempotent), and writes a gitignored local `.env` with local service defaults. Secrets (`BOT_TOKEN`, `OWNER_ID`, `MESSAGE_DUMP`) are expected from Cursor-injected env vars and are never written to disk.

## Type of Change

- [x] Other (developer environment / tooling)

## Testing Done

- [x] Unit tests
- [x] Tested in development environment
- [x] Manual testing

### Test Results

Validated on this Cloud Agent VM (Ubuntu 24.04, Go 1.26):

- `install.sh` and `start.sh` both run cleanly and are idempotent (re-running `start.sh` reports `Applied: 0, Skipped: 36`).
- All 36 SQL migrations apply; database ends with 30 tables.
- `CGO_ENABLED=0 go build` succeeds; `./alita_robot --version` prints `v2.21.7`.
- `make test` (self-contained SQLite + miniredis, `-race`): all 54 packages pass, total coverage **78.6%** (above the 78% gate).
- The bot boots against local Postgres + Redis — config validates, Postgres connects, Redis cache initializes, 8 locales load — reaching the Telegram bot-init step (which requires a real `BOT_TOKEN` secret).

A draft environment build was triggered from this branch to validate `install.sh` on a fresh pod.

## Additional Context

- The bot's live Telegram connection requires `BOT_TOKEN`, `OWNER_ID`, and `MESSAGE_DUMP` to be added as Cursor secrets; everything else runs locally.
- Uses the default Cursor base image (Ubuntu 24.04 + Go 1.26) rather than a custom Dockerfile, so no build pipeline is required for just-in-time provisioning.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51af34e3-610e-40d7-bb8a-cacea12800be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51af34e3-610e-40d7-bb8a-cacea12800be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

