### PR TITLE
fix(devs): include federation counts in /stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -686,6 +686,10 @@ m != nil`) — every helper bails when it's nil.
   deleted bans for the 30m TTL.
   Chat backups
   export **membership only** (`fed_id` + `quiet`), not the federation itself.
+  `/stats` (`devs.LoadAllStats`) includes global federation totals via
+  `federations.LoadFederationStats` (feds, chats, promoted admins, bans,
+  subscriptions) — the same numbers `/fedinfo` shows per-fed. `/fedstat` is a
+  per-user ban lookup, not bot-wide stats.
 - **Log channels** (`logchannels.go`, group **11**, priority 55): `/setlog` in a
   channel stores a pending Redis marker for **that exact message**
   (`alita:setlog:<channel>:<msgId>`, 1h). There is **no** `:0` wildcard — capture

--- a/alita/db/devs/repository.go
+++ b/alita/db/devs/repository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db/chats"
 	"github.com/divkix/Alita_Robot/alita/db/connections"
 	"github.com/divkix/Alita_Robot/alita/db/disabling"
+	"github.com/divkix/Alita_Robot/alita/db/federations"
 	"github.com/divkix/Alita_Robot/alita/db/filters"
 	"github.com/divkix/Alita_Robot/alita/db/greetings"
 	"github.com/divkix/Alita_Robot/alita/db/models"
@@ -146,7 +147,8 @@ func RemSudo(userID int64) error {
 }
 
 // LoadAllStats generates a comprehensive statistics report for the bot.
-// Includes user counts, chat statistics, feature usage, activity metrics, and system information.
+// Includes user counts, chat statistics, feature usage (including federations),
+// activity metrics, and system information.
 func LoadAllStats() string {
 	totalUsers := user.LoadUsersStats()
 	activeChats, inactiveChats := chats.LoadChatStats()
@@ -162,6 +164,7 @@ func LoadAllStats() string {
 	filtersNum, filtersChats := filters.LoadFilterStats()
 	enabledWelcome, enabledGoodbye, cleanServiceEnabled, cleanWelcomeEnabled, cleanGoodbyeEnabled := greetings.LoadGreetingsStats()
 	notesNum, notesChats := notes.LoadNotesStats()
+	fedCount, fedChats, fedAdmins, fedBans, fedSubs := federations.LoadFederationStats()
 	numChannels := channels.LoadChannelStats()
 
 	// Get webhook status information
@@ -238,6 +241,12 @@ func LoadAllStats() string {
 			humanize.Comma(notesNum),
 			humanize.Comma(notesChats),
 		) +
+		"\n<b>Federations:</b>" +
+		fmt.Sprintf("\n    <b>Total:</b> %s", humanize.Comma(fedCount)) +
+		fmt.Sprintf("\n    <b>Chats:</b> %s", humanize.Comma(fedChats)) +
+		fmt.Sprintf("\n    <b>Admins:</b> %s", humanize.Comma(fedAdmins)) +
+		fmt.Sprintf("\n    <b>Bans:</b> %s", humanize.Comma(fedBans)) +
+		fmt.Sprintf("\n    <b>Subscriptions:</b> %s", humanize.Comma(fedSubs)) +
 		fmt.Sprintf("\n<b>Channels Stored</b>: %s", humanize.Comma(numChannels))
 
 	return result

--- a/alita/db/devs/repository_test.go
+++ b/alita/db/devs/repository_test.go
@@ -1,11 +1,15 @@
 package devs
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/db/federations"
 	"github.com/divkix/Alita_Robot/alita/db/models"
 )
 
@@ -243,12 +247,86 @@ func TestLoadAllStats(t *testing.T) {
 		"CleanWelcome",
 		"CleanGoodbye",
 		"Notes",
+		"Federations",
+		"Total",
+		"Chats",
+		"Admins",
+		"Bans",
+		"Subscriptions",
 		"Channels Stored",
 	}
 
 	for _, section := range expectedSections {
 		if !strings.Contains(stats, section) {
 			t.Errorf("LoadAllStats() missing expected section %q", section)
+		}
+	}
+}
+
+func TestLoadAllStats_IncludesFederationCounts(t *testing.T) {
+	skipIfNoDb(t)
+
+	ownerA := time.Now().UnixNano()
+	ownerB := ownerA + 1
+	adminID := ownerA + 2
+	bannedID := ownerA + 3
+	chatID := -ownerA
+
+	fedA, err := federations.CreateFederation(ownerA, "Stats Fed A")
+	if err != nil {
+		t.Fatalf("CreateFederation A: %v", err)
+	}
+	fedB, err := federations.CreateFederation(ownerB, "Stats Fed B")
+	if err != nil {
+		t.Fatalf("CreateFederation B: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = federations.DeleteFederation(fedA.FedID)
+		_ = federations.DeleteFederation(fedB.FedID)
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.Chat{}).Error
+		_ = db.DB.Where("user_id IN ?", []int64{ownerA, ownerB, adminID, bannedID}).
+			Delete(&models.User{}).Error
+	})
+
+	if err := federations.JoinFed(chatID, "stats chat", fedA.FedID); err != nil {
+		t.Fatalf("JoinFed: %v", err)
+	}
+	if err := federations.PromoteFedAdmin(fedA.FedID, adminID); err != nil {
+		t.Fatalf("PromoteFedAdmin: %v", err)
+	}
+	if _, _, err := federations.Fban(fedA.FedID, bannedID, ownerA, "stats"); err != nil {
+		t.Fatalf("Fban: %v", err)
+	}
+	if err := federations.SubscribeFed(fedA.FedID, fedB.FedID); err != nil {
+		t.Fatalf("SubscribeFed: %v", err)
+	}
+
+	feds, fedChats, admins, bans, subs := federations.LoadFederationStats()
+	if feds < 2 || fedChats < 1 || admins < 1 || bans < 1 || subs < 1 {
+		t.Fatalf("LoadFederationStats() = (%d, %d, %d, %d, %d), want at least (2, 1, 1, 1, 1)",
+			feds, fedChats, admins, bans, subs)
+	}
+
+	stats := LoadAllStats()
+	idx := strings.Index(stats, "<b>Federations:</b>")
+	if idx < 0 {
+		t.Fatal("LoadAllStats() missing Federations section")
+	}
+	section := stats[idx:]
+	if end := strings.Index(section, "<b>Channels Stored"); end >= 0 {
+		section = section[:end]
+	}
+
+	want := []string{
+		fmt.Sprintf("<b>Total:</b> %s", humanize.Comma(feds)),
+		fmt.Sprintf("<b>Chats:</b> %s", humanize.Comma(fedChats)),
+		fmt.Sprintf("<b>Admins:</b> %s", humanize.Comma(admins)),
+		fmt.Sprintf("<b>Bans:</b> %s", humanize.Comma(bans)),
+		fmt.Sprintf("<b>Subscriptions:</b> %s", humanize.Comma(subs)),
+	}
+	for _, line := range want {
+		if !strings.Contains(section, line) {
+			t.Errorf("Federations section missing %q\nsection=%q", line, section)
 		}
 	}
 }

--- a/alita/db/devs/testmain_test.go
+++ b/alita/db/devs/testmain_test.go
@@ -1,0 +1,83 @@
+package devs
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/db/models"
+)
+
+func TestMain(m *testing.M) {
+	var dbFileName string
+	if db.DB == nil {
+		dbFile, err := os.CreateTemp("", "alita_devs_test_*.db")
+		if err != nil {
+			fmt.Printf("temp file creation failed: %v\n", err)
+			os.Exit(1)
+		}
+		dbFileName = dbFile.Name()
+		if err := dbFile.Close(); err != nil {
+			fmt.Printf("temp file close failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		sqliteDB, err := gorm.Open(
+			sqlite.Open(dbFileName+"?_busy_timeout=10000&_journal_mode=WAL"),
+			&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
+		)
+		if err != nil {
+			fmt.Printf("SQLite init failed: %v\n", err)
+			os.Exit(1)
+		}
+		sqlDB, err := sqliteDB.DB()
+		if err != nil {
+			fmt.Printf("SQLite handle failed: %v\n", err)
+			os.Exit(1)
+		}
+		sqlDB.SetMaxOpenConns(1)
+		db.DB = sqliteDB
+
+		if err := db.DB.AutoMigrate(
+			&models.User{},
+			&models.Chat{},
+			&models.DevSettings{},
+			&models.PinSettings{},
+			&models.ReportChatSettings{},
+			&models.ReportUserSettings{},
+			&models.AntifloodSettings{},
+			&models.RulesSettings{},
+			&models.BlacklistSettings{},
+			&models.ConnectionSettings{},
+			&models.ConnectionChatSettings{},
+			&models.DisableSettings{},
+			&models.DisableChatSettings{},
+			&models.ChatFilters{},
+			&models.GreetingSettings{},
+			&models.Notes{},
+			&models.ChannelSettings{},
+			&models.Federation{},
+			&models.FederationAdmin{},
+			&models.FederationChat{},
+			&models.FederationBan{},
+			&models.FederationSub{},
+		); err != nil {
+			fmt.Printf("AutoMigrate failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	exitCode := m.Run()
+	if dbFileName != "" {
+		if sqlDB, err := db.DB.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+		_ = os.Remove(dbFileName)
+	}
+	os.Exit(exitCode)
+}

--- a/alita/db/federations/repository.go
+++ b/alita/db/federations/repository.go
@@ -335,6 +335,27 @@ func CountFedBans(fedID string) int {
 	return int(count)
 }
 
+func countModel(model any, op string) int64 {
+	var count int64
+	if err := db.DB.Model(model).Count(&count).Error; err != nil {
+		log.Errorf("[Federations] %s: %v", op, err)
+		return 0
+	}
+	return count
+}
+
+// LoadFederationStats returns bot-wide federation totals for /stats.
+// Counts match the per-fed numbers already used by /fedinfo:
+// federations, joined chats, promoted admins, bans, and subscriptions.
+func LoadFederationStats() (feds, chats, admins, bans, subs int64) {
+	feds = countModel(&models.Federation{}, "LoadFederationStats (feds)")
+	chats = countModel(&models.FederationChat{}, "LoadFederationStats (chats)")
+	admins = countModel(&models.FederationAdmin{}, "LoadFederationStats (admins)")
+	bans = countModel(&models.FederationBan{}, "LoadFederationStats (bans)")
+	subs = countModel(&models.FederationSub{}, "LoadFederationStats (subs)")
+	return
+}
+
 // IsFedOwner reports whether userID owns the federation.
 func IsFedOwner(fedID string, userID int64) bool {
 	fed := GetFed(fedID)

--- a/alita/db/federations/repository_test.go
+++ b/alita/db/federations/repository_test.go
@@ -367,3 +367,114 @@ func TestDeleteFederationInvalidatesBanAndSubscriberCaches(t *testing.T) {
 		t.Fatalf("subscriber fed_subs cache = %v, want empty after target delete", got)
 	}
 }
+
+func TestLoadFederationStats(t *testing.T) {
+	if db.DB == nil {
+		t.Skip("DB not initialized")
+	}
+
+	feds, chats, admins, bans, subs := LoadFederationStats()
+	if feds < 0 || chats < 0 || admins < 0 || bans < 0 || subs < 0 {
+		t.Fatalf("LoadFederationStats() = (%d, %d, %d, %d, %d), want all >= 0",
+			feds, chats, admins, bans, subs)
+	}
+}
+
+func TestLoadFederationStats_ReflectsNewEntries(t *testing.T) {
+	if db.DB == nil {
+		t.Skip("DB not initialized")
+	}
+
+	ownerA := time.Now().UnixNano() + 700
+	ownerB := ownerA + 1
+	adminID := ownerA + 2
+	bannedID := ownerA + 3
+	chatID := -ownerA
+
+	baseFeds, baseChats, baseAdmins, baseBans, baseSubs := LoadFederationStats()
+
+	fedA, err := CreateFederation(ownerA, "Stats Fed A")
+	if err != nil {
+		t.Fatalf("CreateFederation A: %v", err)
+	}
+	fedB, err := CreateFederation(ownerB, "Stats Fed B")
+	if err != nil {
+		t.Fatalf("CreateFederation B: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = DeleteFederation(fedA.FedID)
+		_ = DeleteFederation(fedB.FedID)
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.Chat{}).Error
+		_ = db.DB.Where("user_id IN ?", []int64{ownerA, ownerB, adminID, bannedID}).
+			Delete(&models.User{}).Error
+	})
+
+	if err := chats.EnsureChatInDb(chatID, "stats fed chat"); err != nil {
+		t.Fatalf("EnsureChatInDb: %v", err)
+	}
+	if err := JoinFed(chatID, "stats fed chat", fedA.FedID); err != nil {
+		t.Fatalf("JoinFed: %v", err)
+	}
+	if err := PromoteFedAdmin(fedA.FedID, adminID); err != nil {
+		t.Fatalf("PromoteFedAdmin: %v", err)
+	}
+	if _, _, err := Fban(fedA.FedID, bannedID, ownerA, "stats"); err != nil {
+		t.Fatalf("Fban: %v", err)
+	}
+	if err := SubscribeFed(fedA.FedID, fedB.FedID); err != nil {
+		t.Fatalf("SubscribeFed: %v", err)
+	}
+
+	feds, fedChats, admins, bans, subs := LoadFederationStats()
+	if feds < baseFeds+2 {
+		t.Errorf("feds = %d, want >= %d", feds, baseFeds+2)
+	}
+	if fedChats < baseChats+1 {
+		t.Errorf("chats = %d, want >= %d", fedChats, baseChats+1)
+	}
+	if admins < baseAdmins+1 {
+		t.Errorf("admins = %d, want >= %d", admins, baseAdmins+1)
+	}
+	if bans < baseBans+1 {
+		t.Errorf("bans = %d, want >= %d", bans, baseBans+1)
+	}
+	if subs < baseSubs+1 {
+		t.Errorf("subs = %d, want >= %d", subs, baseSubs+1)
+	}
+}
+
+func TestLoadFederationStatsErrorBranch(t *testing.T) {
+	if db.DB == nil {
+		t.Skip("DB not initialized")
+	}
+
+	tables := []any{
+		&models.FederationSub{},
+		&models.FederationBan{},
+		&models.FederationAdmin{},
+		&models.FederationChat{},
+		&models.Federation{},
+	}
+	for _, table := range tables {
+		if err := db.DB.Migrator().DropTable(table); err != nil {
+			t.Fatalf("DropTable %T: %v", table, err)
+		}
+	}
+	t.Cleanup(func() {
+		if err := db.DB.AutoMigrate(
+			&models.Federation{},
+			&models.FederationAdmin{},
+			&models.FederationChat{},
+			&models.FederationBan{},
+			&models.FederationSub{},
+		); err != nil {
+			t.Errorf("AutoMigrate failed: %v", err)
+		}
+	})
+
+	feds, fedChats, admins, bans, subs := LoadFederationStats()
+	if feds != 0 || fedChats != 0 || admins != 0 || bans != 0 || subs != 0 {
+		t.Fatalf("LoadFederationStats() = (%d, %d, %d, %d, %d), want all 0 on error",
+			feds, fedChats, admins, bans, subs)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`/stats` (owner/dev diagnostic) was assembled by `devs.LoadAllStats()` from per-module `Load*Stats` helpers, but federations were never wired in. Federation numbers already existed for `/fedinfo` (`CountFedChats`, `CountFedBans`, `ListFedAdmins`, `ListSubscribedFedIDs`) and in the `federations` / `federation_chats` / `federation_admins` / `federation_bans` / `federation_subs` tables.

This is a real gap: `/fedstat` is a **per-user ban lookup**, not bot-wide stats, so it does not replace `/stats`.

`federations.LoadFederationStats()` now counts those same tables globally and `/stats` renders them in the same nested HTML voice as Greetings/Rules:

```
Federations:
    Total: N
    Chats: N
    Admins: N
    Bans: N
    Subscriptions: N
