### PR TITLE
fix(help): keep HTML tags in module help instead of showing &lt;b&gt;

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -636,10 +636,10 @@ m != nil`) — every helper bails when it's nil.
   and must be converted with `formatting.ToTelegramHTML` (which uses
   `tgmd2html.MD2HTMLV2`). Newer module help (reactions, backup, approvals, antispam)
   and most status strings are already HTML — `ToTelegramHTML` keeps Telegram tags
-  (`<b>`, `<code>`, …) and only escapes leftover `<keyword>` placeholders. Some
-  short status strings are sent as HTML without conversion; whether to convert
-  depends on the specific key. Never run `MD2HTMLV2` on a concatenated
-  markdown-header + HTML-body string.
+  (`<b>`, `<code>`, …) when both an opener and closer are present, and only
+  escapes leftover `<keyword>` placeholders. Some short status strings are sent
+  as HTML without conversion; whether to convert depends on the specific key.
+  Never run `MD2HTMLV2` on a concatenated markdown-header + HTML-body string.
 - Adding a user-facing string: add the key to **all 7** locale files (en-only works
   via fallback but is silent English leakage). `%d` needs a real int.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,7 +352,9 @@ uses `RegisterLegacyModule`.
   `_help_msg` strings (reactions, backup, approvals, antispam) are already HTML,
   and that path escapes `<b>` into visible tags. Markdown bodies still convert
   through `MD2HTMLV2`; HTML bodies keep Telegram tags and escape leftover
-  placeholders like `<keyword>`.
+  placeholders like `<keyword>`. HTML is detected only when both an opening and
+  a closing Telegram tag are present, so a markdown code span like `` `</b>` ``
+  stays on the markdown path.
 - ⚠️ `moduleStruct` is passed **by value** to handler methods, so it must never
   embed a mutex/`sync.Map`. Temporary note/filter overwrite payloads live in
   Redis, outside the copied module value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,13 @@ uses `RegisterLegacyModule`.
   `GetAbleMap` / `ResetHelpRegistry`. Writes still happen during single-threaded
   startup — do not write it from a handler.
 - `helpableKb` keys are the **Title-cased** module name; per-module help text comes
-  from i18n key `<lowercase>_help_msg` rendered via `tgmd2html.MD2HTMLV2`.
+  from i18n key `<lowercase>_help_msg`. `getModuleHelpAndKb` converts the markdown
+  header (`helpers_module_help_header`) and the body **independently** via
+  `formatting.ToTelegramHTML`. Do **not** concatenate then run `MD2HTMLV2` — newer
+  `_help_msg` strings (reactions, backup, approvals, antispam) are already HTML,
+  and that path escapes `<b>` into visible tags. Markdown bodies still convert
+  through `MD2HTMLV2`; HTML bodies keep Telegram tags and escape leftover
+  placeholders like `<keyword>`.
 - ⚠️ `moduleStruct` is passed **by value** to handler methods, so it must never
   embed a mutex/`sync.Map`. Temporary note/filter overwrite payloads live in
   Redis, outside the copied module value.
@@ -624,9 +630,14 @@ m != nil`) — every helper bails when it's nil.
   `extractOrderedValues` (`first,second,…,question,answer,number,count,value,name,
   user,username,…`). If you use a `%verb` with a param name not in that list, the
   mapping is dropped/misordered — extend `commonKeys`.
-- **Parse mode**: locale strings are authored in Markdown but the bot sends HTML —
-  convert via `tgmd2html.MD2HTMLV2`. Some short status strings are already authored
-  in HTML; whether to convert depends on the specific key.
+- **Parse mode**: locale strings are mixed. Legacy `_help_msg` strings are Markdown
+  and must be converted with `formatting.ToTelegramHTML` (which uses
+  `tgmd2html.MD2HTMLV2`). Newer module help (reactions, backup, approvals, antispam)
+  and most status strings are already HTML — `ToTelegramHTML` keeps Telegram tags
+  (`<b>`, `<code>`, …) and only escapes leftover `<keyword>` placeholders. Some
+  short status strings are sent as HTML without conversion; whether to convert
+  depends on the specific key. Never run `MD2HTMLV2` on a concatenated
+  markdown-header + HTML-body string.
 - Adding a user-facing string: add the key to **all 7** locale files (en-only works
   via fallback but is silent English leakage). `%d` needs a real int.
 
