### PR TITLE
fix: stop in-process cache growth and antiflood goroutine pile-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,8 +577,10 @@ m != nil`) — every helper bails when it's nil.
   Telegram admin lists with an O(1) `UserMap` + linear fallback; negative results
   (bot-not-admin or an empty admin list) are cached with `Cached:true` to avoid
   retry storms; `LoadAdminCache` stores the result before returning so later
-  invalidation cannot be undone by a stale background write. Two paths
-  invalidate the key (`InvalidateAdminCache` + a raw delete in `admin.go`).
+  invalidation cannot be undone by a stale background write. Concurrent callers
+  for the same chat share one in-flight Telegram fetch via `singleflight` — do
+  not drop that coalescing or a cache miss will stampede `getChatAdministrators`.
+  Two paths invalidate the key (`InvalidateAdminCache` + a raw delete in `admin.go`).
 - **Restricted-chat cache** (`restrictedCache.go`, `alita:restricted:<chat>`, 30-min):
   tracks chats where the bot can't send; 5-min probe window with a Redis `SETNX`
   single-flight (`alita:restricted_probe:<chat>`). Fails **open** (returns false) on
@@ -622,9 +624,15 @@ m != nil`) — every helper bails when it's nil.
 
 - **Antiflood** (`antiflood.go`, group 4): per-user count via a per-key `*sync.Mutex`
   (`floodMu`) + `syncHelperMap`, both cleaned together every 5 min. `/setflood`
-  accepts `off`/`0` (disable) or `3..100`. Admin check **fails open** on timeout/
-  semaphore-full (banning a real admin is worse than missing a flood). Mute/ban
-  inline buttons reuse the `unrestrict` callback namespace handled in `bans.go`.
+  accepts `off`/`0` (disable) or `3..100`. A warm admin cache (including negative
+  lookups) is trusted so non-admins do not take a semaphore slot or spawn
+  `IsUserAdmin` per message. Cache-miss admin checks **fail open** on timeout/
+  semaphore-full (banning a real admin is worse than missing a flood) and the
+  semaphore is released **before** flood tracking or mute/ban/delete — holding it
+  across punishment lets 50 slow Telegram calls starve later messages. Cleanup
+  recovers per tick so a panic cannot disable `syncHelperMap`/`floodMu` eviction.
+  Mute/ban inline buttons reuse the `unrestrict` callback namespace handled in
+  `bans.go`.
 - **Antiraid** (`antiraid.go`, group -5): **Redis-only** live state
   (`alita:antiraid:state:<chat>`, TTL covering the requested expiry) + a join
   sorted-set that expires after its 60s counting window; enable/disable/duration/
@@ -667,8 +675,10 @@ m != nil`) — every helper bails when it's nil.
 ## 13. Content modules (concise)
 
 - **Filters/Blacklists** use Aho-Corasick (`keyword_matcher`) with **separate named
-  caches** (`GetNamedCache("filters")` / `"blacklists")`) so they never evict each
-  other — do not revert to the shared global cache. Watchers use `FirstMatch`.
+  caches** (`GetNamedCache("filters")` / `"blacklists"`) so they never evict each
+  other — do not revert to the shared global cache. Each named cache's cleanup
+  ticker recovers per tick so a panic cannot disable matcher eviction. Watchers
+  use `FirstMatch`.
   Search text is built by `buildModerationMatchText`
   (text + caption + URL entities from **both** `Entities` and `CaptionEntities`);
   raw Telegram entity offsets are UTF-16 code units, so slice them through
@@ -693,7 +703,10 @@ m != nil`) — every helper bails when it's nil.
 - **Reactions** accept only Telegram's documented built-in reaction emoji; keyword
   and emoji values are HTML-escaped in replies. `FormattingReplacer` recognizes
   `{rules[:up|same]}` only in the stored template, never in user-substituted text,