```

No new metrics were invented — these are the global analogues of the per-fed `/fedinfo` counts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Dependency update

## Testing Done

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [x] Tested in development environment
- [ ] Other (please specify)

### Test Results

```
go test -tags testtools -count=1 ./alita/db/devs ./alita/db/federations ./alita/modules \
  -run 'TestLoadAllStats|TestLoadFederationStats|TestDevChatInfoLeaveChatStatsAndTeamList|TestDevStats'
ok  alita/db/devs
ok  alita/db/federations
ok  alita/modules
```

Seeded wiring test (`TestLoadAllStats_IncludesFederationCounts`) renders:

```
<b>Federations:</b>
    <b>Total:</b> 2
    <b>Chats:</b> 1
    <b>Admins:</b> 1
    <b>Bans:</b> 1
    <b>Subscriptions:</b> 1
```

`golangci-lint run ./alita/db/devs/... ./alita/db/federations/...` — 0 issues.

Telegram `/stats` itself was not exercised against a live bot (owner-only command; no bot session in this environment). Repro: as owner/dev, send `/stats` and confirm the Federations block appears after Notes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Context

- Related issue(s): owner report that `/stats` omitted federation numbers
- `/fedstat` / `/fbanstat` remain unchanged (per-user ban status)
- `/fedinfo` remains the per-federation detail view

## Release Notes

Owner/dev `/stats` now includes global federation totals (federations, joined chats, promoted admins, bans, subscriptions).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26c88d74-076b-4817-9e1a-dee20502dd83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26c88d74-076b-4817-9e1a-dee20502dd83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