@@ -925,7 +936,8 @@ locale files for user-facing changes. Never commit secrets/`.env`.
 
 **i18n**
 - Double-quote YAML with escapes; `%d` needs a real int; verify keys exist in **all**
-  locale files; convert Markdown→HTML for sends.
+  locale files; convert Markdown→HTML with `formatting.ToTelegramHTML` (do not run
+  `MD2HTMLV2` on strings that already contain `<b>`/`<code>`).
 
 **Boolean logic**
 - `IsAnonymousChannel() || IsLinkedChannel()` matches almost everything — test lock/

--- a/alita/modules/antiraid.go
+++ b/alita/modules/antiraid.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	tgmd2html "github.com/PaulSonOfLars/gotg_md2html"
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
@@ -841,7 +840,7 @@ func (a *antiRaidStruct) callbackHandler(bot *gotgbot.Bot, ctx *ext.Context) err
 		}
 		text, _ := tr.GetString("antiraid_enabled", i18n.TranslationParams{"duration": formatDuration(settings.RaidTime)})
 		_, _ = bot.AnswerCallbackQuery(query.Id, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		_, _, _ = msg.EditText(bot, &gotgbot.EditMessageTextOpts{Text: tgmd2html.MD2HTMLV2(text), ParseMode: formatting.HTML})
+		_, _, _ = msg.EditText(bot, &gotgbot.EditMessageTextOpts{Text: formatting.ToTelegramHTML(text), ParseMode: formatting.HTML})
 	case "off":
 		disabled, err := a.disableRaid(chatID)
 		if err != nil {
@@ -856,7 +855,7 @@ func (a *antiRaidStruct) callbackHandler(bot *gotgbot.Bot, ctx *ext.Context) err
 		}
 		text, _ := tr.GetString("antiraid_disabled")
 		_, _ = bot.AnswerCallbackQuery(query.Id, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		_, _, _ = msg.EditText(bot, &gotgbot.EditMessageTextOpts{Text: tgmd2html.MD2HTMLV2(text), ParseMode: formatting.HTML})
+		_, _, _ = msg.EditText(bot, &gotgbot.EditMessageTextOpts{Text: formatting.ToTelegramHTML(text), ParseMode: formatting.HTML})
 	default:
 		text, _ := tr.GetString("common_callback_invalid_request")
 		_, _ = bot.AnswerCallbackQuery(query.Id, &gotgbot.AnswerCallbackQueryOpts{Text: text})

--- a/alita/modules/help_locale_format_test.go
+++ b/alita/modules/help_locale_format_test.go
@@ -5,11 +5,14 @@ package modules
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+var leftoverMarkdownBold = regexp.MustCompile(`\*[^*\s][^*]*\*`)
 
 func TestAllLocaleHelpMessagesKeepHTMLTags(t *testing.T) {
 	t.Parallel()
@@ -54,11 +57,27 @@ func TestAllLocaleHelpMessagesKeepHTMLTags(t *testing.T) {
 					break
 				}
 			}
+			if isHTMLAuthoredHelp(helpMsg) {
+				if strings.Contains(helpMsg, "`") {
+					t.Errorf("%s %s HTML help contains markdown backticks", path, key)
+				}
+				if leftoverMarkdownBold.MatchString(helpMsg) {
+					t.Errorf("%s %s HTML help contains leftover *bold* markdown", path, key)
+				}
+			}
 		}
 	}
 	if checked == 0 {
 		t.Fatal("no *_help_msg keys found in locales")
 	}