-  and removes the directive when no rules exist.
+  and removes the directive when no rules exist. `{count}` is served from
+  `cachedMemberCount` (`formatting.go`), a process-local `sync.Map` with a 60s TTL;
+  expired entries are deleted on read and via `time.AfterFunc` — do not store
+  unbounded chat IDs there without eviction.
 - **Media** (`utils/media`): `Send` dispatches on `MsgType` (TEXT=1…VIDEO_NOTE=8;
   0/unknown → text; empty `FileID` → text fallback), short-circuits on
   `IsChatRestricted`, and marks chats restricted on permission errors. `SendNote`/

--- a/alita/db/monitoring/metrics.go
+++ b/alita/db/monitoring/metrics.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 )
 
 // ErrDatabaseNotInitialized is returned when database operations are attempted
@@ -42,6 +43,7 @@ func StartMonitoring(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	go func() {
 		defer ticker.Stop()
+		defer error_handling.RecoverFromPanic("DBMonitoring", "metrics")
 
 		for {
 			select {
@@ -49,8 +51,11 @@ func StartMonitoring(ctx context.Context, interval time.Duration) {
 				log.Info("[DBMonitoring] Stopping database monitoring")
 				return
 			case <-ticker.C:
-				metrics := collectMetrics(sqlDB)
-				logMetrics(metrics)
+				func() {
+					defer error_handling.RecoverFromPanic("DBMonitoringTick", "metrics")
+					metrics := collectMetrics(sqlDB)
+					logMetrics(metrics)
+				}()
 			}
 		}
 	}()

--- a/alita/modules/antiflood.go
+++ b/alita/modules/antiflood.go
@@ -128,11 +128,82 @@ func (a *antifloodStruct) cleanupLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			a.cleanupOnce(time.Now().Unix())
+			func() {
+				defer error_handling.RecoverFromPanic("cleanupOnce", "antiflood")
+				a.cleanupOnce(time.Now().Unix())
+			}()
 		case <-ctx.Done():
 			log.Info("Antiflood cleanup goroutine shutting down gracefully")
 			return
 		}
+	}
+}
+
+// cachedAdminStatus reports whether a warm admin cache already knows this user.
+// known=false means the cache missed and the caller must ask Telegram.
+func cachedAdminStatus(chatId, userId int64) (known bool, isAdmin bool) {
+	ok, cached := cache.GetAdminCacheList(chatId)
+	if !ok || !cached.Cached {
+		return false, false
+	}
+	if cached.UserMap != nil {
+		_, isAdmin = cached.UserMap[userId]
+		return true, isAdmin
+	}
+	for i := range cached.UserInfo {
+		if cached.UserInfo[i].User.Id == userId {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// userIsFloodExempt is true when the sender should skip flood tracking.
+// A warm admin cache (including negative lookups) is trusted so non-admins do
+// not take a semaphore slot or spawn an IsUserAdmin goroutine per message.
+// Cache misses use a bounded Telegram check; timeout and a full semaphore
+// fail open. The semaphore is released before flood tracking or punishment.
+func (a *antifloodStruct) userIsFloodExempt(b *gotgbot.Bot, chatId, userId int64) bool {
+	if known, isAdmin := cachedAdminStatus(chatId, userId); known {
+		return isAdmin
+	}
+	return a.adminCheckWithTimeout(b, chatId, userId)
+}
+
+func (a *antifloodStruct) adminCheckWithTimeout(b *gotgbot.Bot, chatId, userId int64) bool {
+	select {
+	case a.adminCheckSemaphore <- struct{}{}:
+		defer func() { <-a.adminCheckSemaphore }()
+	default:
+		log.WithFields(log.Fields{
+			"chatId": chatId,
+			"userId": userId,
+		}).Warn("Admin check semaphore full - assuming admin to prevent false positives")
+		return true
+	}
+
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result := make(chan bool, 1)
+	go func() {
+		defer error_handling.RecoverFromPanic("adminCheck", "antiflood")
+		isAdmin := chat_status.IsUserAdmin(b, chatId, userId)
+		select {
+		case result <- isAdmin:
+		case <-ctxTimeout.Done():
+		}
+	}()
+
+	select {
+	case isAdmin := <-result:
+		return isAdmin
+	case <-ctxTimeout.Done():
+		log.WithFields(log.Fields{
+			"chatId": chatId,
+			"userId": userId,
+		}).Warn("Admin check timed out, skipping flood check to prevent false positives")
+		return true
 	}
 }
 
@@ -230,77 +301,7 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	userId := user.Id()
 	chatId := chat.Id
 
-	if ok, cached := cache.GetAdminCacheList(chatId); ok && cached.Cached {
-		if _, ok := cached.UserMap[userId]; ok {
-			return ext.ContinueGroups
-		}
-	}
-
-	// Use semaphore to limit concurrent admin checks and add timeout
-	select {
-	case antifloodModule.adminCheckSemaphore <- struct{}{}:
-		// Got semaphore, proceed with admin check
-		defer func() { <-antifloodModule.adminCheckSemaphore }()
-
-		// Create context with timeout for admin check
-		ctx_timeout, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		defer cancel()
-
-		// Check if user is admin with timeout and proper goroutine cleanup
-		isAdmin := make(chan bool, 1)
-		done := make(chan struct{})
-
-		go func() {
-			defer func() {
-				close(done) // Signal completion to prevent goroutine leak
-			}()
-			defer error_handling.RecoverFromPanic("adminCheck", "antiflood")
-
-			select {
-			case isAdmin <- chat_status.IsUserAdmin(b, chatId, userId):
-				// Successfully sent result
-			case <-ctx_timeout.Done():
-				// Context cancelled, exit goroutine early
-				return
-			}
-		}()
-
-		select {
-		case admin := <-isAdmin:
-			if admin {
-				// Admins are exempt from flood tracking
-				return ext.ContinueGroups
-			}
-		case <-ctx_timeout.Done():
-			// Admin check timed out, fail open to prevent false positives
-			// It's better to occasionally miss a flood from an admin than to ban actual admins on timeout
-			log.WithFields(log.Fields{
-				"chatId": chatId,
-				"userId": userId,
-			}).Warn("Admin check timed out, skipping flood check to prevent false positives")
-
-			// Wait for goroutine cleanup with timeout to prevent indefinite blocking
-			select {
-			case <-done:
-				// Goroutine completed cleanly
-			case <-time.After(1 * time.Second):
-				// Log if goroutine takes too long to cleanup
-				log.WithFields(log.Fields{
-					"chatId": chatId,
-					"userId": userId,
-				}).Warn("Admin check goroutine cleanup timeout")
-			}
-
-			// Skip flood check on timeout - fail open like semaphore full case
-			return ext.ContinueGroups
-		}
-	default:
-		// CRITICAL FIX: Semaphore full - fail open to prevent false positives
-		// It's better to occasionally miss a flood from an admin than to ban actual admins under load
-		log.WithFields(log.Fields{
-			"chatId": chatId,
-			"userId": userId,
-		}).Warn("Admin check semaphore full - assuming admin to prevent false positives")
+	if antifloodModule.userIsFloodExempt(b, chatId, userId) {
 		return ext.ContinueGroups
 	}
 
@@ -359,6 +360,7 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 				go func(messageId int64) {
 					defer wg.Done()
 					defer func() { <-sem }()
+					defer error_handling.RecoverFromPanic("floodMsgDelete", "antiflood")
 
 					err := helpers.DeleteMessageWithErrorHandling(b, chatId, messageId)
 					recordError(err, messageId)

--- a/alita/modules/antiflood_command_test.go
+++ b/alita/modules/antiflood_command_test.go
@@ -287,6 +287,46 @@ func TestAntifloodWatcherFailsOpenWhenAdminSemaphoreFull(t *testing.T) {
 	}
 }
 
+func TestAntifloodWatcherTrustsCachedNonAdminWithoutSemaphore(t *testing.T) {
+	resetAntifloodState(t)
+	client := newModuleBotClient()
+	bot := newModuleTestBot(client)
+	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Flood Chat"}
+	member := gotgbot.User{Id: 46, FirstName: "Flooder"}
+	seedCallbackAdmins(t, chat.Id, gotgbot.MergedChatMember{
+		Status: "administrator",
+		User:   gotgbot.User{Id: 999, IsBot: true, FirstName: "Alita"},
+	})
+	if err := antiflood.SetFlood(chat.Id, 1); err != nil {
+		t.Fatalf("SetFlood() error = %v", err)
+	}
+	if err := antiflood.SetFloodMode(chat.Id, "ban"); err != nil {
+		t.Fatalf("SetFloodMode() error = %v", err)
+	}
+
+	for i := 0; i < maxConcurrentAdminChecks; i++ {
+		antifloodModule.adminCheckSemaphore <- struct{}{}
+	}
+	t.Cleanup(func() {
+		for i := 0; i < maxConcurrentAdminChecks; i++ {
+			<-antifloodModule.adminCheckSemaphore
+		}
+	})
+
+	firstCtx := newModuleMessageContext(bot, chat, member, "one")
+	if err := antifloodModule.checkFlood(bot, firstCtx); err != ext.ContinueGroups {
+		t.Fatalf("checkFlood first error = %v, want ContinueGroups", err)
+	}
+	secondCtx := newModuleMessageContext(bot, chat, member, "two")
+	secondCtx.EffectiveMessage.MessageId = 202
+	if err := antifloodModule.checkFlood(bot, secondCtx); err != ext.ContinueGroups {
+		t.Fatalf("checkFlood second error = %v, want ContinueGroups", err)
+	}
+	if calls := client.callsFor("banChatMember"); len(calls) != 1 {
+		t.Fatalf("banChatMember calls = %d, want punishment despite full semaphore", len(calls))
+	}
+}
+
 func TestAntifloodWatcherSkipsUntargetableMessages(t *testing.T) {
 	resetAntifloodState(t)
 	client := newModuleBotClient()

--- a/alita/modules/antiflood_command_test.go
+++ b/alita/modules/antiflood_command_test.go
@@ -294,8 +294,9 @@ func TestAntifloodWatcherTrustsCachedNonAdminWithoutSemaphore(t *testing.T) {
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Flood Chat"}
 	member := gotgbot.User{Id: 46, FirstName: "Flooder"}
 	seedCallbackAdmins(t, chat.Id, gotgbot.MergedChatMember{
-		Status: "administrator",
-		User:   gotgbot.User{Id: 999, IsBot: true, FirstName: "Alita"},
+		Status:             "administrator",
+		User:               gotgbot.User{Id: 999, IsBot: true, FirstName: "Alita"},
+		CanRestrictMembers: true,
 	})
 	if err := antiflood.SetFlood(chat.Id, 1); err != nil {
 		t.Fatalf("SetFlood() error = %v", err)

--- a/alita/modules/backup.go
+++ b/alita/modules/backup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db/lang"
 	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 	"github.com/divkix/Alita_Robot/alita/utils/ratelimit"
@@ -178,10 +179,14 @@ func cleanupExpiredPending() {
 
 func startPendingCleanupTicker() {
 	go func() {
+		defer error_handling.RecoverFromPanic("pendingBackupCleanup", "backup")
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
 		for range ticker.C {
-			cleanupExpiredPending()
+			func() {
+				defer error_handling.RecoverFromPanic("pendingBackupCleanupTick", "backup")
+				cleanupExpiredPending()
+			}()
 		}
 	}()
 }

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -893,7 +893,8 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 
 				go func(member gotgbot.User) {
 					defer wg.Done()
-					defer func() { <-sem }() // Release semaphore
+					defer func() { <-sem }()
+					defer error_handling.RecoverFromPanic("processNewMember", "Greetings") // Release semaphore
 
 					// Local chat copy per goroutine so we don't share pointer
 					chatCopy := chatCopyBase

--- a/alita/modules/purges.go
+++ b/alita/modules/purges.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/divkix/Alita_Robot/alita/db/lang"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 
@@ -217,6 +218,7 @@ func (m moduleStruct) purge(bot *gotgbot.Bot, ctx *ext.Context) error {
 			} else {
 				// Delete notification message after 3 seconds in background
 				go func(msgToDelete *gotgbot.Message) {
+					defer error_handling.RecoverFromPanic("purgeNotifyDelete", "purges")
 					time.Sleep(3 * time.Second)
 					_, _ = msgToDelete.Delete(bot, nil)
 				}(pMsg)
@@ -377,6 +379,7 @@ func (moduleStruct) purgeFrom(bot *gotgbot.Bot, ctx *ext.Context) error {
 
 		// Run cleanup in background goroutine to avoid blocking the handler
 		go func(chatId, toDelId int64, msgToDelete *gotgbot.Message) {
+			defer error_handling.RecoverFromPanic("purgeFromCleanup", "purges")
 			time.Sleep(30 * time.Second)
 			// Only clean up if the stored ID is still the same (not overwritten by another purgefrom)
 			if existingId, ok := delMsgs.Load(chatId); ok {
@@ -489,6 +492,7 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 			} else {
 				// Delete notification message after 3 seconds in background
 				go func(msgToDelete *gotgbot.Message) {
+					defer error_handling.RecoverFromPanic("purgeNotifyDelete", "purges")
 					time.Sleep(3 * time.Second)
 					_, _ = msgToDelete.Delete(bot, nil)
 				}(pMsg)

--- a/alita/utils/cache/adminCache.go
+++ b/alita/utils/cache/adminCache.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/eko/gocache/lib/v4/store"
@@ -13,19 +14,30 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/constants"
 )
 
-// LoadAdminCache retrieves and caches the list of administrators for a given chat.
-// It fetches the current administrators from Telegram API and stores them in cache
-// with a 30-minute expiration. Returns an AdminCache struct containing the admin list.
+var adminCacheGroup singleflight.Group
+
 func adminCacheKey(chatId int64) string {
 	return fmt.Sprintf("alita:adminCache:%d", chatId)
 }
 
+// LoadAdminCache retrieves and caches the list of administrators for a given chat.
+// It fetches the current administrators from Telegram API and stores them in cache
+// with a 30-minute expiration. Returns an AdminCache struct containing the admin list.
+// Concurrent callers for the same chat share one in-flight Telegram fetch.
 func LoadAdminCache(b *gotgbot.Bot, chatId int64) AdminCache {
 	if b == nil {
 		log.Error("LoadAdminCache: bot is nil")
 		return AdminCache{}
 	}
 
+	v, _, _ := adminCacheGroup.Do(adminCacheKey(chatId), func() (any, error) {
+		return loadAdminCacheFromTelegram(b, chatId), nil
+	})
+	ac, _ := v.(AdminCache)
+	return ac
+}
+
+func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 	const negativeAdminCacheTTL = 2 * time.Minute
 	const botStatusErrorAdminCacheTTL = 30 * time.Second
 

--- a/alita/utils/cache/adminCache_test.go
+++ b/alita/utils/cache/adminCache_test.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
@@ -122,5 +125,81 @@ func TestLoadAdminCacheHandlesNilBotNonAdminBotAndEmptyAdminList(t *testing.T) {
 	}
 	if found, _ := GetAdminCacheList(-100125); !found {
 		t.Fatal("LoadAdminCache did not store the empty admin-list result")
+	}
+}
+
+type delayedAdminCacheClient struct {
+	inner            *adminCacheBotClient
+	adminListStarted chan struct{}
+	releaseAdminList chan struct{}
+	adminListCalls   atomic.Int32
+}
+
+func (c *delayedAdminCacheClient) RequestWithContext(ctx context.Context, token, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+	if method == "getChatAdministrators" {
+		if c.adminListCalls.Add(1) == 1 {
+			close(c.adminListStarted)
+			<-c.releaseAdminList
+		}
+	}
+	return c.inner.RequestWithContext(ctx, token, method, params, opts)
+}
+
+func (c *delayedAdminCacheClient) GetAPIURL(opts *gotgbot.RequestOpts) string {
+	return c.inner.GetAPIURL(opts)
+}
+
+func (c *delayedAdminCacheClient) FileURL(token, path string, opts *gotgbot.RequestOpts) string {
+	return c.inner.FileURL(token, path, opts)
+}
+
+func TestLoadAdminCacheCoalescesConcurrentFetches(t *testing.T) {
+	withMemoryMarshaler(t)
+
+	inner := &adminCacheBotClient{responses: map[string]json.RawMessage{
+		"getChatMember:999": json.RawMessage(
+			`{"status":"administrator","user":{"id":999,"is_bot":true,"first_name":"Alita"}}`,
+		),
+		"getChatAdministrators": json.RawMessage(
+			`[{"status":"administrator","user":{"id":999,"is_bot":true,"first_name":"Alita"}}]`,
+		),
+	}}
+	client := &delayedAdminCacheClient{
+		inner:            inner,
+		adminListStarted: make(chan struct{}),
+		releaseAdminList: make(chan struct{}),
+	}
+	bot := &gotgbot.Bot{
+		Token:     "999:test",
+		BotClient: client,
+		User: gotgbot.User{
+			Id:       999,
+			IsBot:    true,
+			Username: "AlitaTestBot",
+		},
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			got := LoadAdminCache(bot, -100777)
+			if !got.Cached || len(got.UserInfo) != 1 {
+				t.Errorf("LoadAdminCache() = %+v, want cached admin list", got)
+			}
+		}()
+	}
+	close(start)
+	<-client.adminListStarted
+	time.Sleep(50 * time.Millisecond)
+	close(client.releaseAdminList)
+	wg.Wait()
+
+	if got := client.adminListCalls.Load(); got != 1 {
+		t.Fatalf("getChatAdministrators calls = %d, want 1 coalesced fetch", got)
 	}
 }

--- a/alita/utils/formatting/formatting.go
+++ b/alita/utils/formatting/formatting.go
@@ -53,21 +53,37 @@ type memberCountEntry struct {
 	at    time.Time
 }
 
-var memberCountCache sync.Map // map[int64]memberCountEntry
+const defaultMemberCountCacheTTL = 60 * time.Second
 
-// cachedMemberCount returns member count with 60s TTL per chat to avoid API call per message.
+var (
+	memberCountCache    sync.Map // map[int64]memberCountEntry
+	memberCountCacheTTL = defaultMemberCountCacheTTL
+)
+
+// cachedMemberCount returns member count with a short TTL per chat to avoid an
+// API call per message. Expired entries are deleted on read and via AfterFunc
+// so idle chats cannot accumulate forever.
 func cachedMemberCount(b *gotgbot.Bot, chat *gotgbot.Chat) string {
 	if v, ok := memberCountCache.Load(chat.Id); ok {
-		if e, ok := v.(memberCountEntry); ok && time.Since(e.at) < 60*time.Second {
+		if e, ok := v.(memberCountEntry); ok && time.Since(e.at) < memberCountCacheTTL {
 			return strconv.Itoa(e.count)
 		}
+		memberCountCache.Delete(chat.Id)
 	}
 	count, err := chat.GetMemberCount(b, nil)
 	if err != nil {
 		return "0"
 	}
-	memberCountCache.Store(chat.Id, memberCountEntry{count: int(count), at: time.Now()})
+	entry := memberCountEntry{count: int(count), at: time.Now()}
+	memberCountCache.Store(chat.Id, entry)
+	expireMemberCount(chat.Id, entry)
 	return strconv.Itoa(int(count))
+}
+
+func expireMemberCount(chatID int64, entry memberCountEntry) {
+	time.AfterFunc(memberCountCacheTTL, func() {
+		memberCountCache.CompareAndDelete(chatID, entry)
+	})
 }
 
 // Shtml returns SendMessageOpts configured with HTML parse mode, disabled link preview,

--- a/alita/utils/formatting/formatting_test.go
+++ b/alita/utils/formatting/formatting_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"gorm.io/driver/sqlite"
@@ -317,4 +318,74 @@ func TestGetFullName(t *testing.T) {
 			t.Fatalf("expected 'Alice', got %q", name)
 		}
 	})
+}
+
+func clearMemberCountCache() {
+	memberCountCache.Range(func(key, _ any) bool {
+		memberCountCache.Delete(key)
+		return true
+	})
+}
+
+func TestCachedMemberCountEvictsExpiredEntries(t *testing.T) {
+	clearMemberCountCache()
+	oldTTL := memberCountCacheTTL
+	memberCountCacheTTL = 15 * time.Millisecond
+	t.Cleanup(func() {
+		memberCountCacheTTL = oldTTL
+		clearMemberCountCache()
+	})
+
+	bot := &gotgbot.Bot{
+		Token:     "123:test",
+		BotClient: formattingBotClient{},
+		User:      gotgbot.User{Id: 123, IsBot: true, Username: "FormatBot"},
+	}
+	chat := &gotgbot.Chat{Id: -100999001, Type: "supergroup", Title: "Count Chat"}
+
+	if got := cachedMemberCount(bot, chat); got != "42" {
+		t.Fatalf("cachedMemberCount() = %q, want 42", got)
+	}
+	if _, ok := memberCountCache.Load(chat.Id); !ok {
+		t.Fatal("fresh member count was not stored")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := memberCountCache.Load(chat.Id); !ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("expired member count cache entry was not evicted")
+}
+
+func TestCachedMemberCountReplacesStaleEntryOnRead(t *testing.T) {
+	clearMemberCountCache()
+	t.Cleanup(clearMemberCountCache)
+
+	chatID := int64(-100999002)
+	memberCountCache.Store(chatID, memberCountEntry{
+		count: 1,
+		at:    time.Now().Add(-time.Hour),
+	})
+
+	bot := &gotgbot.Bot{
+		Token:     "123:test",
+		BotClient: formattingBotClient{},
+		User:      gotgbot.User{Id: 123, IsBot: true, Username: "FormatBot"},
+	}
+	chat := &gotgbot.Chat{Id: chatID, Type: "supergroup", Title: "Count Chat"}
+
+	if got := cachedMemberCount(bot, chat); got != "42" {
+		t.Fatalf("cachedMemberCount() = %q, want refreshed 42", got)
+	}
+	v, ok := memberCountCache.Load(chatID)
+	if !ok {
+		t.Fatal("refreshed member count was not stored")
+	}
+	entry, ok := v.(memberCountEntry)
+	if !ok || entry.count != 42 {
+		t.Fatalf("stored entry = %#v, want count 42", v)
+	}
 }

--- a/alita/utils/httpserver/server.go
+++ b/alita/utils/httpserver/server.go
@@ -416,10 +416,12 @@ func (s *Server) Start() error {
 	}()
 
 	// Wait briefly to catch immediate startup errors (e.g., port conflicts)
+	startupTimer := time.NewTimer(100 * time.Millisecond)
+	defer startupTimer.Stop()
 	select {
 	case err := <-errChan:
 		return fmt.Errorf("failed to start HTTP server: %w", err)
-	case <-time.After(100 * time.Millisecond):
+	case <-startupTimer.C:
 		return nil
 	}
 }

--- a/alita/utils/keyword_matcher/cache.go
+++ b/alita/utils/keyword_matcher/cache.go
@@ -152,7 +152,10 @@ func GetNamedCache(name string) *Cache {
 		ticker := time.NewTicker(10 * time.Minute)
 		defer ticker.Stop()
 		for range ticker.C {
-			c.cleanupExpired()
+			func() {
+				defer error_handling.RecoverFromPanic("GetNamedCache.cleanupTick["+name+"]", "keyword_matcher")
+				c.cleanupExpired()
+			}()
 		}
 	}()
 

--- a/alita/utils/monitoring/activity_monitor.go
+++ b/alita/utils/monitoring/activity_monitor.go
@@ -97,7 +97,10 @@ func (am *ActivityMonitor) monitorLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			am.performActivityCheck()
+			func() {
+				defer error_handling.RecoverFromPanic("performActivityCheck", "ActivityMonitor")
+				am.performActivityCheck()
+			}()
 		case <-am.ctx.Done():
 			return
 		}

--- a/alita/utils/monitoring/auto_remediation.go
+++ b/alita/utils/monitoring/auto_remediation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/divkix/Alita_Robot/alita/config"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -148,7 +149,10 @@ func (m *AutoRemediationManager) monitorAndRemediate() {
 	for {
 		select {
 		case <-ticker.C:
-			m.checkAndRemediate()
+			func() {
+				defer error_handling.RecoverFromPanic("checkAndRemediate", "AutoRemediation")
+				m.checkAndRemediate()
+			}()
 		case <-m.ctx.Done():
 			return
 		}

--- a/alita/utils/monitoring/background_stats.go
+++ b/alita/utils/monitoring/background_stats.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/divkix/Alita_Robot/alita/db"
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
+	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -115,7 +116,10 @@ func (collector *BackgroundStatsCollector) systemStatsCollector() {
 	for {
 		select {
 		case <-ticker.C:
-			collector.collectSystemStats()
+			func() {
+				defer error_handling.RecoverFromPanic("collectSystemStats", "BackgroundStats")
+				collector.collectSystemStats()
+			}()
 		case <-collector.ctx.Done():
 			return
 		}
@@ -132,7 +136,10 @@ func (collector *BackgroundStatsCollector) databaseStatsCollector() {
 	for {
 		select {
 		case <-ticker.C:
-			collector.collectDatabaseStats()
+			func() {
+				defer error_handling.RecoverFromPanic("collectDatabaseStats", "BackgroundStats")
+				collector.collectDatabaseStats()
+			}()
 		case <-collector.ctx.Done():
 			return
 		}
@@ -224,7 +231,10 @@ func (collector *BackgroundStatsCollector) reportingWorker() {
 	for {
 		select {
 		case <-ticker.C:
-			collector.reportStats()
+			func() {
+				defer error_handling.RecoverFromPanic("reportStats", "BackgroundStats")
+				collector.reportStats()
+			}()
 		case <-collector.ctx.Done():
 			return
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes several long-running memory leaks and concurrency issues in the bot process:

- `{count}` member-count cache (`formatting.go`) never evicted expired chat entries, so the `sync.Map` grew without bound. Entries now expire on read and via `time.AfterFunc`.
- Antiflood held the admin-check semaphore across mute/ban/delete and re-ran `IsUserAdmin` for every non-admin message even when the admin cache was already warm. The semaphore is now released before flood tracking, and a warm cache (including negative lookups) is trusted.
- `LoadAdminCache` stampeded Telegram on a cache miss. Concurrent callers for the same chat now share one in-flight fetch via `singleflight`.
- Cleanup tickers (keyword matcher, backup pending state, antiflood, monitoring) recovered only at goroutine scope, so one panic permanently disabled eviction. They now recover per tick.
- Fire-and-forget goroutines in purges, greetings, and antiflood message deletion now recover from panics.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Dependency update

## Testing Done

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Tested in development environment
- [x] Other (please specify): `go test -race -tags testtools` on changed packages

### Test Results

All targeted packages passed, including `-race`:

- `alita/utils/formatting` (member-count eviction)
- `alita/utils/cache` (`LoadAdminCache` singleflight coalescing)
- `alita/modules` (antiflood cache-trust + semaphore tests)
- `alita/utils/keyword_matcher`, `alita/utils/monitoring`, `alita/db/monitoring`, `alita/utils/httpserver`, `internal/repo_checks`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context

- Related issue(s): none (sweep of leak/concurrency issues)
- Breaking changes (if any): none

## Release Notes

Long-running processes no longer retain expired `{count}` cache entries, and antiflood no longer occupies all admin-check slots during flood punishment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf007845-1b3f-43a9-a94a-a9e385f906fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf007845-1b3f-43a9-a94a-a9e385f906fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

