### PR TITLE
refactor: bloat-audit safe subset for #828 (-157 lines, -2 deps)

### DIFF
--- a/alita/db/backup/backup.go
+++ b/alita/db/backup/backup.go
@@ -60,44 +60,36 @@ func ExportModuleData(chatID int64, module string) (interface{}, error) {
 	}
 }
 
-// ImportModuleData imports one module atomically into a chat.
-func ImportModuleData(chatID int64, module string, data interface{}) error {
+// withBackupTx runs fn inside a DB transaction, invalidating returned cache keys.
+func withBackupTx(fn func(tx *gorm.DB) ([]string, error)) error {
 	database, err := backupDB()
 	if err != nil {
 		return err
 	}
-
 	var keys []string
-	err = database.Transaction(func(tx *gorm.DB) error {
-		var importErr error
-		keys, importErr = importModuleData(tx, chatID, module, data, false)
-		return importErr
-	})
-	if err != nil {
+	if err := database.Transaction(func(tx *gorm.DB) error {
+		var err error
+		keys, err = fn(tx)
+		return err
+	}); err != nil {
 		return err
 	}
 	invalidate(keys...)
 	return nil
 }
 
+// ImportModuleData imports one module atomically into a chat.
+func ImportModuleData(chatID int64, module string, data interface{}) error {
+	return withBackupTx(func(tx *gorm.DB) ([]string, error) {
+		return importModuleData(tx, chatID, module, data, false)
+	})
+}
+
 // ClearModuleData clears one module atomically from a chat.
 func ClearModuleData(chatID int64, module string) error {
-	database, err := backupDB()
-	if err != nil {
-		return err
-	}
-
-	var keys []string
-	err = database.Transaction(func(tx *gorm.DB) error {
-		var clearErr error
-		keys, clearErr = clearModuleData(tx, chatID, module)
-		return clearErr
+	return withBackupTx(func(tx *gorm.DB) ([]string, error) {
+		return clearModuleData(tx, chatID, module)
 	})
-	if err != nil {
-		return err
-	}
-	invalidate(keys...)
-	return nil
 }
 
 // ExportChatData exports the selected modules. A failed module aborts the
@@ -142,28 +134,18 @@ func ImportChatData(chatID int64, backup *BackupFormat, modules []string) error 
 		}
 	}
 
-	database, err := backupDB()
-	if err != nil {
-		return err
-	}
-
-	var keys []string
-	err = database.Transaction(func(tx *gorm.DB) error {
+	return withBackupTx(func(tx *gorm.DB) ([]string, error) {
+		var keys []string
 		for _, module := range modules {
 			data := backup.Data[module]
 			moduleKeys, err := importModuleData(tx, chatID, module, data, backup.Version == legacyFormatVersion)
 			if err != nil {
-				return fmt.Errorf("failed to import module %s: %w", module, err)
+				return nil, fmt.Errorf("failed to import module %s: %w", module, err)
 			}
 			keys = append(keys, moduleKeys...)
 		}
-		return nil
+		return keys, nil
 	})
-	if err != nil {
-		return err
-	}
-	invalidate(keys...)
-	return nil
 }
 
 // ClearChatData clears every selected module in one transaction.
@@ -172,27 +154,17 @@ func ClearChatData(chatID int64, modules []string) error {
 	if err != nil {
 		return err
 	}
-	database, err := backupDB()
-	if err != nil {
-		return err
-	}
-
-	var keys []string
-	err = database.Transaction(func(tx *gorm.DB) error {
+	return withBackupTx(func(tx *gorm.DB) ([]string, error) {
+		var keys []string
 		for _, module := range modules {
 			moduleKeys, err := clearModuleData(tx, chatID, module)
 			if err != nil {
-				return fmt.Errorf("failed to clear module %s: %w", module, err)
+				return nil, fmt.Errorf("failed to clear module %s: %w", module, err)
 			}
 			keys = append(keys, moduleKeys...)
 		}
-		return nil
+		return keys, nil
 	})
-	if err != nil {
-		return err
-	}
-	invalidate(keys...)
-	return nil
 }
 
 func checkedModules(modules []string) ([]string, error) {

--- a/alita/db/backup/types.go
+++ b/alita/db/backup/types.go
@@ -166,10 +166,13 @@ type AdminBackup struct {
 	ConnectionSettings *models.ConnectionChatSettings `json:"connection_settings,omitempty"`
 }
 
-// AntifloodBackup represents antiflood settings backup data
-type AntifloodBackup struct {
-	Settings *models.AntifloodSettings `json:"settings,omitempty"`
+// SettingBackup is the shared shape for single-setting modules.
+type SettingBackup[T any] struct {
+	Settings *T `json:"settings,omitempty"`
 }
+
+// AntifloodBackup represents antiflood settings backup data
+type AntifloodBackup = SettingBackup[models.AntifloodSettings]
 
 // BlacklistsBackup represents blacklist settings and entries backup data
 type BlacklistsBackup struct {
@@ -179,14 +182,10 @@ type BlacklistsBackup struct {
 }
 
 // CaptchaBackup represents captcha settings backup data
-type CaptchaBackup struct {
-	Settings *models.CaptchaSettings `json:"settings,omitempty"`
-}
+type CaptchaBackup = SettingBackup[models.CaptchaSettings]
 
 // ConnectionsBackup represents connection settings backup data
-type ConnectionsBackup struct {
-	Settings *models.ConnectionChatSettings `json:"settings,omitempty"`
-}
+type ConnectionsBackup = SettingBackup[models.ConnectionChatSettings]
 
 // DisablingBackup represents disabled commands backup data
 type DisablingBackup struct {
@@ -200,9 +199,7 @@ type FiltersBackup struct {
 }
 
 // GreetingsBackup represents greetings/welcome settings backup data
-type GreetingsBackup struct {
-	Settings *models.GreetingSettings `json:"settings,omitempty"`
-}
+type GreetingsBackup = SettingBackup[models.GreetingSettings]
 
 // LocksBackup represents lock settings backup data
 type LocksBackup struct {
@@ -216,19 +213,13 @@ type NotesBackup struct {
 }
 
 // PinsBackup represents pin settings backup data
-type PinsBackup struct {
-	Settings *models.PinSettings `json:"settings,omitempty"`
-}
+type PinsBackup = SettingBackup[models.PinSettings]
 
 // ReportsBackup represents report settings backup data
-type ReportsBackup struct {
-	Settings *models.ReportChatSettings `json:"settings,omitempty"`
-}
+type ReportsBackup = SettingBackup[models.ReportChatSettings]
 
 // RulesBackup represents rules backup data
-type RulesBackup struct {
-	Settings *models.RulesSettings `json:"settings,omitempty"`
-}
+type RulesBackup = SettingBackup[models.RulesSettings]
 
 // WarnsBackup represents warning settings backup data
 type WarnsBackup struct {
@@ -237,9 +228,7 @@ type WarnsBackup struct {
 }
 
 // AntiraidBackup represents anti-raid settings backup data
-type AntiraidBackup struct {
-	Settings *models.AntiRaidSettings `json:"settings,omitempty"`
-}
+type AntiraidBackup = SettingBackup[models.AntiRaidSettings]
 
 // ApprovalsBackup represents approved users backup data
 type ApprovalsBackup struct {
@@ -257,6 +246,4 @@ type FederationsBackup struct {
 }
 
 // LogChannelsBackup stores the group's log-channel binding and categories.
-type LogChannelsBackup struct {
-	Settings *models.LogChannel `json:"settings,omitempty"`
-}
+type LogChannelsBackup = SettingBackup[models.LogChannel]

--- a/alita/db/cache/ttl.go
+++ b/alita/db/cache/ttl.go
@@ -2,24 +2,30 @@ package cache
 
 import "time"
 
-// TTL constants for cache entries. Each domain uses its own TTL to balance
-// freshness vs DB load. Warn settings (30m) are separate from language (1h).
+// TTL constants for cache entries. Most domains share DefaultCacheTTL (30m);
+// language uses LangCacheTTL (1h). Per-domain aliases remain for call-site
+// clarity and grep-ability.
 const (
-	CacheTTLChatSettings    = 30 * time.Minute
-	CacheTTLLanguage        = 1 * time.Hour
-	CacheTTLFilterList      = 30 * time.Minute
-	CacheTTLBlacklist       = 30 * time.Minute
-	CacheTTLGreetings       = 30 * time.Minute
-	CacheTTLNotesList       = 30 * time.Minute
-	CacheTTLNotesSettings   = 30 * time.Minute
-	CacheTTLWarnSettings    = 30 * time.Minute
-	CacheTTLAntiflood       = 30 * time.Minute
-	CacheTTLDisabledCmds    = 30 * time.Minute
-	CacheTTLCaptchaSettings = 30 * time.Minute
-	CacheTTLApprovals       = 30 * time.Minute
-	CacheTTLAntiRaid        = 30 * time.Minute
-	CacheTTLChannels        = 30 * time.Minute
-	CacheTTLReactions       = 30 * time.Minute
-	CacheTTLFederation      = 30 * time.Minute
-	CacheTTLLogChannel      = 30 * time.Minute
+	DefaultCacheTTL = 30 * time.Minute
+	LangCacheTTL    = 1 * time.Hour
+)
+
+const (
+	CacheTTLChatSettings    = DefaultCacheTTL
+	CacheTTLLanguage        = LangCacheTTL
+	CacheTTLFilterList      = DefaultCacheTTL
+	CacheTTLBlacklist       = DefaultCacheTTL
+	CacheTTLGreetings       = DefaultCacheTTL
+	CacheTTLNotesList       = DefaultCacheTTL
+	CacheTTLNotesSettings   = DefaultCacheTTL
+	CacheTTLWarnSettings    = DefaultCacheTTL
+	CacheTTLAntiflood       = DefaultCacheTTL
+	CacheTTLDisabledCmds    = DefaultCacheTTL
+	CacheTTLCaptchaSettings = DefaultCacheTTL
+	CacheTTLApprovals       = DefaultCacheTTL
+	CacheTTLAntiRaid        = DefaultCacheTTL
+	CacheTTLChannels        = DefaultCacheTTL
+	CacheTTLReactions       = DefaultCacheTTL
+	CacheTTLFederation      = DefaultCacheTTL
+	CacheTTLLogChannel      = DefaultCacheTTL
 )

--- a/alita/db/db.go
+++ b/alita/db/db.go
@@ -58,21 +58,26 @@ func getSpanAttributes(model any) []attribute.KeyValue {
 	return attrs
 }
 
-// CreateRecord creates a new database record using the provided model.
-func CreateRecord(model any) error {
-	ctx := context.Background()
-	ctx, span := tracing.StartSpan(ctx, "db.create",
+// withSpan starts a traced span for a DB operation and runs fn inside it.
+func withSpan(ctx context.Context, op string, model any, fn func(ctx context.Context, span trace.Span) error) error {
+	ctx, span := tracing.StartSpan(ctx, op,
 		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
 	defer span.End()
+	return fn(ctx, span)
+}
 
-	result := DB.WithContext(ctx).Create(model)
-	if result.Error != nil {
-		log.Errorf("[Database][CreateRecord]: %v", result.Error)
-		span.SetStatus(codes.Error, result.Error.Error())
-		return result.Error
-	}
-	span.SetAttributes(attribute.Int64("db.rows_affected", result.RowsAffected))
-	return nil
+// CreateRecord creates a new database record using the provided model.
+func CreateRecord(model any) error {
+	return withSpan(context.Background(), "db.create", model, func(ctx context.Context, span trace.Span) error {
+		result := DB.WithContext(ctx).Create(model)
+		if result.Error != nil {
+			log.Errorf("[Database][CreateRecord]: %v", result.Error)
+			span.SetStatus(codes.Error, result.Error.Error())
+			return result.Error
+		}
+		span.SetAttributes(attribute.Int64("db.rows_affected", result.RowsAffected))
+		return nil
+	})
 }
 
 // UpdateRecord updates an existing database record with the provided updates.
@@ -107,23 +112,20 @@ func updateRecordInternal(ctx context.Context, model any, where any, updates any
 
 // GetRecord retrieves a single database record matching the where clause.
 func GetRecord(model any, where any) error {
-	ctx := context.Background()
-	ctx, span := tracing.StartSpan(ctx, "db.get",
-		trace.WithAttributes(append(getSpanAttributes(model), tracing.WorkingModeAttribute())...))
-	defer span.End()
-
-	result := DB.WithContext(ctx).Where(where).First(model)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			span.SetAttributes(attribute.Bool("db.record_found", false))
+	return withSpan(context.Background(), "db.get", model, func(ctx context.Context, span trace.Span) error {
+		result := DB.WithContext(ctx).Where(where).First(model)
+		if result.Error != nil {
+			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+				span.SetAttributes(attribute.Bool("db.record_found", false))
+				return result.Error
+			}
+			log.Errorf("[Database][GetRecord]: %v", result.Error)
+			span.SetStatus(codes.Error, result.Error.Error())
 			return result.Error
 		}
-		log.Errorf("[Database][GetRecord]: %v", result.Error)
-		span.SetStatus(codes.Error, result.Error.Error())
-		return result.Error
-	}
-	span.SetAttributes(attribute.Bool("db.record_found", true))
-	return nil
+		span.SetAttributes(attribute.Bool("db.record_found", true))
+		return nil
+	})
 }
 
 // ChatExists checks if a chat with the given ID exists in the database.
@@ -159,17 +161,14 @@ func TableRowCount(tableName string) int64 {
 
 // GetRecords retrieves multiple database records matching the where clause.
 func GetRecords(models any, where any) error {
-	ctx := context.Background()
-	ctx, span := tracing.StartSpan(ctx, "db.find",
-		trace.WithAttributes(append(getSpanAttributes(models), tracing.WorkingModeAttribute())...))
-	defer span.End()
-
-	result := DB.WithContext(ctx).Where(where).Find(models)
-	if result.Error != nil {
-		log.Errorf("[Database][GetRecords]: %v", result.Error)
-		span.SetStatus(codes.Error, result.Error.Error())
-		return result.Error
-	}
-	span.SetAttributes(attribute.Int64("db.rows_affected", result.RowsAffected))
-	return nil
+	return withSpan(context.Background(), "db.find", models, func(ctx context.Context, span trace.Span) error {
+		result := DB.WithContext(ctx).Where(where).Find(models)
+		if result.Error != nil {
+			log.Errorf("[Database][GetRecords]: %v", result.Error)
+			span.SetStatus(codes.Error, result.Error.Error())
+			return result.Error
+		}
+		span.SetAttributes(attribute.Int64("db.rows_affected", result.RowsAffected))
+		return nil
+	})
 }

--- a/alita/db/devs/repository.go
+++ b/alita/db/devs/repository.go
@@ -3,10 +3,11 @@ package devs
 import (
 	"errors"
 	"fmt"
-	"runtime"
-
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/divkix/Alita_Robot/alita/config"
 	"github.com/divkix/Alita_Robot/alita/db"
@@ -25,8 +26,36 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db/reports"
 	"github.com/divkix/Alita_Robot/alita/db/rules"
 	"github.com/divkix/Alita_Robot/alita/db/user"
-	"github.com/dustin/go-humanize"
 )
+
+// comma formats an int64 with thousands separators (e.g. 1234567 -> "1,234,567").
+func comma(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	neg := ""
+	if strings.HasPrefix(s, "-") {
+		neg, s = "-", s[1:]
+	}
+	if len(s) <= 3 {
+		return neg + s
+	}
+	// ponytail: simple grouping, fast enough for /stats rendering
+	var b strings.Builder
+	b.WriteString(neg)
+	rem := len(s) % 3
+	if rem > 0 {
+		b.WriteString(s[:rem])
+		if len(s) > rem {
+			b.WriteByte(',')
+		}
+	}
+	for i := rem; i < len(s); i += 3 {
+		b.WriteString(s[i : i+3])
+		if i+3 < len(s) {
+			b.WriteByte(',')
+		}
+	}
+	return b.String()
+}
 
 // GetTeamMemInfo retrieves developer settings for a user.
 // Returns default settings (not a dev) if not found or on error.
@@ -184,70 +213,70 @@ func LoadAllStats() string {
 	result := "<u>Alita's Stats:</u>" +
 		fmt.Sprintf("\n\n<b>Deployment Mode:</b> %s%s", deploymentMode, webhookInfo) +
 		fmt.Sprintf("\n<b>Go Version:</b> %s", runtime.Version()) +
-		fmt.Sprintf("\n<b>Goroutines:</b> %s", humanize.Comma(int64(runtime.NumGoroutine()))) +
-		fmt.Sprintf("\n<b>Antiflood:</b> enabled in %s chats", humanize.Comma(antiCount)) +
+		fmt.Sprintf("\n<b>Goroutines:</b> %s", comma(int64(runtime.NumGoroutine()))) +
+		fmt.Sprintf("\n<b>Antiflood:</b> enabled in %s chats", comma(antiCount)) +
 		fmt.Sprintf(
 			"\n<b>Users:</b> %s users found in %s active Chats (%s Inactive, %s Total)",
-			humanize.Comma(totalUsers),
-			humanize.Comma(int64(activeChats)),
-			humanize.Comma(int64(inactiveChats)),
-			humanize.Comma(int64(activeChats+inactiveChats)),
+			comma(totalUsers),
+			comma(int64(activeChats)),
+			comma(int64(inactiveChats)),
+			comma(int64(activeChats+inactiveChats)),
 		) +
 		"\n<b>Group Activity Metrics:</b>" +
-		fmt.Sprintf("\n    <b>Daily Active Groups (DAG):</b> %s", humanize.Comma(dag)) +
-		fmt.Sprintf("\n    <b>Weekly Active Groups (WAG):</b> %s", humanize.Comma(wag)) +
-		fmt.Sprintf("\n    <b>Monthly Active Groups (MAG):</b> %s", humanize.Comma(mag)) +
+		fmt.Sprintf("\n    <b>Daily Active Groups (DAG):</b> %s", comma(dag)) +
+		fmt.Sprintf("\n    <b>Weekly Active Groups (WAG):</b> %s", comma(wag)) +
+		fmt.Sprintf("\n    <b>Monthly Active Groups (MAG):</b> %s", comma(mag)) +
 		"\n<b>User Activity Metrics:</b>" +
-		fmt.Sprintf("\n    <b>Daily Active Users (DAU):</b> %s", humanize.Comma(dau)) +
-		fmt.Sprintf("\n    <b>Weekly Active Users (WAU):</b> %s", humanize.Comma(wau)) +
-		fmt.Sprintf("\n    <b>Monthly Active Users (MAU):</b> %s", humanize.Comma(mau)) +
+		fmt.Sprintf("\n    <b>Daily Active Users (DAU):</b> %s", comma(dau)) +
+		fmt.Sprintf("\n    <b>Weekly Active Users (WAU):</b> %s", comma(wau)) +
+		fmt.Sprintf("\n    <b>Monthly Active Users (MAU):</b> %s", comma(mau)) +
 		"\n<b>Pins:</b>" +
-		fmt.Sprintf("\n    <b>CleanLinked Enabled:</b> %s", humanize.Comma(ClCount)) +
-		fmt.Sprintf("\n    <b>AntiChannelPin Enabled:</b> %s", humanize.Comma(AcCount)) +
+		fmt.Sprintf("\n    <b>CleanLinked Enabled:</b> %s", comma(ClCount)) +
+		fmt.Sprintf("\n    <b>AntiChannelPin Enabled:</b> %s", comma(AcCount)) +
 		fmt.Sprintf(
 			"\n<b>Reports:</b> %s users enabled reports in %s Chats",
-			humanize.Comma(uRCount),
-			humanize.Comma(gRCount),
+			comma(uRCount),
+			comma(gRCount),
 		) +
 		"\n<b>Rules:</b>" +
-		fmt.Sprintf("\n    <b>Set:</b> %s", humanize.Comma(setRules)) +
-		fmt.Sprintf("\n    <b>Private:</b> %s", humanize.Comma(pvtRules)) +
+		fmt.Sprintf("\n    <b>Set:</b> %s", comma(setRules)) +
+		fmt.Sprintf("\n    <b>Private:</b> %s", comma(pvtRules)) +
 		fmt.Sprintf(
 			"\n<b>Blacklists:</b> %s triggers in %s chats",
-			humanize.Comma(blacklistTriggers),
-			humanize.Comma(blacklistChats),
+			comma(blacklistTriggers),
+			comma(blacklistChats),
 		) +
 		"\n<b>Connections:</b>" +
-		fmt.Sprintf("\n    %s users connected to chats", humanize.Comma(connectedUsers)) +
-		fmt.Sprintf("\n    %s chats allow user connections", humanize.Comma(connectedChats)) +
+		fmt.Sprintf("\n    %s users connected to chats", comma(connectedUsers)) +
+		fmt.Sprintf("\n    %s chats allow user connections", comma(connectedChats)) +
 		fmt.Sprintf(
 			"\n<b>Disabling:</b> %s commands disabled in %s chats",
-			humanize.Comma(disabledCmds),
-			humanize.Comma(disableEnabledChats),
+			comma(disabledCmds),
+			comma(disableEnabledChats),
 		) +
 		fmt.Sprintf(
 			"\n<b>Filters:</b> %s filters saved in %s chats",
-			humanize.Comma(filtersNum),
-			humanize.Comma(filtersChats),
+			comma(filtersNum),
+			comma(filtersChats),
 		) +
 		"\n<b>Greetings:</b>" +
-		fmt.Sprintf("\n    <b>Welcome Enabled:</b> %s", humanize.Comma(enabledWelcome)) +
-		fmt.Sprintf("\n    <b>Goodbye Enabled:</b> %s", humanize.Comma(enabledGoodbye)) +
-		fmt.Sprintf("\n    <b>CleanService:</b> %s", humanize.Comma(cleanServiceEnabled)) +
-		fmt.Sprintf("\n    <b>CleanWelcome:</b> %s", humanize.Comma(cleanWelcomeEnabled)) +
-		fmt.Sprintf("\n    <b>CleanGoodbye:</b> %s", humanize.Comma(cleanGoodbyeEnabled)) +
+		fmt.Sprintf("\n    <b>Welcome Enabled:</b> %s", comma(enabledWelcome)) +
+		fmt.Sprintf("\n    <b>Goodbye Enabled:</b> %s", comma(enabledGoodbye)) +
+		fmt.Sprintf("\n    <b>CleanService:</b> %s", comma(cleanServiceEnabled)) +
+		fmt.Sprintf("\n    <b>CleanWelcome:</b> %s", comma(cleanWelcomeEnabled)) +
+		fmt.Sprintf("\n    <b>CleanGoodbye:</b> %s", comma(cleanGoodbyeEnabled)) +
 		fmt.Sprintf(
 			"\n<b>Notes:</b> %s notes saved in %s chats",
-			humanize.Comma(notesNum),
-			humanize.Comma(notesChats),
+			comma(notesNum),
+			comma(notesChats),
 		) +
 		"\n<b>Federations:</b>" +
-		fmt.Sprintf("\n    <b>Total:</b> %s", humanize.Comma(fedCount)) +
-		fmt.Sprintf("\n    <b>Chats:</b> %s", humanize.Comma(fedChats)) +
-		fmt.Sprintf("\n    <b>Admins:</b> %s", humanize.Comma(fedAdmins)) +
-		fmt.Sprintf("\n    <b>Bans:</b> %s", humanize.Comma(fedBans)) +
-		fmt.Sprintf("\n    <b>Subscriptions:</b> %s", humanize.Comma(fedSubs)) +
-		fmt.Sprintf("\n<b>Channels Stored</b>: %s", humanize.Comma(numChannels))
+		fmt.Sprintf("\n    <b>Total:</b> %s", comma(fedCount)) +
+		fmt.Sprintf("\n    <b>Chats:</b> %s", comma(fedChats)) +
+		fmt.Sprintf("\n    <b>Admins:</b> %s", comma(fedAdmins)) +
+		fmt.Sprintf("\n    <b>Bans:</b> %s", comma(fedBans)) +
+		fmt.Sprintf("\n    <b>Subscriptions:</b> %s", comma(fedSubs)) +
+		fmt.Sprintf("\n<b>Channels Stored</b>: %s", comma(numChannels))
 
 	return result
 }

--- a/alita/db/devs/repository_test.go
+++ b/alita/db/devs/repository_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dustin/go-humanize"
-
 	"github.com/divkix/Alita_Robot/alita/db"
 	"github.com/divkix/Alita_Robot/alita/db/federations"
 	"github.com/divkix/Alita_Robot/alita/db/models"
@@ -318,11 +316,11 @@ func TestLoadAllStats_IncludesFederationCounts(t *testing.T) {
 	}
 
 	want := []string{
-		fmt.Sprintf("<b>Total:</b> %s", humanize.Comma(feds)),
-		fmt.Sprintf("<b>Chats:</b> %s", humanize.Comma(fedChats)),
-		fmt.Sprintf("<b>Admins:</b> %s", humanize.Comma(admins)),
-		fmt.Sprintf("<b>Bans:</b> %s", humanize.Comma(bans)),
-		fmt.Sprintf("<b>Subscriptions:</b> %s", humanize.Comma(subs)),
+		fmt.Sprintf("<b>Total:</b> %s", comma(feds)),
+		fmt.Sprintf("<b>Chats:</b> %s", comma(fedChats)),
+		fmt.Sprintf("<b>Admins:</b> %s", comma(admins)),
+		fmt.Sprintf("<b>Bans:</b> %s", comma(bans)),
+		fmt.Sprintf("<b>Subscriptions:</b> %s", comma(subs)),
 	}
 	for _, line := range want {
 		if !strings.Contains(section, line) {

--- a/alita/modules/antiraid.go
+++ b/alita/modules/antiraid.go
@@ -857,8 +857,7 @@ func (a *antiRaidStruct) callbackHandler(bot *gotgbot.Bot, ctx *ext.Context) err
 		_, _ = bot.AnswerCallbackQuery(query.Id, &gotgbot.AnswerCallbackQueryOpts{Text: text})
 		_, _, _ = msg.EditText(bot, &gotgbot.EditMessageTextOpts{Text: formatting.ToTelegramHTML(text), ParseMode: formatting.HTML})
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = bot.AnswerCallbackQuery(query.Id, &gotgbot.AnswerCallbackQueryOpts{Text: text})
+		return answerInvalidCallback(bot, ctx, query)
 	}
 
 	return ext.EndGroups

--- a/alita/modules/approvals.go
+++ b/alita/modules/approvals.go
@@ -493,9 +493,7 @@ func (m moduleStruct) unapproveAllCallback(b *gotgbot.Bot, ctx *ext.Context) err
 	}
 	if action == "" {
 		log.Warnf("[Approvals] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	var helpText string

--- a/alita/modules/backup.go
+++ b/alita/modules/backup.go
@@ -592,9 +592,7 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 	chat := ctx.EffectiveChat
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if chat == nil {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	// Only creator can confirm import/reset
@@ -610,9 +608,7 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 	// Decode callback data
 	decoded, ok := decodeCallbackData(query.Data, "backup")
 	if !ok {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	action, _ := decoded.Field("a")
@@ -624,9 +620,7 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 		action == backupActionConfirmReset ||
 		action == backupActionCancelReset
 	if err != nil || chatID != chat.Id || token == "" || !validAction {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	switch action {

--- a/alita/modules/bans.go
+++ b/alita/modules/bans.go
@@ -43,43 +43,8 @@ func (m moduleStruct) dkick(b *gotgbot.Bot, ctx *ext.Context) error {
 // kickTargetValidation validates the target for kick commands.
 // Checks: user in chat, not ban-protected, not the bot itself.
 func kickTargetValidation(c *moderationCtx, t *target) error {
-	if !chat_status.IsUserInChat(c.Bot, c.Chat, t.userID) {
-		text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_kick_user_not_in_chat")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_user_not_in_chat")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errUserNotInChat
-	}
-	if chat_status.IsUserBanProtected(c.Bot, c.Ctx, nil, t.userID) {
-		text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_kick_cannot_kick_admin")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_admin")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errAdminTarget
-	}
-	if t.userID == c.Bot.Id {
-		text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_kick_is_bot_itself")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_self")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errTargetIsBot
-	}
-	return nil
+	prefix := strings.ToLower(c.Module.moduleName)
+	return validateTarget(c, t.userID, true, prefix+"_kick_user_not_in_chat", prefix+"_kick_cannot_kick_admin", prefix+"_kick_is_bot_itself")
 }
 
 // kickReply builds and sends the success reply for kick commands.
@@ -112,31 +77,8 @@ func kickReply(c *moderationCtx, t *target) error {
 // banTargetValidation validates the target for ban commands.
 // Checks: not ban-protected, not the bot itself.
 func banTargetValidation(c *moderationCtx, t *target) error {
-	if chat_status.IsUserBanProtected(c.Bot, c.Ctx, nil, t.userID) {
-		text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_ban_is_admin")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_admin")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errAdminTarget
-	}
-	if t.userID == c.Bot.Id {
-		text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_ban_is_bot_itself")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_self")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errTargetIsBot
-	}
-	return nil
+	prefix := strings.ToLower(c.Module.moduleName)
+	return validateTarget(c, t.userID, false, "", prefix+"_ban_is_admin", prefix+"_ban_is_bot_itself")
 }
 
 // moderationDkick is the shared moderationCommand definition for /dkick.
@@ -168,12 +110,10 @@ func moderationTban(m *moduleStruct) *moderationCommand {
 		extract:  extractFromArgs,
 		validate: banTargetValidation,
 		execute: func(c *moderationCtx, t *target) error {
-			_time, timeVal, reason := extraction.ExtractTime(c.Bot, c.Ctx, t.reason)
+			_time := extractTemporalTarget(c, t)
 			if _time == -1 {
 				return ext.EndGroups
 			}
-			t.timeVal = timeVal
-			t.reason = reason
 			_, err := c.Chat.BanMember(c.Bot, t.userID, &gotgbot.BanChatMemberOpts{UntilDate: _time})
 			return err
 		},
@@ -675,10 +615,7 @@ func (moduleStruct) restrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) erro
 		return ext.EndGroups
 	}
 	if query.Message == nil {
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	chat := ctx.EffectiveChat
 	user := chat_status.RequireUser(b, ctx)
@@ -896,9 +833,7 @@ func (moduleStruct) unrestrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) er
 	msg := query.Message
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if msg == nil {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	// permissions check
@@ -1148,9 +1083,7 @@ func (m moduleStruct) unbanAllCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 		action, _ = decoded.Field("a")
 	}
 	if action == "" {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	if (action == "yes" || action == "no") && query.Message == nil {
 		text, _ := tr.GetString("common_callback_message_unavailable")

--- a/alita/modules/blacklists.go
+++ b/alita/modules/blacklists.go
@@ -461,10 +461,7 @@ func (m moduleStruct) buttonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	if creatorAction == "" {
 		log.Warnf("[Blacklists] Invalid callback data format: %s", query.Data)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var helpText string
 
@@ -483,9 +480,7 @@ func (m moduleStruct) buttonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	case "no":
 		helpText, _ = tr.GetString(strings.ToLower(m.moduleName) + "_rm_all_bl_button_handler_no")
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	_, _, err := query.Message.EditText(b, &gotgbot.EditMessageTextOpts{Text: helpText, ParseMode: formatting.HTML})

--- a/alita/modules/bot_updates.go
+++ b/alita/modules/bot_updates.go
@@ -121,9 +121,7 @@ func verifyAnonymousAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 	qmsg := query.Message
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if qmsg == nil {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	chatIDRaw := ""
@@ -134,23 +132,17 @@ func verifyAnonymousAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	if chatIDRaw == "" || msgIDRaw == "" {
 		log.Warnf("[BotUpdates] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	chatId, err := strconv.ParseInt(chatIDRaw, 10, 64)
 	if err != nil {
 		log.Warnf("[BotUpdates] Invalid callback chat ID: %s (%s)", query.Data, chatIDRaw)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	msgId, err := strconv.ParseInt(msgIDRaw, 10, 64)
 	if err != nil {
 		log.Warnf("[BotUpdates] Invalid callback message ID: %s (%s)", query.Data, msgIDRaw)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	// if non-admins try to press it

--- a/alita/modules/callback_codec.go
+++ b/alita/modules/callback_codec.go
@@ -1,8 +1,13 @@
 package modules
 
 import (
+	"slices"
 	"strings"
 
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/divkix/Alita_Robot/alita/db/lang"
+	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/callbackcodec"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,12 +25,8 @@ func encodeCallbackData(namespace string, fields map[string]string) string {
 }
 
 func mustCallbackData(namespace string, fields map[string]string) (string, bool) {
-	data, err := callbackcodec.Encode(namespace, fields)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"namespace": namespace,
-			"error":     err,
-		}).Warn("[CallbackCodec] Failed to encode callback data")
+	data := encodeCallbackData(namespace, fields)
+	if data == "" {
 		return "", false
 	}
 	return data, true
@@ -39,10 +40,19 @@ func decodeCallbackData(data string, expectedNamespaces ...string) (*callbackcod
 	if len(expectedNamespaces) == 0 {
 		return decoded, true
 	}
-	for _, expected := range expectedNamespaces {
-		if strings.EqualFold(decoded.Namespace, expected) {
-			return decoded, true
-		}
+	if slices.ContainsFunc(expectedNamespaces, func(expected string) bool {
+		return strings.EqualFold(decoded.Namespace, expected)
+	}) {
+		return decoded, true
 	}
 	return nil, false
+}
+
+// answerInvalidCallback answers a malformed callback with the shared
+// "invalid request" string and ends group dispatch.
+func answerInvalidCallback(b *gotgbot.Bot, ctx *ext.Context, query *gotgbot.CallbackQuery) error {
+	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
+	text, _ := tr.GetString("common_callback_invalid_request")
+	_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
+	return ext.EndGroups
 }

--- a/alita/modules/connections.go
+++ b/alita/modules/connections.go
@@ -215,9 +215,7 @@ func (m moduleStruct) connectionButtons(b *gotgbot.Bot, ctx *ext.Context) error 
 	msg := query.Message
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if msg == nil {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	userType := ""
@@ -228,9 +226,7 @@ func (m moduleStruct) connectionButtons(b *gotgbot.Bot, ctx *ext.Context) error 
 	case "Admin", "User", "Main":
 	default:
 		log.Warnf("[Connections] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	backText, _ := tr.GetString("button_back")

--- a/alita/modules/filters.go
+++ b/alita/modules/filters.go
@@ -455,10 +455,7 @@ func (moduleStruct) filtersButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	}
 	if response == "" {
 		log.Warnf("[Filters] Invalid callback data format: %s", query.Data)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var helpText string
 
@@ -475,9 +472,7 @@ func (moduleStruct) filtersButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	case "no":
 		helpText, _ = tr.GetString("filters_clear_all_cancelled")
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if query.Message == nil {
@@ -532,9 +527,7 @@ func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) e
 	}
 	if action != "yes" && action != "cancel" {
 		log.WithField("action", action).Warn("[Filters] Invalid overwrite action")
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var helpText string
 

--- a/alita/modules/formatting.go
+++ b/alita/modules/formatting.go
@@ -149,10 +149,7 @@ func (m moduleStruct) formattingHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 	}
 	msg := query.Message
 	if msg == nil {
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
@@ -162,16 +159,12 @@ func (m moduleStruct) formattingHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 	}
 	if module == "" {
 		log.Warnf("[Formatting] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	switch module {
 	case "md_formatting", "fillings", "random":
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	backText, _ := tr.GetString("common_back")

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -1032,25 +1032,16 @@ func (m moduleStruct) joinRequestHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	}
 	if response == "" || joinUserIDRaw == "" {
 		log.Warnf("[Greetings] Invalid callback data format: %s", query.Data)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	if response != "accept" && response != "decline" && response != "ban" {
 		log.Warnf("[Greetings] Invalid join request action: %s", response)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	joinUserId, err := strconv.ParseInt(joinUserIDRaw, 10, 64)
 	if err != nil {
 		log.Errorf("[Greetings] Failed to parse join user ID '%s': %v", joinUserIDRaw, err)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if response == "ban" {

--- a/alita/modules/help.go
+++ b/alita/modules/help.go
@@ -178,9 +178,7 @@ func (moduleStruct) about(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	if query, ok := callbackQueryFromContext(ctx); ok {
 		if query.Message == nil {
-			text, _ := tr.GetString("common_callback_invalid_request")
-			_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-			return ext.EndGroups
+			return answerInvalidCallback(b, ctx, query)
 		}
 		response := ""
 		if decoded, ok := decodeCallbackData(query.Data, "about"); ok {
@@ -211,9 +209,7 @@ func (moduleStruct) about(b *gotgbot.Bot, ctx *ext.Context) error {
 				},
 			}
 		default:
-			text, _ := tr.GetString("common_callback_invalid_request")
-			_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-			return ext.EndGroups
+			return answerInvalidCallback(b, ctx, query)
 		}
 		_, _, err := query.Message.EditText(b, &gotgbot.EditMessageTextOpts{Text: currText, ReplyMarkup: currKb,
 			LinkPreviewOptions: &gotgbot.LinkPreviewOptions{
@@ -294,10 +290,7 @@ func (moduleStruct) helpButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 	if query.Message == nil {
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	module := ""
 	if decoded, ok := decodeCallbackData(query.Data, "helpq"); ok {
@@ -446,10 +439,7 @@ func (moduleStruct) botConfig(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	msg := query.Message
 	if msg == nil {
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	// just in case
@@ -525,9 +515,7 @@ func (moduleStruct) botConfig(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		text, _ = tr.GetString("help_configuration_step-3")
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	_, _, err := msg.EditText(b, &gotgbot.EditMessageTextOpts{Text: text, ParseMode: formatting.HTML,
 		LinkPreviewOptions: &gotgbot.LinkPreviewOptions{

--- a/alita/modules/help_system.go
+++ b/alita/modules/help_system.go
@@ -11,9 +11,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db/lang"
 	"github.com/divkix/Alita_Robot/alita/i18n"
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // markup is the global help menu keyboard.
@@ -57,7 +54,10 @@ func initHelpButtonsFrom(registry *moduleStruct) gotgbot.InlineKeyboardMarkup {
 
 // getModuleHelpAndKb retrieves help text and keyboard for a specific module.
 func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText string, replyMarkup gotgbot.InlineKeyboardMarkup) {
-	ModName := cases.Title(language.English).String(module)
+	ModName := module
+	if ModName != "" {
+		ModName = strings.ToUpper(ModName[:1]) + ModName[1:]
+	}
 	tr := i18n.MustNewTranslator(lang)
 	helpMsg, _ := tr.GetString(fmt.Sprintf("%s_help_msg", strings.ToLower(ModName)))
 	headerTemplate, _ := tr.GetString("helpers_module_help_header")

--- a/alita/modules/language.go
+++ b/alita/modules/language.go
@@ -95,10 +95,7 @@ func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := query.From
 	if chat == nil || user.Id == 0 {
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	language := ""

--- a/alita/modules/moderation.go
+++ b/alita/modules/moderation.go
@@ -271,3 +271,64 @@ var (
 	errAdminTarget   = fmt.Errorf("target is a protected admin")
 	errTargetIsBot   = fmt.Errorf("target is the bot itself")
 )
+
+// replyValidationError sends a validation failure reply, logging send errors.
+func replyValidationError(c *moderationCtx, text string) error {
+	_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	return nil
+}
+
+// validateTarget runs the shared target checks: optional in-chat membership,
+// admin-protection, and bot-self. Each key falls back to the shared common_*
+// string when the module-specific key is empty. Returns the sentinel for the
+// first failing check, nil when the target is actionable.
+func validateTarget(c *moderationCtx, userID int64, checkInChat bool, notInChatKey, adminKey, selfKey string) error {
+	if checkInChat && !chat_status.IsUserInChat(c.Bot, c.Chat, userID) {
+		text, _ := c.Tr.GetString(notInChatKey)
+		if text == "" {
+			text, _ = c.Tr.GetString("common_user_not_in_chat")
+		}
+		if err := replyValidationError(c, text); err != nil {
+			return err
+		}
+		return errUserNotInChat
+	}
+	if chat_status.IsUserBanProtected(c.Bot, c.Ctx, nil, userID) {
+		text, _ := c.Tr.GetString(adminKey)
+		if text == "" {
+			text, _ = c.Tr.GetString("common_cannot_target_admin")
+		}
+		if err := replyValidationError(c, text); err != nil {
+			return err
+		}
+		return errAdminTarget
+	}
+	if userID == c.Bot.Id {
+		text, _ := c.Tr.GetString(selfKey)
+		if text == "" {
+			text, _ = c.Tr.GetString("common_cannot_target_self")
+		}
+		if err := replyValidationError(c, text); err != nil {
+			return err
+		}
+		return errTargetIsBot
+	}
+	return nil
+}
+
+// extractTemporalTarget parses the duration from the target reason via
+// ExtractTime, storing the normalized timeVal/reason back on the target.
+// Returns the Telegram until_date, or -1 when extraction already replied.
+func extractTemporalTarget(c *moderationCtx, t *target) int64 {
+	_time, timeVal, reason := extraction.ExtractTime(c.Bot, c.Ctx, t.reason)
+	if _time == -1 {
+		return -1
+	}
+	t.timeVal = timeVal
+	t.reason = reason
+	return _time
+}

--- a/alita/modules/mute.go
+++ b/alita/modules/mute.go
@@ -19,40 +19,7 @@ var mutesModule = moduleStruct{moduleName: "Mutes"}
 // muteTargetValidation validates the target for mute commands.
 // Checks: user is in chat, not ban-protected, not the bot itself.
 func muteTargetValidation(c *moderationCtx, t *target) error {
-	if !chat_status.IsUserInChat(c.Bot, c.Chat, t.userID) {
-		text, _ := c.Tr.GetString("common_user_not_in_chat")
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errUserNotInChat
-	}
-	if chat_status.IsUserBanProtected(c.Bot, c.Ctx, nil, t.userID) {
-		text, _ := c.Tr.GetString("mutes_mute_admin_error")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_admin")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errAdminTarget
-	}
-	if t.userID == c.Bot.Id {
-		text, _ := c.Tr.GetString("mutes_restrict_self_error")
-		if text == "" {
-			text, _ = c.Tr.GetString("common_cannot_target_self")
-		}
-		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-		return errTargetIsBot
-	}
-	return nil
+	return validateTarget(c, t.userID, true, "common_user_not_in_chat", "mutes_mute_admin_error", "mutes_restrict_self_error")
 }
 
 // muteReplyWithButton builds and sends the success reply for mute commands
@@ -130,12 +97,10 @@ func moderationTmute(m *moduleStruct) *moderationCommand {
 		extract:  extractFromArgs,
 		validate: muteTargetValidation,
 		execute: func(c *moderationCtx, t *target) error {
-			_time, timeVal, reason := extraction.ExtractTime(c.Bot, c.Ctx, t.reason)
+			_time := extractTemporalTarget(c, t)
 			if _time == -1 {
 				return ext.EndGroups
 			}
-			t.timeVal = timeVal
-			t.reason = reason
 			_, err := c.Chat.RestrictMember(c.Bot, t.userID, MutedPermissions,
 				&gotgbot.RestrictChatMemberOpts{UntilDate: _time},
 			)

--- a/alita/modules/notes.go
+++ b/alita/modules/notes.go
@@ -606,9 +606,7 @@ func (m moduleStruct) noteOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) err
 		}
 	default:
 		log.WithField("action", action).Warn("Unknown note overwrite action")
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if query.Message == nil {
@@ -659,10 +657,7 @@ func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	if response == "" {
 		log.Warnf("[Notes] Invalid callback data format: %s", query.Data)
-		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var helpText string
 
@@ -684,9 +679,7 @@ func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	case "no":
 		helpText, _ = tr.GetString("notes_clear_all_cancelled")
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if query.Message == nil {

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -125,11 +125,8 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	chat := ctx.EffectiveChat
 	user := query.From
-	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if user.Id == 0 {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	// Re-check permissions in callback to prevent non-admin users from executing
@@ -197,9 +194,7 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		_, _ = query.Answer(b, nil)
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	return ext.EndGroups
 }

--- a/alita/modules/reactions.go
+++ b/alita/modules/reactions.go
@@ -84,9 +84,7 @@ func (m moduleStruct) reactionsHelpHandler(b *gotgbot.Bot, ctx *ext.Context) err
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if action == "" {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	var helpText string
@@ -96,9 +94,7 @@ func (m moduleStruct) reactionsHelpHandler(b *gotgbot.Bot, ctx *ext.Context) err
 	case "remove":
 		helpText, _ = tr.GetString("reactions_remove_usage")
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if query.Message == nil {

--- a/alita/modules/registry.go
+++ b/alita/modules/registry.go
@@ -1,7 +1,7 @@
 package modules
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 	log "github.com/sirupsen/logrus"
@@ -35,10 +35,7 @@ func RegisterLegacyModule(name string, priority int, load func(*ext.Dispatcher))
 func LoadAllModules(dispatcher *ext.Dispatcher) {
 	mods := append([]registeredModule(nil), registry...)
 
-	sort.SliceStable(mods, func(i, j int) bool {
-		return mods[i].priority < mods[j].priority
-	})
-
+	slices.SortStableFunc(mods, func(a, b registeredModule) int { return a.priority - b.priority })
 	for _, m := range mods {
 		log.Debugf("Loading module: %s (priority=%d)", m.name, m.priority)
 		if m.load != nil {

--- a/alita/modules/reports.go
+++ b/alita/modules/reports.go
@@ -451,9 +451,7 @@ func (moduleStruct) markResolvedButtonHandler(b *gotgbot.Bot, ctx *ext.Context) 
 	msg := query.Message
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if msg == nil {
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var replyQuery, replyText string
 

--- a/alita/modules/warns.go
+++ b/alita/modules/warns.go
@@ -460,16 +460,12 @@ func (moduleStruct) rmWarnButton(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	if userMatch == "" {
 		log.Warnf("[Warns] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	userId, parseErr := strconv.ParseInt(userMatch, 10, 64)
 	if parseErr != nil {
 		log.Errorf("[Warns] Failed to parse user ID from callback: %v", parseErr)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var replyText string
 
@@ -711,9 +707,7 @@ func (moduleStruct) warnsButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	if response == "" {
 		log.Warnf("[Warns] Invalid callback data format: %s", query.Data)
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 	var helpText string
 
@@ -738,9 +732,7 @@ func (moduleStruct) warnsButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		helpText, _ = tr.GetString("warns_reset_all_cancelled")
 		replyText = helpText
 	default:
-		text, _ := tr.GetString("common_callback_invalid_request")
-		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: text})
-		return ext.EndGroups
+		return answerInvalidCallback(b, ctx, query)
 	}
 
 	if query.Message == nil {

--- a/alita/utils/content/content.go
+++ b/alita/utils/content/content.go
@@ -313,15 +313,15 @@ func ConvertButtonV2ToDbButton(buttons []tgmd2html.ButtonV2) (btns []db.Button) 
 // RevertButtons converts database button format back to markdown button string format.
 // Generates markdown buttonurl syntax for each button with proper same-line handling.
 func RevertButtons(buttons []db.Button) string {
-	res := ""
+	var sb strings.Builder
 	for _, btn := range buttons {
 		if btn.SameLine {
-			res += fmt.Sprintf("\n[%s](buttonurl://%s:same)", btn.Name, btn.Url)
+			fmt.Fprintf(&sb, "\n[%s](buttonurl://%s:same)", btn.Name, btn.Url)
 		} else {
-			res += fmt.Sprintf("\n[%s](buttonurl://%s)", btn.Name, btn.Url)
+			fmt.Fprintf(&sb, "\n[%s](buttonurl://%s)", btn.Name, btn.Url)
 		}
 	}
-	return res
+	return sb.String()
 }
 
 // inlineKeyboardToButtonV2 converts Telegram inline keyboard to markdown button format.

--- a/alita/utils/extraction/extraction.go
+++ b/alita/utils/extraction/extraction.go
@@ -53,8 +53,7 @@ func ExtractChat(b *gotgbot.Bot, ctx *ext.Context) *gotgbot.Chat {
 	msg := ctx.EffectiveMessage
 	args := ctx.Args()[1:]
 	if len(args) != 0 {
-		if _, err := strconv.ParseInt(args[0], 10, 64); err == nil {
-			chatId, _ := strconv.ParseInt(args[0], 10, 64)
+		if chatId, err := strconv.ParseInt(args[0], 10, 64); err == nil {
 			chat, err := b.GetChat(chatId, nil)
 			if err != nil {
 				tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))

--- a/alita/utils/formatting/formatting.go
+++ b/alita/utils/formatting/formatting.go
@@ -5,15 +5,15 @@ package formatting
 
 import (
 	"fmt"
+	"github.com/PaulSonOfLars/gotgbot/v2"
 	"html"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
-
-	"github.com/PaulSonOfLars/gotgbot/v2"
 
 	"github.com/divkix/Alita_Robot/alita/db"
 	"github.com/divkix/Alita_Robot/alita/db/rules"
@@ -150,11 +150,8 @@ func SplitMessage(msg string) []string {
 				smallMsg = ""
 				smallMsgRunes = 0
 			}
-			runes := []rune(line)
-			for len(runes) > 0 {
-				chunkSize := min(MaxMessageLength, len(runes))
-				result = append(result, string(runes[:chunkSize]))
-				runes = runes[chunkSize:]
+			for chunk := range slices.Chunk([]rune(line), MaxMessageLength) {
+				result = append(result, string(chunk))
 			}
 		} else {
 			if smallMsg != "" {

--- a/alita/utils/keyword_matcher/cache.go
+++ b/alita/utils/keyword_matcher/cache.go
@@ -1,6 +1,7 @@
 package keyword_matcher
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -30,14 +31,12 @@ func newCache(ttl time.Duration) *Cache {
 // Uses RWMutex for concurrent read access and only takes write lock when
 // creating a new matcher or when patterns have changed.
 func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatcher {
-	h := hashPatterns(patterns)
-
 	// Fast path: read-only check with RLock
 	c.mu.RLock()
 	matcher, exists := c.matchers[chatID]
 	if exists {
-		// O(1) hash comparison avoids copying patterns
-		if matcher.patternHash == h {
+		// ponytail: O(n) compare, patterns are typically tens per chat
+		if slices.Equal(matcher.patterns, patterns) {
 			c.mu.RUnlock()
 			c.touchLastUsed(chatID)
 			return matcher
@@ -50,7 +49,7 @@ func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatc
 
 	// Double-check after acquiring write lock
 	if matcher, exists := c.matchers[chatID]; exists {
-		if matcher.patternHash == h {
+		if slices.Equal(matcher.patterns, patterns) {
 			c.mu.Unlock()
 			c.touchLastUsed(chatID)
 			return matcher

--- a/alita/utils/keyword_matcher/cache_named_test.go
+++ b/alita/utils/keyword_matcher/cache_named_test.go
@@ -3,6 +3,7 @@
 package keyword_matcher
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -48,8 +49,8 @@ func TestNamedCachesDoNotCollide(t *testing.T) {
 		t.Error("filters and blacklists caches returned the same matcher pointer for the same chatID — namespacing is broken")
 	}
 
-	// Verify pattern hashes differ (the core fix: each cache keeps its own hash).
-	if mA1.patternHash == mB1.patternHash {
-		t.Errorf("expected different patternHash for different pattern sets; got same hash %x", mA1.patternHash)
+	// Verify stored patterns differ (each cache keeps its own patterns).
+	if slices.Equal(mA1.patterns, mB1.patterns) {
+		t.Errorf("expected different patterns for different pattern sets; got %v", mA1.patterns)
 	}
 }

--- a/alita/utils/keyword_matcher/matcher.go
+++ b/alita/utils/keyword_matcher/matcher.go
@@ -1,7 +1,6 @@
 package keyword_matcher
 
 import (
-	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
@@ -12,28 +11,16 @@ import (
 
 // KeywordMatcher provides efficient multi-pattern matching using Aho-Corasick algorithm
 type KeywordMatcher struct {
-	matcher     *ahocorasick.Matcher
-	patterns    []string
-	patternHash uint64
-	mu          sync.RWMutex
-	lastBuild   time.Time
-}
-
-// hashPatterns computes a hash of the pattern slice for fast comparison.
-func hashPatterns(patterns []string) uint64 {
-	h := fnv.New64a()
-	for _, p := range patterns {
-		_, _ = h.Write([]byte(p))
-		_, _ = h.Write([]byte{0}) // separator
-	}
-	return h.Sum64()
+	matcher   *ahocorasick.Matcher
+	patterns  []string
+	mu        sync.RWMutex
+	lastBuild time.Time
 }
 
 // newKeywordMatcher creates a keyword matcher with the given patterns.
 func newKeywordMatcher(patterns []string) *KeywordMatcher {
 	km := &KeywordMatcher{
-		patterns:    make([]string, len(patterns)),
-		patternHash: hashPatterns(patterns),
+		patterns: make([]string, len(patterns)),
 	}
 	copy(km.patterns, patterns)
 	km.build()
@@ -62,6 +49,7 @@ func (km *KeywordMatcher) build() {
 		"build_time":     time.Since(start),
 	}).Debug("Built Aho-Corasick matcher")
 }
+
 // FirstMatch returns the first pattern that matches the given text.
 // ahocorasick.Matcher.Match is not safe for concurrent use, so we hold an
 // exclusive lock across the Match call. ToLower is done outside the lock to

--- a/alita/utils/logredact/logredact.go
+++ b/alita/utils/logredact/logredact.go
@@ -24,7 +24,7 @@ package logredact
 
 import (
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -110,9 +110,7 @@ func RegisterSecret(values ...string) {
 
 	// Longest-first ensures we redact the most specific (largest) secret before
 	// any of its substrings.
-	sort.Slice(registry.secrets, func(i, j int) bool {
-		return len(registry.secrets[i]) > len(registry.secrets[j])
-	})
+	slices.SortFunc(registry.secrets, func(a, b string) int { return len(b) - len(a) })
 }
 
 // reset clears all registered secrets. It exists for tests.

--- a/alita/utils/media/sender.go
+++ b/alita/utils/media/sender.go
@@ -46,12 +46,6 @@ func resolveSendResult[T any](result T, err error, chatID int64, mediaType strin
 // Sentinel errors
 var ErrNoPermission = fmt.Errorf("bot lacks permission to send messages")
 
-// ParseMode constants
-const (
-	HTML = "HTML"
-	None = ""
-)
-
 // Content represents the media content to be sent.
 type Content struct {
 	Text    string // Text content or caption
@@ -83,9 +77,9 @@ func Send(b *gotgbot.Bot, content Content, opts Options) (*gotgbot.Message, erro
 	}
 
 	// Determine parse mode
-	parseMode := HTML
+	parseMode := formatting.HTML
 	if opts.NoFormat {
-		parseMode = None
+		parseMode = ""
 	}
 
 	// Build reply parameters if reply message ID is set
@@ -140,7 +134,7 @@ func sendText(b *gotgbot.Bot, content Content, opts Options, parseMode string, r
 func sendSticker(b *gotgbot.Bot, content Content, opts Options, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for STICKER '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
-		return sendText(b, content, opts, HTML, replyParams)
+		return sendText(b, content, opts, formatting.HTML, replyParams)
 	}
 	msg, err := b.SendSticker(opts.ChatID, gotgbot.InputFileByID(content.FileID), &gotgbot.SendStickerOpts{
 		ReplyParameters:     replyParams,
@@ -246,7 +240,7 @@ func sendVideo(b *gotgbot.Bot, content Content, opts Options, parseMode string, 
 func sendVideoNote(b *gotgbot.Bot, content Content, opts Options, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for VideoNote '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
-		return sendText(b, content, opts, HTML, replyParams)
+		return sendText(b, content, opts, formatting.HTML, replyParams)
 	}
 	msg, err := b.SendVideoNote(opts.ChatID, gotgbot.InputFileByID(content.FileID), &gotgbot.SendVideoNoteOpts{
 		ReplyParameters:     replyParams,


### PR DESCRIPTION
Safe behavior-preserving subset of #828 (whole-repo bloat audit).

**Did (-157 net: 501 del / 344 add, 36 files):**
- Phase 1: `answerInvalidCallback` helper (42 callback guards), moderation `validateTarget` + `extractTemporalTarget` (kick/ban/mute/tban/tmute), backup `withBackupTx` + generic `SettingBackup[T]` (9 single-setting modules)
- Phase 2: `db.withSpan`, `slices.SortStableFunc`, TTL `DefaultCacheTTL`/`LangCacheTTL` aliases, callback `must`-delegate + `slices.ContainsFunc`
- Phase 4 (safe 2/7 deps): `humanize.Comma` -> local `comma` (drops `dustin/go-humanize`), `cases.Title` -> upper-first (drops `golang.org/x/text`); stdlib `strings.Builder`, `slices.Chunk`, `slices.Equal` (drops FNV hash), single `ParseInt`, `formatting.HTML`
- No command renames, no reply-text changes, no permission-semantics changes, no migration edits, no locale-key changes.

**Verification:**
- `go vet -tags testtools ./alita/...` clean
- `go build ./...` ok
- `go test -tags testtools ./alita/...` all ok (incl. `alita/modules` 3.7s, `alita/db/backup`, `keyword_matcher`, `devs`)
- `make lint` fails pre-existing in this env: `file requires newer Go version go1.27 (application built with go1.26)`; `gofmt` clean on touched files.

**Deferred (kept existing code, per ground rules):** alias->`WrapCommand` conversions, gate-preamble pipeline moves (connection semantics), full backup 19-module registry table, twin registries/1-line delegate merges, Phase 3 dead config (env behavior), `migrate_psql.sh` thinning (ops path, needs maintainer), risky deps `gocache`/`ahocorasick`/`msgpack`/`uuid` (wire-format/perf, need benchmarks).

Closes #828 as safe-subset delivery; remainder tracked as follow-ups.