+}
+
+func isHTMLAuthoredHelp(s string) bool {
+	hasOpen := strings.Contains(s, "<b>") || strings.Contains(s, "<code>") ||
+		strings.Contains(s, "<i>") || strings.Contains(s, "<u>")
+	hasClose := strings.Contains(s, "</b>") || strings.Contains(s, "</code>") ||
+		strings.Contains(s, "</i>") || strings.Contains(s, "</u>")
+	return hasOpen && hasClose
 }
 
 func findLocalesDir(t *testing.T) string {

--- a/alita/modules/help_locale_format_test.go
+++ b/alita/modules/help_locale_format_test.go
@@ -1,0 +1,75 @@
+//go:build testtools
+
+package modules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAllLocaleHelpMessagesKeepHTMLTags(t *testing.T) {
+	t.Parallel()
+
+	localeDir := findLocalesDir(t)
+	entries, err := os.ReadDir(localeDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", localeDir, err)
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "config.yml" || !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		path := filepath.Join(localeDir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", path, err)
+		}
+		var data map[string]any
+		if err := yaml.Unmarshal(raw, &data); err != nil {
+			t.Fatalf("yaml.Unmarshal(%s): %v", path, err)
+		}
+		header, _ := data["helpers_module_help_header"].(string)
+		if header == "" {
+			t.Fatalf("%s missing helpers_module_help_header", path)
+		}
+		for key, value := range data {
+			if !strings.HasSuffix(key, "_help_msg") {
+				continue
+			}
+			helpMsg, ok := value.(string)
+			if !ok {
+				t.Fatalf("%s %s is %T, want string", path, key, value)
+			}
+			checked++
+			got := renderModuleHelp(header, "Reactions", helpMsg)
+			for _, escaped := range []string{"&lt;b&gt;", "&lt;/b&gt;", "&lt;i&gt;", "&lt;code&gt;", "&lt;/code&gt;"} {
+				if strings.Contains(got, escaped) {
+					t.Errorf("%s %s rendered escaped tag %s:\n%s", path, key, escaped, got)
+					break
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no *_help_msg keys found in locales")
+	}
+}
+
+func findLocalesDir(t *testing.T) string {
+	t.Helper()
+	candidates := []string{"locales", "../locales", "../../locales"}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	t.Fatal("cannot find locales directory")
+	return ""
+}

--- a/alita/modules/help_render_test.go
+++ b/alita/modules/help_render_test.go
@@ -133,3 +133,58 @@ func TestGetBotUsernameCachesStructAndGetMeFallbacks(t *testing.T) {
 		t.Fatalf("getBotUsername(nil) = %q, want empty", got)
 	}
 }
+
+func TestRenderModuleHelpHTMLBodyKeepsBoldTags(t *testing.T) {
+	t.Parallel()
+
+	header := "Here is the help for the *%s* module:\n\n"
+	body := `<b>🎭 Auto-Reactions</b>
+
+Automatically react to messages with specific keywords!
+
+<b>Admin Commands:</b>
+• /addreaction <keyword> <emoji> - Add an auto-reaction
+<b>Example:</b>
+• /addreaction hello 👋`
+
+	got := renderModuleHelp(header, "Reactions", body)
+	if strings.Contains(got, "&lt;b&gt;") || strings.Contains(got, "*Reactions*") {
+		t.Fatalf("renderModuleHelp() escaped HTML or left markdown: %q", got)
+	}
+	if !strings.Contains(got, "<b>Reactions</b>") {
+		t.Fatalf("renderModuleHelp() missing converted header bold: %q", got)
+	}
+	if !strings.Contains(got, "<b>🎭 Auto-Reactions</b>") {
+		t.Fatalf("renderModuleHelp() missing body heading: %q", got)
+	}
+	if !strings.Contains(got, "<b>Admin Commands:</b>") {
+		t.Fatalf("renderModuleHelp() missing Admin Commands heading: %q", got)
+	}
+	if !strings.Contains(got, "<b>Example:</b>") {
+		t.Fatalf("renderModuleHelp() missing Example heading: %q", got)
+	}
+	if !strings.Contains(got, "module:</b>\n\n<b>🎭 Auto-Reactions</b>") &&
+		!strings.Contains(got, "module:\n\n<b>🎭 Auto-Reactions</b>") {
+		t.Fatalf("renderModuleHelp() missing blank line between header and body: %q", got)
+	}
+	if !strings.Contains(got, "&lt;keyword&gt;") || !strings.Contains(got, "&lt;emoji&gt;") {
+		t.Fatalf("renderModuleHelp() did not escape placeholders: %q", got)
+	}
+}
+
+func TestRenderModuleHelpMarkdownBodyConvertsBold(t *testing.T) {
+	t.Parallel()
+
+	header := "Here is the help for the *%s* module:\n\n"
+	body := "*Admin Commands:*\n× /promote `<reply/username>`: Promote a user."
+	got := renderModuleHelp(header, "Admin", body)
+	if !strings.Contains(got, "<b>Admin</b>") {
+		t.Fatalf("renderModuleHelp(markdown) missing header bold: %q", got)
+	}
+	if !strings.Contains(got, "<b>Admin Commands:</b>") && !strings.Contains(got, "<b>Admin Commands</b>") {
+		t.Fatalf("renderModuleHelp(markdown) missing converted section heading: %q", got)
+	}
+	if strings.Contains(got, "<reply/username>") {
+		t.Fatalf("renderModuleHelp(markdown) left raw placeholder: %q", got)
+	}
+}

--- a/alita/modules/help_system.go
+++ b/alita/modules/help_system.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	tgmd2html "github.com/PaulSonOfLars/gotg_md2html"
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 	"github.com/divkix/Alita_Robot/alita/db/lang"
@@ -62,7 +61,10 @@ func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText s
 	tr := i18n.MustNewTranslator(lang)
 	helpMsg, _ := tr.GetString(fmt.Sprintf("%s_help_msg", strings.ToLower(ModName)))
 	headerTemplate, _ := tr.GetString("helpers_module_help_header")
-	helpText = tgmd2html.MD2HTMLV2(fmt.Sprintf(headerTemplate, ModName) + helpMsg)
+	// Convert the markdown header and the body independently. Concatenating
+	// first then running MD2HTMLV2 escapes already-HTML _help_msg strings
+	// (reactions/backup/approvals/antispam) into visible <b> tags.
+	helpText = renderModuleHelp(headerTemplate, ModName, helpMsg)
 
 	backText, _ := tr.GetString("common_back_arrow")
 	homeText, _ := tr.GetString("common_home")
@@ -82,6 +84,14 @@ func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText s
 		InlineKeyboard: append(kb, backBtnSuffix),
 	}
 	return
+}
+
+// renderModuleHelp converts the markdown help header and the module body to
+// Telegram HTML independently so HTML-authored _help_msg strings keep their
+// tags instead of being escaped into visible <b> text.
+func renderModuleHelp(headerTemplate, modName, helpMsg string) string {
+	return formatting.ToTelegramHTML(fmt.Sprintf(headerTemplate, modName)) +
+		formatting.ToTelegramHTML(helpMsg)
 }
 
 // sendHelpkb sends help information for a specific module with navigation keyboard.

--- a/alita/utils/formatting/telegram_html.go
+++ b/alita/utils/formatting/telegram_html.go
@@ -1,0 +1,93 @@
+package formatting
+
+import (
+	"html"
+	"regexp"
+	"strings"
+
+	tgmd2html "github.com/PaulSonOfLars/gotg_md2html"
+)
+
+// telegramHTMLTagRe matches Telegram-supported HTML tags, including optional
+// attributes. It is a closed allowlist so command placeholders such as
+// <keyword> or <reply/username> are not treated as markup.
+var telegramHTMLTagRe = regexp.MustCompile(
+	`(?i)</?(?:b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler|span|tg-emoji|a)(?:\s[^>]*)?>`,
+)
+
+// telegramHTMLCloseTagRe detects already-authored Telegram HTML. Closing tags
+// are the signal: markdown help uses placeholders like <trigger>, which would
+// otherwise look like opening tags.
+var telegramHTMLCloseTagRe = regexp.MustCompile(
+	`(?i)</(?:b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler|span|tg-emoji|a)>`,
+)
+
+// htmlEntityRe matches existing HTML entities so preserveTelegramHTML does not
+// double-escape &amp; / &#123; / &#x1F; into visible entity text.
+var htmlEntityRe = regexp.MustCompile(`&(?:#\d+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]+);`)
+
+// ToTelegramHTML converts locale or template text to Telegram HTML.
+// Markdown is converted with MD2HTMLV2. Strings that already contain Telegram
+// HTML tags keep those tags and only escape leftover <, >, and & so
+// placeholders like <keyword> display as text instead of being parsed as tags.
+// Leading and trailing newlines are preserved because MD2HTMLV2 strips them,
+// and the help header relies on a trailing blank line before the body.
+func ToTelegramHTML(s string) string {
+	if s == "" {
+		return ""
+	}
+	leading, core, trailing := splitEdgeNewlines(s)
+	if core == "" {
+		return s
+	}
+	var out string
+	if telegramHTMLCloseTagRe.MatchString(core) {
+		out = preserveTelegramHTML(core)
+	} else {
+		out = tgmd2html.MD2HTMLV2(core)
+	}
+	return leading + out + trailing
+}
+
+func splitEdgeNewlines(s string) (leading, core, trailing string) {
+	start := 0
+	for start < len(s) && s[start] == '\n' {
+		start++
+	}
+	end := len(s)
+	for end > start && s[end-1] == '\n' {
+		end--
+	}
+	return s[:start], s[start:end], s[end:]
+}
+
+// preserveTelegramHTML keeps Telegram HTML tags intact and HTML-escapes the
+// text around them, leaving pre-existing entities unchanged.
+func preserveTelegramHTML(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	last := 0
+	for _, loc := range telegramHTMLTagRe.FindAllStringIndex(s, -1) {
+		b.WriteString(escapeHTMLTextPreservingEntities(s[last:loc[0]]))
+		b.WriteString(s[loc[0]:loc[1]])
+		last = loc[1]
+	}
+	b.WriteString(escapeHTMLTextPreservingEntities(s[last:]))
+	return b.String()
+}
+
+func escapeHTMLTextPreservingEntities(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	last := 0
+	for _, loc := range htmlEntityRe.FindAllStringIndex(s, -1) {
+		b.WriteString(html.EscapeString(s[last:loc[0]]))
+		b.WriteString(s[loc[0]:loc[1]])
+		last = loc[1]
+	}
+	b.WriteString(html.EscapeString(s[last:]))
+	return b.String()
+}

--- a/alita/utils/formatting/telegram_html.go
+++ b/alita/utils/formatting/telegram_html.go
@@ -15,9 +15,16 @@ var telegramHTMLTagRe = regexp.MustCompile(
 	`(?i)</?(?:b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler|span|tg-emoji|a)(?:\s[^>]*)?>`,
 )
 
-// telegramHTMLCloseTagRe detects already-authored Telegram HTML. Closing tags
-// are the signal: markdown help uses placeholders like <trigger>, which would
-// otherwise look like opening tags.
+// telegramHTMLOpenTagRe matches opening Telegram HTML tags. Combined with
+// telegramHTMLCloseTagRe, this avoids treating a markdown code span such as
+// `</b>` as an HTML-authored string.
+var telegramHTMLOpenTagRe = regexp.MustCompile(
+	`(?i)<(?:b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler|span|tg-emoji|a)(?:\s[^>]*)?>`,
+)
+
+// telegramHTMLCloseTagRe matches closing Telegram HTML tags. Markdown help
+// uses placeholders like <trigger>, which would otherwise look like opening
+// tags, so a closer alone is not enough to select the HTML path.
 var telegramHTMLCloseTagRe = regexp.MustCompile(
 	`(?i)</(?:b|strong|i|em|u|ins|s|strike|del|code|pre|blockquote|tg-spoiler|span|tg-emoji|a)>`,
 )
@@ -41,12 +48,16 @@ func ToTelegramHTML(s string) string {
 		return s
 	}
 	var out string
-	if telegramHTMLCloseTagRe.MatchString(core) {
+	if looksLikeTelegramHTML(core) {
 		out = preserveTelegramHTML(core)
 	} else {
 		out = tgmd2html.MD2HTMLV2(core)
 	}
 	return leading + out + trailing
+}
+
+func looksLikeTelegramHTML(s string) bool {
+	return telegramHTMLOpenTagRe.MatchString(s) && telegramHTMLCloseTagRe.MatchString(s)
 }
 
 func splitEdgeNewlines(s string) (leading, core, trailing string) {

--- a/alita/utils/formatting/telegram_html_test.go
+++ b/alita/utils/formatting/telegram_html_test.go
@@ -1,0 +1,107 @@
+package formatting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToTelegramHTMLMarkdownBold(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("*Admin Commands:*")
+	if !strings.Contains(got, "<b>") || !strings.Contains(got, "Admin Commands") {
+		t.Fatalf("ToTelegramHTML(markdown) = %q, want HTML bold", got)
+	}
+	if strings.Contains(got, "&lt;b&gt;") {
+		t.Fatalf("ToTelegramHTML(markdown) escaped its own tags: %q", got)
+	}
+}
+
+func TestToTelegramHTMLPreservesHTMLBold(t *testing.T) {
+	t.Parallel()
+
+	input := "<b>🎭 Auto-Reactions</b>\n\n<b>Admin Commands:</b>"
+	got := ToTelegramHTML(input)
+	if !strings.Contains(got, "<b>🎭 Auto-Reactions</b>") {
+		t.Fatalf("ToTelegramHTML(html) = %q, want preserved <b> tags", got)
+	}
+	if strings.Contains(got, "&lt;b&gt;") {
+		t.Fatalf("ToTelegramHTML(html) escaped <b> tags: %q", got)
+	}
+}
+
+func TestToTelegramHTMLEscapesCommandPlaceholdersInHTML(t *testing.T) {
+	t.Parallel()
+
+	input := "<b>Admin Commands:</b>\n• /addreaction <keyword> <emoji> - Add"
+	got := ToTelegramHTML(input)
+	if !strings.Contains(got, "<b>Admin Commands:</b>") {
+		t.Fatalf("ToTelegramHTML() lost heading tags: %q", got)
+	}
+	if !strings.Contains(got, "&lt;keyword&gt;") || !strings.Contains(got, "&lt;emoji&gt;") {
+		t.Fatalf("ToTelegramHTML() did not escape placeholders: %q", got)
+	}
+	if strings.Contains(got, "<keyword>") || strings.Contains(got, "<emoji>") {
+		t.Fatalf("ToTelegramHTML() left raw placeholder tags: %q", got)
+	}
+}
+
+func TestToTelegramHTMLEscapesPlaceholdersInsideCodeTags(t *testing.T) {
+	t.Parallel()
+
+	input := `/approve <code><reply/username/mention/userid></code>`
+	got := ToTelegramHTML(input)
+	want := `/approve <code>&lt;reply/username/mention/userid&gt;</code>`
+	if got != want {
+		t.Fatalf("ToTelegramHTML() = %q, want %q", got, want)
+	}
+}
+
+func TestToTelegramHTMLEscapesAmpersandButKeepsEntities(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("<b>Backup & Restore</b>")
+	if got != "<b>Backup &amp; Restore</b>" {
+		t.Fatalf("ToTelegramHTML(raw amp) = %q, want escaped ampersand", got)
+	}
+
+	got = ToTelegramHTML("<b>Texte &amp; Médias</b>")
+	if got != "<b>Texte &amp; Médias</b>" {
+		t.Fatalf("ToTelegramHTML(entity) = %q, want entity preserved", got)
+	}
+}
+
+func TestToTelegramHTMLMarkdownPlaceholdersStayEscaped(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("× /promote `<reply/username>`: Promote a user.")
+	if strings.Contains(got, "<reply/username>") {
+		t.Fatalf("ToTelegramHTML(markdown) left raw placeholder: %q", got)
+	}
+	if !strings.Contains(got, "&lt;reply/username&gt;") {
+		t.Fatalf("ToTelegramHTML(markdown) = %q, want escaped placeholder", got)
+	}
+}
+
+func TestToTelegramHTMLPreservesTrailingNewlines(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("Here is the help for the *Reactions* module:\n\n")
+	if !strings.HasSuffix(got, "\n\n") {
+		t.Fatalf("ToTelegramHTML(header) = %q, want trailing blank line", got)
+	}
+	if !strings.Contains(got, "<b>Reactions</b>") {
+		t.Fatalf("ToTelegramHTML(header) = %q, want converted module name", got)
+	}
+}
+
+func TestToTelegramHTMLEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := ToTelegramHTML(""); got != "" {
+		t.Fatalf("ToTelegramHTML(empty) = %q, want empty", got)
+	}
+	if got := ToTelegramHTML("\n\n"); got != "\n\n" {
+		t.Fatalf("ToTelegramHTML(newlines) = %q, want unchanged newlines", got)
+	}
+}

--- a/alita/utils/formatting/telegram_html_test.go
+++ b/alita/utils/formatting/telegram_html_test.go
@@ -105,3 +105,30 @@ func TestToTelegramHTMLEmpty(t *testing.T) {
 		t.Fatalf("ToTelegramHTML(newlines) = %q, want unchanged newlines", got)
 	}
 }
+
+func TestToTelegramHTMLMarkdownCloseTagInCodeSpanStaysMarkdown(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("Use `</b>` to end *bold* text.")
+	if strings.Contains(got, "`") {
+		t.Fatalf("ToTelegramHTML() treated markdown as HTML: %q", got)
+	}
+	if !strings.Contains(got, "<code>") || !strings.Contains(got, "&lt;/b&gt;") {
+		t.Fatalf("ToTelegramHTML() = %q, want markdown code span around escaped </b>", got)
+	}
+	if !strings.Contains(got, "<b>bold</b>") {
+		t.Fatalf("ToTelegramHTML() = %q, want converted markdown bold", got)
+	}
+}
+
+func TestToTelegramHTMLOpenTagWithoutCloserStaysMarkdown(t *testing.T) {
+	t.Parallel()
+
+	got := ToTelegramHTML("Mention <b> in *help* text")
+	if !strings.Contains(got, "&lt;b&gt;") {
+		t.Fatalf("ToTelegramHTML() = %q, want escaped standalone <b>", got)
+	}
+	if !strings.Contains(got, "<b>help</b>") {
+		t.Fatalf("ToTelegramHTML() = %q, want converted markdown bold", got)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Module help mixed a Markdown header (`Here is the help for the *Reactions* module:`) with HTML-authored bodies (`<b>Admin Commands:</b>`), then ran `MD2HTMLV2` on the concatenation. That escaped real HTML tags, so Telegram showed literal `<b>` instead of bold in Reactions, Backup, Approvals, and Antispam help.

This converts the header and body independently via `formatting.ToTelegramHTML`: Markdown still goes through `MD2HTMLV2`, while already-HTML strings keep Telegram tags and only escape leftover placeholders like `<keyword>`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Dependency update

## Testing Done

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Tested in development environment
- [ ] Other (please specify)

### Test Results

`go test -tags testtools` for `./alita/utils/formatting/` and help rendering tests in `./alita/modules/` pass, including a locale-wide check that every `*_help_msg` keeps `<b>`/`<code>` tags instead of escaping them.

Before (old concat + `MD2HTMLV2` path):

```
Here is the help for the <b>Reactions</b> module:

&lt;b&gt;Admin Commands:&lt;/b&gt;
```

After (`ToTelegramHTML` independently):

```
Here is the help for the <b>Reactions</b> module:

<b>Admin Commands:</b>
• /addreaction &lt;keyword&gt; &lt;emoji&gt;
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context

- Related issue(s): user-reported Reactions `/help` showing raw `<b>` tags
- Breaking changes (if any): none

## Release Notes

Help text for modules authored in HTML (Reactions, Backup, Approvals, Antispam) now renders bold/code formatting instead of showing raw `<b>` tags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a041b1-5e9d-73e1-8cf4-8bb0806048e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a041b1-5e9d-73e1-8cf4-8bb0806048e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

