### PR TITLE
chore: strip restatement comments in alita/utils

### DIFF
--- a/alita/utils/actionlog/actionlog.go
+++ b/alita/utils/actionlog/actionlog.go
@@ -12,14 +12,11 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
-// Log sends htmlText to the chat's log channel when the category is enabled.
 // Failures are swallowed so logging never blocks a user-facing command.
 func Log(b *gotgbot.Bot, chat *gotgbot.Chat, category, htmlText string) {
 	if b == nil || chat == nil || htmlText == "" {
 		return
 	}
-	// Skip channel *chats* (broadcast channels). Supergroup IDs are also
-	// channel-shaped numerically, so do not use IsChannelId here.
 	if chat.Type == "channel" {
 		return
 	}
@@ -36,7 +33,6 @@ func Log(b *gotgbot.Bot, chat *gotgbot.Chat, category, htmlText string) {
 	}
 }
 
-// Admin logs a human admin action (ban/mute/kick/warn).
 func Admin(b *gotgbot.Bot, chat *gotgbot.Chat, actor *gotgbot.User, action string, targetID int64, reason string) {
 	if actor == nil {
 		return
@@ -53,7 +49,6 @@ func Admin(b *gotgbot.Bot, chat *gotgbot.Chat, actor *gotgbot.User, action strin
 	Log(b, chat, logchannels.CategoryAdmin, text)
 }
 
-// User logs a user-initiated action such as kickme.
 func User(b *gotgbot.Bot, chat *gotgbot.Chat, actor *gotgbot.User, action string) {
 	if actor == nil {
 		return
@@ -66,7 +61,6 @@ func User(b *gotgbot.Bot, chat *gotgbot.Chat, actor *gotgbot.User, action string
 	Log(b, chat, logchannels.CategoryUser, text)
 }
 
-// Reports logs a /report or @admin event.
 func Reports(b *gotgbot.Bot, chat *gotgbot.Chat, reporter *gotgbot.User, targetID int64) {
 	if reporter == nil {
 		return
@@ -79,7 +73,6 @@ func Reports(b *gotgbot.Bot, chat *gotgbot.Chat, reporter *gotgbot.User, targetI
 	Log(b, chat, logchannels.CategoryReports, text)
 }
 
-// Settings logs a settings change.
 func Settings(b *gotgbot.Bot, chat *gotgbot.Chat, actor *gotgbot.User, summary string) {
 	actorBit := "unknown"
 	if actor != nil {

--- a/alita/utils/cache/adminCache.go
+++ b/alita/utils/cache/adminCache.go
@@ -20,10 +20,6 @@ func adminCacheKey(chatId int64) string {
 	return fmt.Sprintf("alita:adminCache:%d", chatId)
 }
 
-// LoadAdminCache retrieves and caches the list of administrators for a given chat.
-// It fetches the current administrators from Telegram API and stores them in cache
-// with a 30-minute expiration. Returns an AdminCache struct containing the admin list.
-// Concurrent callers for the same chat share one in-flight Telegram fetch.
 // getChatAdministrators is called with ReturnBots so other administrator bots
 // are included; without it Telegram omits them and IsUserAdmin treats them as
 // regular members.
@@ -62,7 +58,6 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 		return storeWithTTL(ac, negativeAdminCacheTTL)
 	}
 
-	// Check if bot itself is admin with a dedicated timeout context
 	botCtx, botCancel := context.WithTimeout(context.Background(), constants.DefaultTimeout)
 	botMember, botErr := b.GetChatMemberWithContext(botCtx, chatId, b.Id, nil)
 	botCancel()
@@ -72,7 +67,6 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 			"botId":  b.Id,
 			"error":  botErr,
 		}).Warning("LoadAdminCache: Could not verify bot admin status")
-		// Store short-TTL negative to damp storm but allow quick retry on flaky API
 		return storeWithTTL(AdminCache{
 			ChatId:   chatId,
 			UserInfo: []gotgbot.MergedChatMember{},
@@ -89,8 +83,6 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 		})
 	}
 
-	// Bot has admin rights — clear any stale restricted flag so sends are
-	// no longer short-circuited for this chat.
 	MarkChatNotRestricted(chatId)
 
 	log.WithFields(log.Fields{
@@ -99,7 +91,6 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 		"botStatus": botStatus,
 	}).Debug("LoadAdminCache: Bot has admin privileges")
 
-	// Retry logic for API call — per-attempt timeout to avoid deadline exceeded after sleeps
 	maxRetries := 3
 	var adminList []gotgbot.ChatMember
 	var err error
@@ -121,7 +112,7 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 			}).Warning("LoadAdminCache: Failed to get chat administrators, retrying...")
 
 			if attempt < maxRetries-1 {
-				time.Sleep(time.Duration(attempt+1) * time.Second) // Exponential backoff
+				time.Sleep(time.Duration(attempt+1) * time.Second)
 				continue
 			}
 
@@ -131,15 +122,13 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 			}).Error("LoadAdminCache: Failed to get chat administrators after all retries")
 			return AdminCache{}
 		}
-		break // Success
+		break
 	}
 
 	if len(adminList) == 0 {
 		log.WithFields(log.Fields{
 			"chatId": chatId,
 		}).Warning("LoadAdminCache: No administrators found - this is unusual for a valid group")
-		// Empty admin list is unusual but not necessarily an error
-		// Return empty cache but mark it as cached to avoid infinite retries
 		return storeResult(AdminCache{
 			ChatId:   chatId,
 			UserInfo: []gotgbot.MergedChatMember{},
@@ -147,13 +136,11 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 		})
 	}
 
-	// Convert ChatMember to MergedChatMember and build lookup map
 	userList := make([]gotgbot.MergedChatMember, 0, len(adminList))
 	userMap := make(map[int64]gotgbot.MergedChatMember, len(adminList))
 	for _, admin := range adminList {
 		merged := admin.MergeChatMember()
 		userList = append(userList, merged)
-		// GetUser returns User by value, so check if ID is valid (non-zero)
 		user := admin.GetUser()
 		if user.Id != 0 {
 			userMap[user.Id] = merged
@@ -170,8 +157,6 @@ func loadAdminCacheFromTelegram(b *gotgbot.Bot, chatId int64) AdminCache {
 	return storeResult(adminCache)
 }
 
-// GetAdminCacheList retrieves the cached administrator list for a specific chat.
-// Returns true and the AdminCache if found in cache, false and empty AdminCache if cache miss.
 func GetAdminCacheList(chatId int64) (bool, AdminCache) {
 	m := GetMarshal()
 	if m == nil {
@@ -198,32 +183,25 @@ func GetAdminCacheList(chatId int64) (bool, AdminCache) {
 	return true, *gotAdminlist.(*AdminCache)
 }
 
-// GetAdminCacheUser searches for a specific user in the cached administrator list of a chat.
-// Returns true and the MergedChatMember if the user is found as an admin,
-// false and empty MergedChatMember if not found or cache miss.
 func GetAdminCacheUser(chatId, userId int64) (bool, gotgbot.MergedChatMember) {
 	m := GetMarshal()
 	if m == nil {
 		return false, gotgbot.MergedChatMember{}
 	}
-	// Use consistent string key format matching LoadAdminCache
 	adminList, err := m.Get(Context, adminCacheKey(chatId), new(AdminCache))
 	if err != nil || adminList == nil {
 		return false, gotgbot.MergedChatMember{}
 	}
 
-	// Type assert with check to prevent panic
 	adminCache, ok := adminList.(*AdminCache)
 	if !ok || adminCache == nil {
 		return false, gotgbot.MergedChatMember{}
 	}
 
-	// O(1) lookup via map (primary method)
 	if admin, found := adminCache.UserMap[userId]; found {
 		return true, admin
 	}
 
-	// Fallback to linear search for backwards compatibility (e.g., cached data without UserMap)
 	for i := range adminCache.UserInfo {
 		admin := &adminCache.UserInfo[i]
 		if admin.User.Id == userId {
@@ -233,8 +211,6 @@ func GetAdminCacheUser(chatId, userId int64) (bool, gotgbot.MergedChatMember) {
 	return false, gotgbot.MergedChatMember{}
 }
 
-// InvalidateAdminCache removes the cached admin list for a chat.
-// Should be called when admins are promoted/demoted to ensure fresh data.
 func InvalidateAdminCache(chatId int64) {
 	m := GetMarshal()
 	if m == nil {

--- a/alita/utils/cache/cache.go
+++ b/alita/utils/cache/cache.go
@@ -24,20 +24,16 @@ var (
 	marshalMu   sync.RWMutex
 )
 
-// ContextWithTimeout returns a context with a 5-second timeout derived from the background Context.
-// Use this for cache Get/Set/Delete operations to avoid indefinite blocking when Redis is unavailable.
 func ContextWithTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(Context, 5*time.Second)
 }
 
-// GetMarshal returns the active cache marshaler when initialized.
 func GetMarshal() *marshaler.Marshaler {
 	marshalMu.RLock()
 	defer marshalMu.RUnlock()
 	return marshal
 }
 
-// SetMarshal updates the active cache marshaler.
 func SetMarshal(m *marshaler.Marshaler) {
 	marshalMu.Lock()
 	defer marshalMu.Unlock()
@@ -47,14 +43,10 @@ func SetMarshal(m *marshaler.Marshaler) {
 type AdminCache struct {
 	ChatId   int64
 	UserInfo []gotgbot.MergedChatMember
-	UserMap  map[int64]gotgbot.MergedChatMember // O(1) lookup map
+	UserMap  map[int64]gotgbot.MergedChatMember
 	Cached   bool
 }
 
-// InitCache initializes the Redis-only cache system.
-// It establishes connection to Redis and returns an error if initialization fails.
-// When DISABLE_CACHE=true, Redis is optional: if unreachable it logs a warning and continues
-// with caching disabled (all DB reads go direct, antiraid/join state degrades to in-memory).
 func InitCache() error {
 	if config.AppConfig != nil && config.AppConfig.DisableCache {
 		log.Warn("[Cache] DISABLE_CACHE=true — bypassing read-through cache; every DB read will hit Postgres directly")
@@ -69,7 +61,6 @@ func InitCache() error {
 	}
 	redisClient = redis.NewClient(options)
 
-	// Test Redis connection with retry logic
 	maxRetries := 5
 	var pingErr error
 	for attempt := range maxRetries {
@@ -84,7 +75,6 @@ func InitCache() error {
 		}).Warning("[Cache] Failed to connect to Redis, retrying...")
 
 		if attempt < maxRetries-1 {
-			// Exponential backoff: 1s, 2s, 4s, 8s
 			time.Sleep(time.Duration(1<<attempt) * time.Second)
 		}
 	}
@@ -97,18 +87,15 @@ func InitCache() error {
 		return fmt.Errorf("failed to connect to Redis after %d attempts: %w", maxRetries, pingErr)
 	}
 
-	// Clear all caches on startup if configured to do so
 	if config.AppConfig.ClearCacheOnStartup {
 		if err := ClearAllCaches(); err != nil {
 			log.Warnf("[Cache] Failed to clear caches on startup: %v", err)
 		}
 	}
 
-	// Initialize cache manager with Redis only
 	redisStore := gocache_store.NewRedis(redisClient)
 	cacheManager := cache.New[any](redisStore)
 
-	// Initializes marshaler
 	SetMarshal(marshaler.New(cacheManager))
 	Manager = cacheManager
 
@@ -137,9 +124,6 @@ func newRedisOptions(cfg *config.Config) (*redis.Options, error) {
 	return options, nil
 }
 
-// ClearAllCaches clears all cache entries from Redis using FLUSHDB.
-// This function is called on bot startup to ensure fresh data and eliminate cache coherence issues.
-// Since Redis is dedicated to the bot, FLUSHDB safely clears all keys in the current database.
 func ClearAllCaches() error {
 	if redisClient == nil {
 		return fmt.Errorf("redis client not initialized")
@@ -147,8 +131,6 @@ func ClearAllCaches() error {
 
 	log.Info("[Cache] Clearing all caches using FLUSHDB...")
 
-	// Use FLUSHDB to clear all keys in current database
-	// This is safe since Redis is dedicated to the bot
 	if err := redisClient.FlushDB(Context).Err(); err != nil {
 		return fmt.Errorf("failed to flush database: %w", err)
 	}
@@ -157,19 +139,14 @@ func ClearAllCaches() error {
 	return nil
 }
 
-// GetRedisClient exposes the internal Redis client for modules that need
-// low-level Redis operations (e.g., sorted sets for rate-limiting).
-// Returns nil if cache has not been initialized.
 func GetRedisClient() *redis.Client {
 	return redisClient
 }
 
-// IsRedisAvailable returns whether the Redis client is initialized.
 func IsRedisAvailable() bool {
 	return redisClient != nil
 }
 
-// DisableRedisForTest clears the Redis client until restore is called.
 func DisableRedisForTest() (restore func()) {
 	previous := redisClient
 	redisClient = nil

--- a/alita/utils/cache/marshal_test.go
+++ b/alita/utils/cache/marshal_test.go
@@ -52,7 +52,6 @@ func TestGetMarshalSetMarshalConcurrentAccess(t *testing.T) {
 }
 
 func TestInitTestMarshalSetsAndRestores(t *testing.T) {
-	// TestInitTestMarshalSetsAndRestores captures pre-call state.
 	before := GetMarshal()
 
 	restore := InitTestMarshal()

--- a/alita/utils/cache/restrictedCache.go
+++ b/alita/utils/cache/restrictedCache.go
@@ -18,18 +18,14 @@ var (
 	restrictedCacheMisses atomic.Int64
 )
 
-// restrictedChatKey returns the Redis key for a restricted chat.
 func restrictedChatKey(chatID int64) string {
 	return fmt.Sprintf("alita:restricted:%d", chatID)
 }
 
-// restrictedProbeKey returns the Redis key used to coordinate probe attempts.
 func restrictedProbeKey(chatID int64) string {
 	return fmt.Sprintf("alita:restricted_probe:%d", chatID)
 }
 
-// MarkChatRestricted marks a chat as restricted (bot can't send messages).
-// The restriction expires after RestrictedCacheTTL (30 min).
 func MarkChatRestricted(chatID int64) {
 	m := GetMarshal()
 	if m == nil {
@@ -48,10 +44,6 @@ func MarkChatRestricted(chatID int64) {
 	}
 }
 
-// IsChatRestricted checks if a chat is currently in the restricted cache.
-// Returns true if the bot should skip sending to this chat.
-// A periodic probe window allows retries so stale restrictions don't block sends
-// for the full key TTL.
 func IsChatRestricted(chatID int64) bool {
 	m := GetMarshal()
 	if m == nil {
@@ -66,7 +58,6 @@ func IsChatRestricted(chatID int64) bool {
 
 	restrictedSince, parseErr := time.Parse(time.RFC3339, ts)
 	if parseErr != nil {
-		// Allow a probe when cache payload is malformed to avoid hard lockout.
 		restrictedCacheMisses.Add(1)
 		log.WithFields(log.Fields{
 			"chat_id": chatID,
@@ -77,8 +68,6 @@ func IsChatRestricted(chatID int64) bool {
 	}
 
 	if time.Since(restrictedSince) >= constants.RestrictedProbeInterval {
-		// Coordinate a single probe attempt across concurrent workers so only one
-		// sender retries Telegram when probe window opens.
 		if redisClient != nil {
 			_, claimErr := redisClient.SetArgs(
 				Context,
@@ -119,8 +108,6 @@ func IsChatRestricted(chatID int64) bool {
 	return true
 }
 
-// MarkChatNotRestricted removes the restricted flag for a chat.
-// Called when the bot's permissions are upgraded (e.g., admin cache load detects bot is admin).
 func MarkChatNotRestricted(chatID int64) {
 	m := GetMarshal()
 	if m == nil {
@@ -136,7 +123,6 @@ func MarkChatNotRestricted(chatID int64) {
 	}
 }
 
-// GetRestrictedCacheStats returns cumulative hit/miss counters for monitoring.
 func GetRestrictedCacheStats() (hits, misses int64) {
 	return restrictedCacheHits.Load(), restrictedCacheMisses.Load()
 }

--- a/alita/utils/cache/restrictedCache_test.go
+++ b/alita/utils/cache/restrictedCache_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/constants"
 )
 
-// TestMain gives cache tests an isolated Redis instance.
 func TestMain(m *testing.M) {
 	redisServer, err := miniredis.Run()
 	if err != nil {
@@ -39,17 +38,12 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-// skipIfNoCache skips the current test when the cache is not initialized.
 func skipIfNoCache(t *testing.T) {
 	t.Helper()
 	if GetMarshal() == nil {
 		t.Skip("requires Redis connection")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// restrictedChatKey
-// ---------------------------------------------------------------------------
 
 func TestRestrictedCacheKey_Format(t *testing.T) {
 	t.Parallel()
@@ -74,10 +68,6 @@ func TestRestrictedCacheKey_Format(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// restrictedProbeKey
-// ---------------------------------------------------------------------------
-
 func TestRestrictedProbeKey_Format(t *testing.T) {
 	t.Parallel()
 
@@ -101,12 +91,7 @@ func TestRestrictedProbeKey_Format(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// GetRestrictedCacheStats — no Redis needed (atomic counters)
-// ---------------------------------------------------------------------------
-
 func TestGetRestrictedCacheStats_InitialZero(t *testing.T) {
-	// Save and restore counters to avoid side effects from other tests.
 	origHits := restrictedCacheHits.Load()
 	origMisses := restrictedCacheMisses.Load()
 	defer func() {
@@ -129,14 +114,11 @@ func TestGetRestrictedCacheStats_InitialZero(t *testing.T) {
 func TestGetRestrictedCacheStats_BothCounters(t *testing.T) {
 	skipIfNoCache(t)
 
-	// Use a unique chat ID to avoid collisions with parallel tests.
 	const chatA = int64(-10099901)
 	const chatB = int64(-10099902)
 
-	// Record baseline to isolate this test from others.
 	baseHits, baseMisses := GetRestrictedCacheStats()
 
-	// Mark chatA restricted, then check it → hit.
 	MarkChatRestricted(chatA)
 	defer MarkChatNotRestricted(chatA)
 
@@ -144,7 +126,6 @@ func TestGetRestrictedCacheStats_BothCounters(t *testing.T) {
 		t.Fatal("IsChatRestricted(chatA) should return true after MarkChatRestricted")
 	}
 
-	// Check chatB (never marked) → miss.
 	if IsChatRestricted(chatB) {
 		t.Fatal("IsChatRestricted(chatB) should return false for unknown chat")
 	}
@@ -157,10 +138,6 @@ func TestGetRestrictedCacheStats_BothCounters(t *testing.T) {
 		t.Errorf("expected at least 1 new miss, got delta=%d", misses-baseMisses)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// MarkChatRestricted / IsChatRestricted
-// ---------------------------------------------------------------------------
 
 func TestMarkChatRestricted(t *testing.T) {
 	skipIfNoCache(t)
@@ -256,12 +233,10 @@ func TestIsChatRestricted_ProbeSingleFlight(t *testing.T) {
 		t.Fatalf("failed to seed restricted cache: %v", err)
 	}
 
-	// First check after probe interval should allow one send attempt.
 	if IsChatRestricted(chatID) {
 		t.Fatal("first check after probe interval should allow probe attempt")
 	}
 
-	// Immediate second check should be blocked by probe lock.
 	if !IsChatRestricted(chatID) {
 		t.Fatal("second check should be blocked while probe lock is active")
 	}
@@ -274,16 +249,12 @@ func TestMarkChatRestricted_Idempotent(t *testing.T) {
 	defer MarkChatNotRestricted(chatID)
 
 	MarkChatRestricted(chatID)
-	MarkChatRestricted(chatID) // second call must not cause an error or flip state
+	MarkChatRestricted(chatID)
 
 	if !IsChatRestricted(chatID) {
 		t.Errorf("IsChatRestricted(%d) = false after double MarkChatRestricted, want true", chatID)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Stats counters
-// ---------------------------------------------------------------------------
 
 func TestIsChatRestricted_StatsIncrementHit(t *testing.T) {
 	skipIfNoCache(t)
@@ -320,10 +291,6 @@ func TestIsChatRestricted_StatsIncrementMiss(t *testing.T) {
 		t.Errorf("expected misses delta=1, got %d", misses-baseMisses)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Nil-safety: functions must not panic when Marshal is nil
-// ---------------------------------------------------------------------------
 
 func TestRestrictedChatKey_NilSafe(t *testing.T) {
 	t.Parallel()

--- a/alita/utils/callbackcodec/callbackcodec.go
+++ b/alita/utils/callbackcodec/callbackcodec.go
@@ -8,31 +8,23 @@ import (
 )
 
 const (
-	// Version identifies the current callback payload format.
 	Version = "v1"
 	// MaxCallbackDataLen matches Telegram's callback_data limit.
 	MaxCallbackDataLen = 64
 )
 
 var (
-	// ErrInvalidFormat indicates callback data is not in codec format.
-	ErrInvalidFormat = errors.New("invalid callback format")
-	// ErrUnsupportedVersion indicates the callback version is not supported.
+	ErrInvalidFormat      = errors.New("invalid callback format")
 	ErrUnsupportedVersion = errors.New("unsupported callback version")
-	// ErrInvalidNamespace indicates callback namespace is invalid.
-	ErrInvalidNamespace = errors.New("invalid callback namespace")
-	// ErrDataTooLong indicates encoded callback data exceeds Telegram limits.
-	ErrDataTooLong = errors.New("callback data exceeds max length")
+	ErrInvalidNamespace   = errors.New("invalid callback namespace")
+	ErrDataTooLong        = errors.New("callback data exceeds max length")
 )
 
-// Decoded represents a decoded callback payload.
 type Decoded struct {
 	Namespace string
 	Fields    map[string]string
 }
 
-// Encode serializes callback payload fields into a compact versioned format.
-// Format: <namespace>|v1|<query-encoded fields>
 func Encode(namespace string, fields map[string]string) (string, error) {
 	if namespace == "" || strings.Contains(namespace, "|") {
 		return "", ErrInvalidNamespace
@@ -58,7 +50,6 @@ func Encode(namespace string, fields map[string]string) (string, error) {
 	return data, nil
 }
 
-// EncodeOrFallback returns encoded data, or fallback when encoding fails.
 func EncodeOrFallback(namespace string, fields map[string]string, fallback string) string {
 	data, err := Encode(namespace, fields)
 	if err != nil {
@@ -67,7 +58,6 @@ func EncodeOrFallback(namespace string, fields map[string]string, fallback strin
 	return data
 }
 
-// Decode parses callback data in codec format.
 func Decode(data string) (*Decoded, error) {
 	parts := strings.SplitN(data, "|", 3)
 	if len(parts) != 3 {
@@ -106,7 +96,6 @@ func Decode(data string) (*Decoded, error) {
 	}, nil
 }
 
-// Field returns a decoded field value and whether it exists.
 func (d *Decoded) Field(key string) (string, bool) {
 	if d == nil {
 		return "", false

--- a/alita/utils/callbackcodec/callbackcodec_test.go
+++ b/alita/utils/callbackcodec/callbackcodec_test.go
@@ -190,7 +190,6 @@ func TestEncodeSkipsEmptyKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encode() with empty key error = %v", err)
 	}
-	// empty key skipped -> payload collapses to "_"
 	if result != "ns|v1|_" {
 		t.Fatalf("expected \"ns|v1|_\" (empty key skipped), got %q", result)
 	}
@@ -266,7 +265,6 @@ func TestDecodeRejectsCorruptBase64(t *testing.T) {
 func TestDecodeRejectsMissingVersionField(t *testing.T) {
 	t.Parallel()
 
-	// Only 2 pipe-separated parts instead of 3
 	_, err := Decode("ns|v1")
 	if !errors.Is(err, ErrInvalidFormat) {
 		t.Fatalf("expected ErrInvalidFormat for missing payload segment, got %v", err)
@@ -285,7 +283,6 @@ func TestDecodeRejectsEmptyVersion(t *testing.T) {
 func TestDecodeRejectsPipeOnlyPayload(t *testing.T) {
 	t.Parallel()
 
-	// Too few parts after splitting
 	_, err := Decode("|")
 	if !errors.Is(err, ErrInvalidFormat) {
 		t.Fatalf("expected ErrInvalidFormat for single pipe, got %v", err)
@@ -299,10 +296,6 @@ func TestDecodeRejectsPipeOnlyPayload(t *testing.T) {
 func TestEncodeNearMaxLength(t *testing.T) {
 	t.Parallel()
 
-	// Construct a payload that approaches MaxCallbackDataLen
-	// Namespace "test" + version separator "|v1|" = 5 chars for "|v1|"
-	// So max field payload = 64 - len("test") - 5 = 55
-	// The payload is URL-encoded, so we need to stay within bounds
 	result, err := Encode("ns", map[string]string{"k": "v"})
 	if err != nil {
 		t.Fatalf("Encode() for small payload error = %v", err)

--- a/alita/utils/chat_status/access.go
+++ b/alita/utils/chat_status/access.go
@@ -5,8 +5,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-// hasUserPermission checks whether the specified user in a chat satisfies a
-// permission predicate. It handles anonymous admin bypass and member lookup.
 func hasUserPermission(
 	b *gotgbot.Bot,
 	ctx *ext.Context,
@@ -37,49 +35,42 @@ func hasUserPermission(
 	return requiredField(&userMember) || userMember.Status == "creator"
 }
 
-// CanUserChangeInfo reports whether the user can change chat information.
 func CanUserChangeInfo(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanChangeInfo
 	})
 }
 
-// CanUserRestrict reports whether the user can restrict other members.
 func CanUserRestrict(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanRestrictMembers
 	})
 }
 
-// CanUserPromote reports whether the user can promote/demote other members.
 func CanUserPromote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanPromoteMembers
 	})
 }
 
-// CanUserPin reports whether the user can pin messages.
 func CanUserPin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanPinMessages
 	})
 }
 
-// CanUserDelete reports whether the user can delete messages.
 func CanUserDelete(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanDeleteMessages
 	})
 }
 
-// CanUserInvite reports whether the user can invite members and manage join requests.
 func CanUserInvite(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	return hasUserPermission(b, ctx, chat, userId, func(m *gotgbot.MergedChatMember) bool {
 		return m.CanInviteUsers
 	})
 }
 
-// CanBotRestrict reports whether the bot can restrict members.
 func CanBotRestrict(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -96,7 +87,6 @@ func CanBotRestrict(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return botMember.CanRestrictMembers
 }
 
-// CanBotPromote reports whether the bot can promote/demote members.
 func CanBotPromote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -113,7 +103,6 @@ func CanBotPromote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return botMember.CanPromoteMembers
 }
 
-// CanBotPin reports whether the bot can pin messages.
 func CanBotPin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -130,7 +119,6 @@ func CanBotPin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return botMember.CanPinMessages
 }
 
-// CanBotChangeInfo reports whether the bot can change chat title, photo, or description.
 func CanBotChangeInfo(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -147,7 +135,6 @@ func CanBotChangeInfo(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool
 	return botMember.CanChangeInfo
 }
 
-// CanBotDelete reports whether the bot can delete messages.
 func CanBotDelete(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -164,7 +151,6 @@ func CanBotDelete(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return botMember.CanDeleteMessages
 }
 
-// CanBotInvite reports whether the bot can invite members and manage join requests.
 func CanBotInvite(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	if b == nil {
 		return false
@@ -181,12 +167,10 @@ func CanBotInvite(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return botMember.CanInviteUsers
 }
 
-// RequireBotAdmin reports whether the bot is an admin.
 func RequireBotAdmin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return IsBotAdmin(b, ctx, chat)
 }
 
-// RequireUserAdmin reports whether the user is an admin.
 func RequireUserAdmin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	chat = extractChatFromContext(ctx, chat)
 	if chat == nil {
@@ -195,7 +179,6 @@ func RequireUserAdmin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, user
 	return IsUserAdmin(b, chat.Id, userId)
 }
 
-// RequireUserOwner reports whether the user is the chat owner.
 func RequireUserOwner(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	chat = extractChatFromContext(ctx, chat)
 	if chat == nil {
@@ -209,8 +192,6 @@ func RequireUserOwner(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, user
 	return mem.GetStatus() == "creator"
 }
 
-// RequireGroup reports whether the chat is a group (not private).
-//
 //nolint:dupl // RequirePrivate/RequireGroup have symmetric logic
 func RequireGroup(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	chat = extractChatFromContext(ctx, chat)
@@ -220,8 +201,6 @@ func RequireGroup(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return chat.Type != "private"
 }
 
-// RequirePrivate reports whether the chat is a private chat.
-//
 //nolint:dupl // RequirePrivate/RequireGroup have symmetric logic
 func RequirePrivate(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	chat = extractChatFromContext(ctx, chat)

--- a/alita/utils/chat_status/access_test.go
+++ b/alita/utils/chat_status/access_test.go
@@ -779,7 +779,6 @@ func TestRequirePrivate(t *testing.T) {
 
 func TestRequireGroup_NilChat(t *testing.T) {
 	ctx := makeCtxWithMessage("group")
-	// When chat is nil, extractChatFromContext pulls from ctx's embedded Update.Message.Chat
 	if !RequireGroup(nil, ctx, nil) {
 		t.Fatal("RequireGroup(nil, ctxWithGroup, nil) should be true")
 	}
@@ -806,7 +805,6 @@ func TestRequirePrivate_NilContextAndChat(t *testing.T) {
 
 func TestIsBotAdmin_NilBot(t *testing.T) {
 	ctx := makeCtxWithMessage("private")
-	// Private chats always return true from IsBotAdmin.
 	if !IsBotAdmin(nil, ctx, nil) {
 		t.Fatal("IsBotAdmin(nil, privateCtx, nil) should be true for private chats")
 	}

--- a/alita/utils/chat_status/chat_status.go
+++ b/alita/utils/chat_status/chat_status.go
@@ -37,19 +37,15 @@ var (
 	anonChatMapExpiration = 20 * time.Second
 )
 
-// IsValidUserId checks if an ID represents a valid Telegram user.
 // User IDs are always positive (> 0).
 // Channel IDs are negative with format -100XXXXXXXXXX (< -1000000000000).
 // Regular chat/group IDs are negative but in a different range.
 func IsValidUserId(id int64) bool {
-	// Valid user IDs are always positive
 	return id > 0
 }
 
-// IsChannelId checks if an ID represents a Telegram channel.
 // Channel IDs have the format -100XXXXXXXXXX (-100 prefix followed by 10+ digits).
 func IsChannelId(id int64) bool {
-	// Channel IDs are < -1000000000000 (-100 followed by 10+ digits)
 	return id < -1000000000000
 }
 
@@ -64,9 +60,6 @@ func callbackQueryFromContext(ctx *ext.Context) (*gotgbot.CallbackQuery, bool) {
 	return update.CallbackQuery, true
 }
 
-// checkAnonAdmin handles anonymous admin checks.
-// Returns true if user should be treated as admin (anon bypass enabled),
-// false if anon keyboard was sent, and a bool indicating if caller should return immediately.
 func checkAnonAdmin(b *gotgbot.Bot, chat *gotgbot.Chat, msg *gotgbot.Message, sender *gotgbot.Sender) (isAdmin bool, shouldReturn bool) {
 	if sender == nil || !sender.IsAnonymousAdmin() {
 		return false, false
@@ -85,18 +78,6 @@ func checkAnonAdmin(b *gotgbot.Bot, chat *gotgbot.Chat, msg *gotgbot.Message, se
 	return false, true
 }
 
-// extractChatFromContext extracts the chat from the context.
-// It handles callback queries, regular messages, and MyChatMember updates.
-// If chat parameter is already provided (non-nil), it returns it directly.
-//
-// SAFETY NOTE: This function returns pointers to values within the context struct
-// or local variables. Go's escape analysis ensures these are heap-allocated when
-// their addresses escape, making the returned pointers valid for the lifetime of
-// the context. The caller must ensure the context remains valid while using the
-// returned pointer. This pattern is safe because:
-//  1. Go's compiler escape analysis moves address-taken variables to the heap
-//  2. The gotgbot.Chat struct is a value type that gets copied when assigned
-//  3. All returned pointers point to stable memory locations
 func extractChatFromContext(ctx *ext.Context, chat *gotgbot.Chat) *gotgbot.Chat {
 	if chat != nil {
 		return chat
@@ -127,8 +108,6 @@ func extractChatFromContext(ctx *ext.Context, chat *gotgbot.Chat) *gotgbot.Chat 
 	return nil
 }
 
-// getUserMemberWithCache retrieves a chat member, using cache if available.
-// Returns the merged chat member and a boolean indicating if the lookup was successful.
 func getUserMemberWithCache(b *gotgbot.Bot, chat *gotgbot.Chat, userId int64, funcName string) (gotgbot.MergedChatMember, bool) {
 	found, userMember := cache.GetAdminCacheUser(chat.Id, userId)
 	if found {
@@ -142,8 +121,6 @@ func getUserMemberWithCache(b *gotgbot.Bot, chat *gotgbot.Chat, userId int64, fu
 	return tmpUserMember.MergeChatMember(), true
 }
 
-// GetChat retrieves chat information by chat ID or username.
-// Makes a direct API request to support username-based chat retrieval.
 func GetChat(bot *gotgbot.Bot, chatId string) (*gotgbot.Chat, error) {
 	r, err := bot.Request("getChat", map[string]any{"chat_id": chatId}, nil)
 	if err != nil {
@@ -154,17 +131,11 @@ func GetChat(bot *gotgbot.Bot, chatId string) (*gotgbot.Chat, error) {
 	return &c, json.Unmarshal(r, &c)
 }
 
-// CheckDisabledCmd checks if a command is disabled in the chat and handles deletion if configured.
-// Returns true if the command should be blocked, false if it should proceed.
-// Skips checks for private chats and admin users.
-// If command is disabled for non-admin users, optionally deletes the message based on chat settings.
 func CheckDisabledCmd(bot *gotgbot.Bot, msg *gotgbot.Message, cmd string) bool {
-	// Private chats don't have disabled commands
 	if msg.Chat.Type == "private" {
 		return false
 	}
 
-	// Check if command is disabled in this chat
 	if !disabling.IsCommandDisabled(msg.Chat.Id, cmd) {
 		return false
 	}
@@ -174,13 +145,10 @@ func CheckDisabledCmd(bot *gotgbot.Bot, msg *gotgbot.Message, cmd string) bool {
 		return false
 	}
 
-	// Admins and creators can bypass disabled commands
 	if IsUserAdmin(bot, msg.Chat.Id, msg.From.Id) {
 		return false
 	}
 
-	// Command is disabled and user is not admin - block the command
-	// Optionally delete the message if chat has deletion enabled
 	if disabling.ShouldDel(msg.Chat.Id) {
 		_, err := msg.Delete(bot, nil)
 		if err != nil {
@@ -188,25 +156,15 @@ func CheckDisabledCmd(bot *gotgbot.Bot, msg *gotgbot.Message, cmd string) bool {
 		}
 	}
 
-	// Return true to indicate command is blocked (regardless of whether deletion succeeded)
 	return true
 }
 
-// IsApproved checks if a user is in the approved whitelist for a chat.
-// Approved users are immune to anti-spam measures (antiflood, blacklists, locks, captcha, antispam).
-// This is a simple delegation to the DB layer for consistent usage in watcher handlers.
 func IsApproved(b *gotgbot.Bot, chatID, userID int64) bool {
 	return approvals.IsUserApproved(chatID, userID)
 }
 
-// IsUserAdmin checks if a user has administrator privileges in a chat.
-// Uses caching system to avoid repeated API calls and handles special Telegram admin accounts.
-// Returns true if the user is an admin, creator, or special Telegram account.
 func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
-	// Validate user ID - channel IDs and other invalid IDs should not be checked
-	// User IDs in Telegram are always positive, negative IDs are chat/channel IDs
 	if !IsValidUserId(userId) {
-		// Provide more specific error messages based on ID type
 		if IsChannelId(userId) {
 			log.WithFields(log.Fields{
 				"chatID": chatID,
@@ -221,22 +179,18 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 		return false
 	}
 
-	// Placing this first would not make additional queries if check is success!
 	if slices.Contains(tgAdminList, userId) {
 		return true
 	}
 
-	// Check cache first - avoid GetChat call if possible
 	adminsAvail, admins := cache.GetAdminCacheList(chatID)
 	if adminsAvail && admins.Cached {
-		// O(1) lookup via map when available
 		if admins.UserMap != nil {
 			if admin, found := admins.UserMap[userId]; found && admin.User.Id != 0 {
 				return true
 			}
 			return false
 		}
-		// Fallback to linear scan for backwards compatibility (cached data without UserMap)
 		for i := range admins.UserInfo {
 			if admins.UserInfo[i].User.Id == userId {
 				return true
@@ -245,7 +199,6 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 		return false
 	}
 
-	// Only make GetChat call if cache miss - use fresh context per API call
 	ctxGetChat, cancelGetChat := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelGetChat()
 	chat, err := b.GetChatWithContext(ctxGetChat, chatID, nil)
@@ -258,21 +211,17 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 		return false
 	}
 
-	// Don't allow check if not a group/supergroup
 	if chat.Type != "group" && chat.Type != "supergroup" {
 		return false
 	}
 
-	// Load admin cache with timeout protection
 	adminList := cache.LoadAdminCache(b, chatID)
 
-	// Check if user is in admin list via O(1) map lookup
 	if adminList.UserMap != nil {
 		if admin, found := adminList.UserMap[userId]; found && admin.User.Id != 0 {
 			return true
 		}
 	} else {
-		// Fallback to linear scan for backwards compatibility
 		for i := range adminList.UserInfo {
 			if adminList.UserInfo[i].User.Id == userId {
 				return true
@@ -280,8 +229,6 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 		}
 	}
 
-	// Fallback: If admin cache is empty but we know this is a group/supergroup,
-	// try a direct GetChatMember call as backup with a fresh context
 	if len(adminList.UserInfo) == 0 {
 		log.WithFields(log.Fields{
 			"chatID": chatID,
@@ -292,7 +239,6 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 		defer cancelMember()
 		member, err := b.GetChatMemberWithContext(ctxMember, chatID, userId, nil)
 		if err != nil {
-			// Check for context timeout
 			if ctxMember.Err() != nil {
 				log.WithFields(log.Fields{
 					"chatID": chatID,
@@ -300,7 +246,6 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 				}).Warn("IsUserAdmin: GetChatMember fallback timed out, assuming non-admin")
 				return false
 			}
-			// Check for specific permission errors to avoid spam
 			errStr := err.Error()
 			if strings.Contains(errStr, "CHAT_ADMIN_REQUIRED") {
 				log.WithFields(log.Fields{
@@ -339,9 +284,6 @@ func IsUserAdmin(b *gotgbot.Bot, chatID, userId int64) bool {
 	return false
 }
 
-// IsBotAdmin checks if the bot has administrator privileges in the specified chat.
-// Returns true for private chats (bot is always "admin" in private).
-// For groups, verifies the bot's actual admin status.
 func IsBotAdmin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	chat = extractChatFromContext(ctx, chat)
 	if chat == nil {
@@ -361,9 +303,6 @@ func IsBotAdmin(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat) bool {
 	return mem.Status == "administrator"
 }
 
-// CanInvite checks if the bot and user have permissions to generate invite links.
-// Returns true immediately if the chat has a public username.
-// Validates both bot and user permissions for invite link generation.
 func CanInvite(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, msg *gotgbot.Message) bool {
 	chat = extractChatFromContext(ctx, chat)
 	if chat == nil {
@@ -429,7 +368,6 @@ func IsUserInChatWithError(b *gotgbot.Bot, chat *gotgbot.Chat, userId int64) (bo
 	}
 }
 
-// IsUserInChat checks if a user is currently a member of the specified chat.
 func IsUserInChat(b *gotgbot.Bot, chat *gotgbot.Chat, userId int64) bool {
 	isMember, err := IsUserInChatWithError(b, chat, userId)
 	if err != nil {
@@ -439,9 +377,6 @@ func IsUserInChat(b *gotgbot.Bot, chat *gotgbot.Chat, userId int64) bool {
 	return isMember
 }
 
-// IsUserConnected checks if a user is connected to a chat and validates permissions.
-// Handles both private messages (with connection system) and group messages.
-// Returns the effective chat if all checks pass, nil otherwise.
 func IsUserConnected(b *gotgbot.Bot, ctx *ext.Context, chatAdmin, botAdmin bool) (chat *gotgbot.Chat) {
 	msg := ctx.EffectiveMessage
 	user := ctx.EffectiveUser
@@ -559,9 +494,6 @@ func IsUserConnected(b *gotgbot.Bot, ctx *ext.Context, chatAdmin, botAdmin bool)
 	return chat
 }
 
-// IsUserBanProtected checks if a user is protected from being banned.
-// Returns true for private chats, admins, and special Telegram accounts.
-// Used to prevent banning of administrators and system accounts.
 func IsUserBanProtected(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, userId int64) bool {
 	chat = extractChatFromContext(ctx, chat)
 	if chat == nil {
@@ -576,9 +508,6 @@ func IsUserBanProtected(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, us
 	return IsUserAdmin(b, ctx.EffectiveChat.Id, userId) || slices.Contains(tgAdminList, userId)
 }
 
-// setAnonAdminCache stores anonymous admin message information in cache.
-// Used to track anonymous admin verification requests with expiration.
-// Logs errors but doesn't fail since cache is non-critical.
 func setAnonAdminCache(chatId int64, msg *gotgbot.Message) {
 	m := cache.GetMarshal()
 	if m == nil || msg == nil {
@@ -587,12 +516,10 @@ func setAnonAdminCache(chatId int64, msg *gotgbot.Message) {
 	}
 	err := m.Set(cache.Context, fmt.Sprintf("alita:anonAdmin:%d:%d", chatId, msg.MessageId), msg, store.WithExpiration(anonChatMapExpiration))
 	if err != nil {
-		// Log error but don't fail the operation since cache is not critical
 		log.Errorf("Failed to set anonymous admin cache: %v", err)
 	}
 }
 
-// GetEffectiveUser safely extracts the user from context.
 // Returns nil for channel posts and cases where user is unavailable.
 func GetEffectiveUser(ctx *ext.Context) *gotgbot.User {
 	if ctx == nil || ctx.EffectiveSender == nil {
@@ -601,19 +528,13 @@ func GetEffectiveUser(ctx *ext.Context) *gotgbot.User {
 	return ctx.EffectiveSender.User
 }
 
-// RequireUser ensures a valid user exists in context.
-// Returns the user or nil.
 func RequireUser(b *gotgbot.Bot, ctx *ext.Context) *gotgbot.User {
 	return GetEffectiveUser(ctx)
 }
 
-// GetMessageLinkFromMessageId generates a Telegram message link from chat and message ID.
-// Handles both public groups (with username) and private groups (without username).
 // NOTE: msg.GetLink() only works for supergroups/channels. This custom implementation
 // also handles private groups and non-supergroups by constructing the link manually.
 func GetMessageLinkFromMessageId(chat *gotgbot.Chat, messageId int64) (messageLink string) {
-	// This function expects group/supergroup/channel chats (negative IDs).
-	// For user chats or invalid contexts, return empty string.
 	if chat == nil || chat.Id >= 0 {
 		return ""
 	}
@@ -625,7 +546,6 @@ func GetMessageLinkFromMessageId(chat *gotgbot.Chat, messageId int64) (messageLi
 		if IsChannelId(chat.Id) {
 			linkId = strings.ReplaceAll(chatIdStr, "-100", "")
 		} else if strings.HasPrefix(chatIdStr, "-") && !IsChannelId(chat.Id) {
-			// this is for non-supergroups
 			linkId = strings.ReplaceAll(chatIdStr, "-", "")
 		}
 		messageLink += fmt.Sprintf("c/%s/%d", linkId, messageId)
@@ -635,11 +555,7 @@ func GetMessageLinkFromMessageId(chat *gotgbot.Chat, messageId int64) (messageLi
 	return
 }
 
-// ExtractJoinLeftStatusChange analyzes ChatMemberUpdated events to detect join/leave status changes.
-// Returns (was_member, is_member) booleans indicating membership status transition.
-// Returns (false, false) for channels or if no status change occurred.
 func ExtractJoinLeftStatusChange(u *gotgbot.ChatMemberUpdated) (bool, bool) {
-	// return false for channels
 	if u.Chat.Type == "channel" {
 		return false, false
 	}
@@ -666,11 +582,7 @@ func ExtractJoinLeftStatusChange(u *gotgbot.ChatMemberUpdated) (bool, bool) {
 	return wasMember, isMember
 }
 
-// ExtractAdminUpdateStatusChange detects admin status changes from ChatMemberUpdated events.
-// Returns true if there was a transition to/from administrator or creator status.
-// Returns false for channels or if no admin status change occurred.
 func ExtractAdminUpdateStatusChange(u *gotgbot.ChatMemberUpdated) bool {
-	// return false for channels
 	if u.Chat.Type == "channel" {
 		return false
 	}
@@ -678,7 +590,6 @@ func ExtractAdminUpdateStatusChange(u *gotgbot.ChatMemberUpdated) bool {
 	oldMemberStatus := u.OldChatMember.MergeChatMember().Status
 	newMemberStatus := u.NewChatMember.MergeChatMember().Status
 
-	// status remains same
 	if oldMemberStatus == newMemberStatus {
 		return false
 	}
@@ -701,10 +612,7 @@ func ExtractAdminUpdateStatusChange(u *gotgbot.ChatMemberUpdated) bool {
 	return adminStatusChanged
 }
 
-// sendAnonAdminKeyboard sends an inline keyboard to verify anonymous admin identity.
-// Creates a callback button that anonymous admins can click to prove their admin status.
 func sendAnonAdminKeyboard(b *gotgbot.Bot, msg *gotgbot.Message, chat *gotgbot.Chat) (*gotgbot.Message, error) {
-	// Create a minimal context to get the language
 	ctx := &ext.Context{
 		EffectiveMessage: msg,
 	}

--- a/alita/utils/chat_status/chat_status_test.go
+++ b/alita/utils/chat_status/chat_status_test.go
@@ -27,14 +27,11 @@ func TestIsApproved(t *testing.T) {
 		_ = approvals.RemoveAllApprovedUsers(chatID)
 	})
 
-	// Mock bot pointer - IsApproved doesn't actually use it, just needs non-nil
-	// We pass nil intentionally since IsApproved delegates to approvals.IsUserApproved which ignores bot
 	got := IsApproved(nil, chatID, 1001)
 	if got != false {
 		t.Fatalf("IsApproved(nil, chat, unapproved) = %v, want false", got)
 	}
 
-	// Approve user and verify
 	if err := approvals.AddApprovedUser(chatID, 1001, 1, "test"); err != nil {
 		t.Fatalf("AddApprovedUser() error = %v", err)
 	}
@@ -61,18 +58,15 @@ func TestCanInvite(t *testing.T) {
 	bot := newChatStatusBot(999)
 	chat := &gotgbot.Chat{Id: -1001, Type: "supergroup", Title: "Permission Chat"}
 
-	// Test 1: Nil chat and nil context
 	if CanInvite(bot, nil, nil, nil) {
 		t.Fatal("CanInvite(nil, nil, nil) should be false")
 	}
 
-	// Test 2: Public chat (Username != "")
 	publicChat := &gotgbot.Chat{Id: -1001, Type: "supergroup", Username: "public_group"}
 	if !CanInvite(bot, nil, publicChat, nil) {
 		t.Fatal("CanInvite should be true for public chats")
 	}
 
-	// Test 3: Bot lacks CanInviteUsers permission
 	limitedBot := newChatStatusBot(998)
 	ctx := makeCtxWithMessage("supergroup")
 	msg := &gotgbot.Message{From: &gotgbot.User{Id: 10}}
@@ -80,25 +74,21 @@ func TestCanInvite(t *testing.T) {
 		t.Fatal("CanInvite should be false if bot lacks invite permission")
 	}
 
-	// Test 4: Bot has invite permission, but msg.From is nil (channel post)
 	nilFromMsg := &gotgbot.Message{From: nil}
 	if CanInvite(bot, ctx, chat, nilFromMsg) {
 		t.Fatal("CanInvite should be false if msg.From is nil")
 	}
 
-	// Test 5: Full Admin user (has invite permission)
 	fullAdminMsg := &gotgbot.Message{From: &gotgbot.User{Id: 10}}
 	if !CanInvite(bot, ctx, chat, fullAdminMsg) {
 		t.Fatal("CanInvite should be true for Full Admin user")
 	}
 
-	// Test 6: Limited Admin user (lacks invite permission)
 	limitedAdminMsg := &gotgbot.Message{From: &gotgbot.User{Id: 11}}
 	if CanInvite(bot, ctx, chat, limitedAdminMsg) {
 		t.Fatal("CanInvite should be false for Limited Admin user")
 	}
 
-	// Test 7: Owner/Creator (allowed without explicit invite flag)
 	ownerMsg := &gotgbot.Message{From: &gotgbot.User{Id: 12}}
 	if !CanInvite(bot, ctx, chat, ownerMsg) {
 		t.Fatal("CanInvite should be true for Owner")
@@ -110,74 +100,60 @@ func TestOtherExportedFunctions(t *testing.T) {
 	chat := &gotgbot.Chat{Id: -1001, Type: "supergroup", Title: "Permission Chat"}
 	ctx := makeCtxWithMessage("supergroup")
 
-	// 1. CanUserChangeInfo
 	if !CanUserChangeInfo(bot, ctx, chat, 10) {
 		t.Error("CanUserChangeInfo(10) should be true")
 	}
 
-	// 2. CanUserRestrict
 	if !CanUserRestrict(bot, ctx, chat, 10) {
 		t.Error("CanUserRestrict(10) should be true")
 	}
 
-	// 3. CanBotRestrict
 	if !CanBotRestrict(bot, ctx, chat) {
 		t.Error("CanBotRestrict() should be true")
 	}
 
-	// 4. CanBotPromote
 	if !CanBotPromote(bot, ctx, chat) {
 		t.Error("CanBotPromote() should be true")
 	}
 
-	// 5. CanUserPin
 	if !CanUserPin(bot, ctx, chat, 10) {
 		t.Error("CanUserPin(10) should be true")
 	}
 
-	// 6. CanBotPin
 	if !CanBotPin(bot, ctx, chat) {
 		t.Error("CanBotPin() should be true")
 	}
 
-	// 7. CanUserDelete
 	if !CanUserDelete(bot, ctx, chat, 10) {
 		t.Error("CanUserDelete(10) should be true")
 	}
 
-	// 8. CanBotDelete
 	if !CanBotDelete(bot, ctx, chat) {
 		t.Error("CanBotDelete() should be true")
 	}
 
-	// 9. RequireBotAdmin
 	if !RequireBotAdmin(bot, ctx, chat) {
 		t.Error("RequireBotAdmin() should be true")
 	}
 
-	// 10. RequireUserAdmin
 	if !RequireUserAdmin(bot, ctx, chat, 10) {
 		t.Error("RequireUserAdmin(10) should be true")
 	}
 
-	// 11. RequireUserOwner
 	if !RequireUserOwner(bot, ctx, chat, 12) {
 		t.Error("RequireUserOwner(12) should be true")
 	}
 
-	// 12. RequirePrivate
 	privateCtx := makeCtxWithMessage("private")
 	privateChat := &gotgbot.Chat{Type: "private"}
 	if !RequirePrivate(bot, privateCtx, privateChat) {
 		t.Error("RequirePrivate() should be true for private chat")
 	}
 
-	// 13. RequireGroup
 	if !RequireGroup(bot, ctx, chat) {
 		t.Error("RequireGroup() should be true for supergroup")
 	}
 
-	// 14. GetEffectiveUser & RequireUser
 	if got := GetEffectiveUser(ctx); got == nil || got.Id != 42 {
 		t.Errorf("GetEffectiveUser() = %v, want User 42", got)
 	}
@@ -188,7 +164,6 @@ func TestOtherExportedFunctions(t *testing.T) {
 		t.Errorf("GetEffectiveUser(nil) = %v, want nil", got)
 	}
 
-	// 15. IsBotAdmin
 	if !IsBotAdmin(bot, ctx, chat) {
 		t.Error("IsBotAdmin() should be true for bot 999 in chat -1001")
 	}
@@ -350,22 +325,15 @@ func TestExtractAdminUpdateStatusChange(t *testing.T) {
 	})
 }
 
-// TestIsBotAdminUsesCacheAndStatus verifies that IsBotAdmin correctly reports
-// true when the bot is an administrator and false when it is a regular member.
-// After Step 2 the code path goes through getUserMemberWithCache which falls
-// back to a live getChatMember on a cache miss — the fake bot client simulates
-// both outcomes.
 func TestIsBotAdminUsesCacheAndStatus(t *testing.T) {
 	chat := &gotgbot.Chat{Id: -1001, Type: "supergroup", Title: "Permission Chat"}
 
-	// Bot ID 999 → chatStatusBotClient returns status "administrator" → want true.
 	adminBot := newChatStatusBot(999)
 	adminCtx := makeCtxForBot(adminBot, "supergroup")
 	if !IsBotAdmin(adminBot, adminCtx, chat) {
 		t.Error("IsBotAdmin(adminBot) = false, want true for administrator status")
 	}
 
-	// Bot ID 100 → chatStatusBotClient default case returns status "member" → want false.
 	memberBot := &gotgbot.Bot{
 		Token:     "100:test",
 		BotClient: chatStatusBotClient{},
@@ -376,7 +344,6 @@ func TestIsBotAdminUsesCacheAndStatus(t *testing.T) {
 		t.Error("IsBotAdmin(memberBot) = true, want false for member status")
 	}
 
-	// Private chat → always true regardless of bot status.
 	privateChat := &gotgbot.Chat{Id: 42, Type: "private"}
 	privateCtx := makeCtxForBot(memberBot, "private")
 	if !IsBotAdmin(memberBot, privateCtx, privateChat) {
@@ -384,7 +351,6 @@ func TestIsBotAdminUsesCacheAndStatus(t *testing.T) {
 	}
 }
 
-// makeCtxForBot creates a minimal ext.Context whose message chat type matches chatType.
 func makeCtxForBot(b *gotgbot.Bot, chatType string) *ext.Context {
 	msg := &gotgbot.Message{
 		MessageId: 200,

--- a/alita/utils/chat_status/isuseradmin_test.go
+++ b/alita/utils/chat_status/isuseradmin_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
 )
 
-// errorBotClient is a bot client that returns an error for getChat requests,
-// used to exercise the GetChatWithContext error path inside IsUserAdmin.
 type errorBotClient struct {
-	chatErr  bool   // if true, getChat returns an error
-	chatType string // if non-empty and chatErr is false, getChat returns this type
+	chatErr  bool
+	chatType string
 }
 
 func (c *errorBotClient) RequestWithContext(
@@ -70,8 +68,6 @@ func (c *statusOnlyBotClient) RequestWithContext(
 	case "getChatMember":
 		uidStr := fmt.Sprint(params["user_id"])
 
-		// Bot is not an admin → LoadAdminCache will return an empty cached list,
-		// which triggers the direct-GetChatMember fallback in IsUserAdmin.
 		if uidStr == fmt.Sprint(c.botID) {
 			return json.RawMessage(fmt.Sprintf(
 				`{"status":"member","user":{"id":%d,"is_bot":true,"first_name":"FallbackBot"}}`,
@@ -79,7 +75,6 @@ func (c *statusOnlyBotClient) RequestWithContext(
 			)), nil
 		}
 
-		// Resolve the requested user ID to the stubbed status.
 		for uid, status := range c.statusMap {
 			if uidStr == fmt.Sprint(uid) {
 				return json.RawMessage(fmt.Sprintf(
@@ -88,7 +83,6 @@ func (c *statusOnlyBotClient) RequestWithContext(
 				)), nil
 			}
 		}
-		// Unknown user → treat as regular member.
 		return json.RawMessage(`{"status":"member","user":{"id":0,"is_bot":false,"first_name":"Unknown"}}`), nil
 
 	default:
@@ -112,8 +106,6 @@ func newStatusBot(botID int64, statusMap map[int64]string) *gotgbot.Bot {
 	}
 }
 
-// recordingClient wraps statusOnlyBotClient and tracks every method called.
-// Used by TestIsUserAdminChannelIDReturnsFalse to assert no API call is made.
 type recordingStatusClient struct {
 	inner *statusOnlyBotClient
 	calls []string
@@ -135,14 +127,6 @@ func (c *recordingStatusClient) FileURL(token, path string, opts *gotgbot.Reques
 	return c.inner.FileURL(token, path, opts)
 }
 
-// TestIsUserAdminMemberStatuses verifies the documented contract:
-//   - "creator" and "administrator" → IsUserAdmin returns true
-//   - "member", "restricted", "left", "kicked" → IsUserAdmin returns false
-//
-// The test forces the GetChatMember fallback path inside IsUserAdmin by
-// using a bot that is not a chat administrator (so LoadAdminCache returns an
-// empty list) and then seeding the response for the target user.
-//
 // NOTE: this test must NOT use t.Parallel() because SetupTestMemoryMarshaler
 // writes to package-level globals that are not safe to write concurrently.
 func TestIsUserAdminMemberStatuses(t *testing.T) {
@@ -166,7 +150,6 @@ func TestIsUserAdminMemberStatuses(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Each sub-test uses a unique chatID so cache entries do not interfere.
 			subChatID := chatID - tc.userID
 			bot := newStatusBot(8800+tc.userID, map[int64]string{tc.userID: tc.status})
 
@@ -178,10 +161,7 @@ func TestIsUserAdminMemberStatuses(t *testing.T) {
 	}
 }
 
-// TestIsUserAdminChannelIDReturnsFalse asserts that IsUserAdmin short-circuits
-// to false for channel IDs (< -1000000000000) without making any Telegram API
-// call.  This guards against the privilege-escalation class of bugs where a
-// channel acting as a group member could be treated as an admin.
+// Guards against privilege escalation where a channel acting as a group member could be treated as an admin.
 func TestIsUserAdminChannelIDReturnsFalse(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -203,7 +183,6 @@ func TestIsUserAdminChannelIDReturnsFalse(t *testing.T) {
 	}
 
 	for _, chanID := range channelIDs {
-		// Confirm the ID is indeed recognised as a channel ID.
 		if !IsChannelId(chanID) {
 			t.Fatalf("test setup error: %d is not recognised as a channel ID", chanID)
 		}
@@ -219,13 +198,6 @@ func TestIsUserAdminChannelIDReturnsFalse(t *testing.T) {
 	}
 }
 
-// TestIsUserAdminUsesCache verifies two things:
-//
-//  1. Cache HIT: when the admin cache is pre-populated with a user's entry,
-//     IsUserAdmin returns true without touching the Telegram API.
-//
-//  2. Cache MISS: after the cache is invalidated, IsUserAdmin falls back to the
-//     live API (stubbed here) and returns the correct value.
 func TestIsUserAdminUsesCache(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -235,9 +207,6 @@ func TestIsUserAdminUsesCache(t *testing.T) {
 		nonAdminID = int64(302)
 	)
 
-	// ── Part 1: cache HIT ────────────────────────────────────────────────────
-
-	// Seed the admin cache directly, bypassing the API entirely.
 	adminEntry := gotgbot.MergedChatMember{
 		Status: "administrator",
 		User:   gotgbot.User{Id: adminID, FirstName: "CachedAdmin"},
@@ -256,7 +225,6 @@ func TestIsUserAdminUsesCache(t *testing.T) {
 		t.Fatalf("seeding admin cache: %v", err)
 	}
 
-	// A recording bot that must NOT be called during the cache-hit phase.
 	inner := &statusOnlyBotClient{
 		botID:     9901,
 		statusMap: map[int64]string{nonAdminID: "member"},
@@ -275,7 +243,6 @@ func TestIsUserAdminUsesCache(t *testing.T) {
 		t.Errorf("cache HIT: unexpected API calls (should have used cache): %v", rec.calls)
 	}
 
-	// A non-admin user should return false via the cache as well.
 	if IsUserAdmin(bot, chatID, nonAdminID) {
 		t.Error("cache HIT: IsUserAdmin(nonAdminID) = true, want false (user not in admin cache)")
 	}
@@ -283,21 +250,15 @@ func TestIsUserAdminUsesCache(t *testing.T) {
 		t.Errorf("cache HIT: unexpected API calls for non-admin lookup: %v", rec.calls)
 	}
 
-	// ── Part 2: cache MISS (invalidated → falls back to API) ─────────────────
-
 	cache.InvalidateAdminCache(chatID)
-	rec.calls = nil // reset the call log
+	rec.calls = nil
 
-	// After invalidation the cache miss triggers: GetChatWithContext →
-	// LoadAdminCache (bot is non-admin → empty list) → GetChatMemberWithContext.
-	// The stub returns "administrator" for adminID.
 	inner.statusMap[adminID] = "administrator"
 	rec.inner = &statusOnlyBotClient{
 		botID:     9901,
 		statusMap: map[int64]string{adminID: "administrator", nonAdminID: "member"},
 	}
 
-	// Use a unique chatID to avoid any lingering cache from part 1.
 	const cacheMissChatID = int64(-3002)
 	innerFresh := &statusOnlyBotClient{
 		botID:     9902,
@@ -318,9 +279,6 @@ func TestIsUserAdminUsesCache(t *testing.T) {
 	}
 }
 
-// TestIsUserAdminTelegramServiceAccounts verifies that the special Telegram
-// service account IDs (groupAnonymousBot and tgUserId) are always treated as
-// admins regardless of what the cache or API would return.
 func TestIsUserAdminTelegramServiceAccounts(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -350,15 +308,11 @@ func TestIsUserAdminTelegramServiceAccounts(t *testing.T) {
 		}
 	}
 
-	// Service accounts are handled before any cache or API lookup.
 	if len(rec.calls) != 0 {
 		t.Errorf("IsUserAdmin made unexpected API calls for service accounts: %v", rec.calls)
 	}
 }
 
-// TestIsUserAdminInvalidNonChannelUserIDs covers the warning branch for IDs that
-// are ≤ 0 but not channel IDs (i.e. zero and small-negative group IDs).
-// This exercises the else-if branch at chat_status.go:212.
 func TestIsUserAdminInvalidNonChannelUserIDs(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -370,12 +324,9 @@ func TestIsUserAdminInvalidNonChannelUserIDs(t *testing.T) {
 		User:      gotgbot.User{Id: 9904, IsBot: true, FirstName: "InvBot"},
 	}
 
-	// These IDs are ≤ 0 but are NOT channel IDs (not < -1000000000000),
-	// so they trigger the Warning branch rather than the channel-ID Debug branch.
 	nonChannelInvalidIDs := []int64{0, -1, -999, -100000000000}
 	for _, id := range nonChannelInvalidIDs {
 		if IsChannelId(id) {
-			// skip any that happen to be channel IDs to keep the branch distinct
 			continue
 		}
 		if IsUserAdmin(bot, -100888, id) {
@@ -383,15 +334,11 @@ func TestIsUserAdminInvalidNonChannelUserIDs(t *testing.T) {
 		}
 	}
 
-	// The guard fires before any API call.
 	if len(rec.calls) != 0 {
 		t.Errorf("IsUserAdmin made unexpected API calls for invalid user IDs: %v", rec.calls)
 	}
 }
 
-// TestIsUserAdminGetChatError covers the error path when GetChatWithContext
-// fails (cache miss scenario where the API is unreachable).
-// Exercises chat_status.go:251-258.
 func TestIsUserAdminGetChatError(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -401,19 +348,15 @@ func TestIsUserAdminGetChatError(t *testing.T) {
 		User:      gotgbot.User{Id: 9905, IsBot: true, FirstName: "ErrBot"},
 	}
 
-	// Cache is empty so IsUserAdmin will try GetChatWithContext which returns an error.
 	got := IsUserAdmin(bot, -4001, 42)
 	if got {
 		t.Error("IsUserAdmin(GetChatWithContext error) = true, want false")
 	}
 }
 
-// TestIsUserAdminNonGroupChatType covers the guard at chat_status.go:261-263
-// where the function returns false if the chat is not a group or supergroup.
 func TestIsUserAdminNonGroupChatType(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
-	// Use a bot whose getChat returns a "private" type — the guard fires immediately.
 	bot := &gotgbot.Bot{
 		Token:     "9906:privtest",
 		BotClient: &errorBotClient{chatErr: false, chatType: "private"},
@@ -426,9 +369,6 @@ func TestIsUserAdminNonGroupChatType(t *testing.T) {
 	}
 }
 
-// TestIsUserAdminCacheHitLinearScan covers the backwards-compatibility linear
-// scan path (chat_status.go:241-246) where a cached AdminCache has a nil
-// UserMap and must be searched via UserInfo slice.
 func TestIsUserAdminCacheHitLinearScan(t *testing.T) {
 	cache.SetupTestMemoryMarshaler(t)
 
@@ -437,7 +377,6 @@ func TestIsUserAdminCacheHitLinearScan(t *testing.T) {
 		adminID = int64(501)
 	)
 
-	// Seed cache WITHOUT a UserMap (nil) to trigger the linear scan path.
 	adminEntry := gotgbot.MergedChatMember{
 		Status: "administrator",
 		User:   gotgbot.User{Id: adminID, FirstName: "LinearAdmin"},
@@ -464,16 +403,13 @@ func TestIsUserAdminCacheHitLinearScan(t *testing.T) {
 		User:      gotgbot.User{Id: 9907, IsBot: true, FirstName: "LinBot"},
 	}
 
-	// Cache hit with linear scan → should find the admin and return true.
 	if !IsUserAdmin(bot, chatID, adminID) {
 		t.Error("cache HIT linear scan: IsUserAdmin(adminID) = false, want true")
 	}
-	// No API call should have been made.
 	if len(rec.calls) != 0 {
 		t.Errorf("cache HIT linear scan: unexpected API calls: %v", rec.calls)
 	}
 
-	// A user NOT in the UserInfo list must return false.
 	if IsUserAdmin(bot, chatID, 502) {
 		t.Error("cache HIT linear scan: IsUserAdmin(non-admin) = true, want false")
 	}
@@ -482,11 +418,6 @@ func TestIsUserAdminCacheHitLinearScan(t *testing.T) {
 	}
 }
 
-// TestIsUserAdminFallbackGetChatMemberErrors covers the error sub-paths inside
-// the GetChatMember fallback (chat_status.go:292-321): CHAT_ADMIN_REQUIRED,
-// invalid user_id, and an unexpected generic error must all return false without
-// panicking.
-//
 // NOTE: must NOT use t.Parallel() at sub-test level because SetupTestMemoryMarshaler
 // writes package-level globals that are not concurrency-safe across goroutines.
 func TestIsUserAdminFallbackGetChatMemberErrors(t *testing.T) {
@@ -503,14 +434,9 @@ func TestIsUserAdminFallbackGetChatMemberErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cache.SetupTestMemoryMarshaler(t)
 
-			// Use a unique chatID per sub-test to avoid cache bleed.
 			chatID := int64(-6000) - int64(len(tc.name))
 			userID := int64(601)
 
-			// A client where:
-			//   getChat → valid supergroup (so IsUserAdmin proceeds past type guard)
-			//   getChatMember:<botID> → "member" (bot not admin → LoadAdminCache returns empty)
-			//   getChatMember:<userID> → error
 			client := &fallbackErrBotClient{
 				botID:   int64(9910),
 				chatID:  chatID,
@@ -556,7 +482,6 @@ func (c *fallbackErrBotClient) RequestWithContext(
 	case "getChatMember":
 		uidStr := fmt.Sprint(params["user_id"])
 		if uidStr == fmt.Sprint(c.botID) {
-			// Bot is not an admin → LoadAdminCache returns empty list.
 			return json.RawMessage(fmt.Sprintf(
 				`{"status":"member","user":{"id":%d,"is_bot":true,"first_name":"ErrFallbackBot"}}`,
 				c.botID,

--- a/alita/utils/chat_status/permission_responder.go
+++ b/alita/utils/chat_status/permission_responder.go
@@ -9,25 +9,19 @@ import (
 	"github.com/divkix/Alita_Robot/alita/i18n"
 )
 
-// respondCfg holds per-call options for PermissionResponder.Respond.
 type respondCfg struct {
 	useReply              bool
 	fallbackToSendMessage bool
 }
 
-// respondOpt configures a single Respond call.
 type respondOpt func(*respondCfg)
 
-// WithReply makes the responder use msg.Reply instead of b.SendMessage.
-// This preserves the exact behaviour of functions like RequireBotAdmin.
 func WithReply() respondOpt {
 	return func(c *respondCfg) {
 		c.useReply = true
 	}
 }
 
-// WithReplyFallback makes the responder try msg.Reply first and fall back to
-// b.SendMessage with ReplyParameters if Reply fails. Used by RequireUserAdmin.
 func WithReplyFallback() respondOpt {
 	return func(c *respondCfg) {
 		c.useReply = true
@@ -35,29 +29,14 @@ func WithReplyFallback() respondOpt {
 	}
 }
 
-// PermissionResponder centralises the response choreography for failed
-// permission checks. Callers perform the pure check; when it fails they
-// delegate error messaging to Respond.
 type PermissionResponder struct {
 	bot *gotgbot.Bot
 }
 
-// NewPermissionResponder creates a PermissionResponder for the given bot.
 func NewPermissionResponder(b *gotgbot.Bot) *PermissionResponder {
 	return &PermissionResponder{bot: b}
 }
 
-// Respond sends the correct error response for a failed permission check.
-//
-//   - If btnKey is non-empty and the update is a callback query, the text is
-//     answered via query.Answer with btnKey translation.
-//   - Otherwise the text is sent as a chat message using cmdKey translation.
-//     By default SendMessage with ReplyParameters{AllowSendingWithoutReply:true}
-//     is used. Callers that previously used msg.Reply can pass WithReply().
-//     RequireUserAdmin passes WithReplyFallback().
-//
-// It always returns false so the permission check function can return it
-// directly.
 func (r *PermissionResponder) Respond(ctx *ext.Context, cmdKey, btnKey string, opts ...respondOpt) bool {
 	cfg := respondCfg{}
 	for _, o := range opts {
@@ -71,7 +50,6 @@ func (r *PermissionResponder) Respond(ctx *ext.Context, cmdKey, btnKey string, o
 
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Callback query path.
 	if btnKey != "" {
 		query, _ := callbackQueryFromContext(ctx)
 		if query != nil {

--- a/alita/utils/chat_status/permission_responder_test.go
+++ b/alita/utils/chat_status/permission_responder_test.go
@@ -54,7 +54,6 @@ func TestNewPermissionResponder(t *testing.T) {
 	}
 }
 
-// TestPermissionResponderRespondNegativeCases verifies that Respond returns false for nil context or nil EffectiveMessage.
 func TestPermissionResponderRespondNegativeCases(t *testing.T) {
 	tests := []struct {
 		name string
@@ -77,18 +76,15 @@ func TestPermissionResponderRespondNegativeCases(t *testing.T) {
 func TestPermissionResponderRespond(t *testing.T) {
 	bot := newChatStatusBot(999)
 
-	// Test 1: Callback Query path
 	t.Run("CallbackQuery", func(t *testing.T) {
 		ctx := makeCtxWithCallbackQuery()
 		r := NewPermissionResponder(bot)
-		// btnKey is non-empty, and update has callback query
 		res := r.Respond(ctx, "chat_status_restrict_cmd_error", "chat_status_restrict_button_error")
 		if res != false {
 			t.Fatal("Respond should return false")
 		}
 	})
 
-	// Test 2: Reply path (WithReply)
 	t.Run("WithReply", func(t *testing.T) {
 		ctx := makeCtxWithMessage("supergroup")
 		r := NewPermissionResponder(bot)
@@ -98,7 +94,6 @@ func TestPermissionResponderRespond(t *testing.T) {
 		}
 	})
 
-	// Test 3: Reply path with fallback (WithReplyFallback)
 	t.Run("WithReplyFallback", func(t *testing.T) {
 		ctx := makeCtxWithMessage("supergroup")
 		r := NewPermissionResponder(bot)

--- a/alita/utils/constants/time.go
+++ b/alita/utils/constants/time.go
@@ -2,26 +2,21 @@ package constants
 
 import "time"
 
-// Common time durations used throughout the application
 const (
-	// Cache durations
 	AdminCacheTTL           = 30 * time.Minute
 	RestrictedCacheTTL      = 30 * time.Minute
 	RestrictedProbeInterval = 5 * time.Minute
 	ShortCacheTTL           = 1 * time.Minute
 
-	// Update intervals
 	UserUpdateInterval    = 5 * time.Minute
 	ChatUpdateInterval    = 5 * time.Minute
 	ChannelUpdateInterval = 5 * time.Minute
 
-	// Timeout durations
 	DefaultTimeout  = 10 * time.Second
 	ShortTimeout    = 5 * time.Second
 	LongTimeout     = 30 * time.Second
 	VeryLongTimeout = 120 * time.Second
 
-	// Connection pooling
 	DefaultHTTPPort         = 8080
 	MaxIdleConnsExtraBuffer = 20
 )

--- a/alita/utils/content/content.go
+++ b/alita/utils/content/content.go
@@ -13,7 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/i18n"
 )
 
-// ExtractResult holds the parsed content and metadata from a note or filter message.
 type ExtractResult struct {
 	KeyWord     string
 	FileID      string
@@ -29,7 +28,6 @@ type ExtractResult struct {
 	ErrorMsg    string
 }
 
-// WelcomeResult holds the parsed content and metadata from a welcome/greeting message.
 type WelcomeResult struct {
 	Text     string
 	DataType int
@@ -38,21 +36,16 @@ type WelcomeResult struct {
 	ErrorMsg string
 }
 
-// ExtractNoteAndFilter extracts and processes note or filter content from a Telegram message.
-// Handles text, media files, and reply messages with button parsing and content validation.
-// Returns parsed content with metadata like data type, buttons, and special options.
-//
 //nolint:dupl // ExtractNoteAndFilter shares media detection logic with ExtractWelcome
 func ExtractNoteAndFilter(msg *gotgbot.Message, isFilter bool, language string) ExtractResult {
 	var result ExtractResult
-	result.DataType = -1 // not defined datatype; invalid note
+	result.DataType = -1
 	tr := i18n.MustNewTranslator(language)
 
-	// Check for nil message to prevent panic
 	if msg == nil {
 		result.ErrorMsg, _ = tr.GetString("content_invalid_message")
 		if result.ErrorMsg == "" {
-			result.ErrorMsg = "Invalid message: message is nil" // fallback
+			result.ErrorMsg = "Invalid message: message is nil"
 		}
 		return result
 	}
@@ -60,12 +53,12 @@ func ExtractNoteAndFilter(msg *gotgbot.Message, isFilter bool, language string) 
 	if isFilter {
 		result.ErrorMsg, _ = tr.GetString("content_need_filter_content")
 		if result.ErrorMsg == "" {
-			result.ErrorMsg = "You need to give the filter some content!" // fallback
+			result.ErrorMsg = "You need to give the filter some content!"
 		}
 	} else {
 		result.ErrorMsg, _ = tr.GetString("content_need_note_content")
 		if result.ErrorMsg == "" {
-			result.ErrorMsg = "You need to give the note some content!" // fallback
+			result.ErrorMsg = "You need to give the note some content!"
 		}
 	}
 
@@ -73,15 +66,12 @@ func ExtractNoteAndFilter(msg *gotgbot.Message, isFilter bool, language string) 
 		rawText string
 		args    = strings.Fields(msg.Text)[1:]
 	)
-	_buttons := make([]tgmd2html.ButtonV2, 0) // make a slice for buttons
+	_buttons := make([]tgmd2html.ButtonV2, 0)
 	replyMsg := msg.ReplyToMessage
 
-	// set rawText from helper function
 	setRawText(msg, args, &rawText)
 
-	// extract the noteword
 	if len(args) >= 2 && replyMsg == nil {
-		// Uses inline extraction to avoid circular dependency with the extraction package.
 		if len(args) > 0 {
 			result.KeyWord = args[0]
 			if len(args) > 1 {
@@ -91,7 +81,6 @@ func ExtractNoteAndFilter(msg *gotgbot.Message, isFilter bool, language string) 
 		result.Text, _buttons = tgmd2html.MD2HTMLButtonsV2(result.Text)
 		result.DataType = db.TEXT
 	} else if replyMsg != nil && len(args) >= 1 {
-		// Uses inline extraction to avoid circular dependency with the extraction package.
 		result.KeyWord = strings.Join(args, " ")
 
 		if replyMsg.ReplyMarkup == nil {
@@ -108,21 +97,15 @@ func ExtractNoteAndFilter(msg *gotgbot.Message, isFilter bool, language string) 
 		}
 	}
 
-	// pre-fix the data before sending it back
 	preFixes(_buttons, result.KeyWord, &result.Text, &result.DataType, result.FileID, &result.Buttons, &result.ErrorMsg, language)
 
-	// return if datatype is invalid
 	if result.DataType != -1 && !isFilter {
-		// parse options such as pvtOnly, adminOnly, webPrev and replace them
 		result.PvtOnly, result.GrpOnly, result.AdminOnly, result.WebPreview, result.IsProtected, result.NoNotif, _ = NotesParser(result.Text)
 	}
 
 	return result
 }
 
-// extractMediaFromReply extracts media file ID and data type from a reply message.
-// Checks for sticker, document, photo, audio, voice, video, animation, and video note in order.
-// Returns empty fileid and -1 dataType if no media is found.
 func extractMediaFromReply(replyMsg *gotgbot.Message) (fileid string, dataType int) {
 	if replyMsg == nil {
 		return "", -1
@@ -147,16 +130,13 @@ func extractMediaFromReply(replyMsg *gotgbot.Message) (fileid string, dataType i
 	return "", -1
 }
 
-// ExtractWelcome extracts and processes welcome/greeting content from a Telegram message.
-// Similar to ExtractNoteAndFilter but specifically for greeting messages.
-// Returns processed content with data type, file ID, and buttons for the greeting.
 func ExtractWelcome(msg *gotgbot.Message, greetingType string, language string) WelcomeResult {
 	var result WelcomeResult
 	result.DataType = -1
 	tr := i18n.MustNewTranslator(language)
 	template, _ := tr.GetString("content_need_content")
 	if template == "" {
-		template = "You need to give me some content to %s users!" // fallback
+		template = "You need to give me some content to %s users!"
 	}
 	result.ErrorMsg = fmt.Sprintf(template, greetingType)
 	var (
@@ -166,7 +146,6 @@ func ExtractWelcome(msg *gotgbot.Message, greetingType string, language string) 
 	_buttons := make([]tgmd2html.ButtonV2, 0)
 	replyMsg := msg.ReplyToMessage
 
-	// set rawText from helper function
 	setRawText(msg, args, &rawText)
 
 	if len(args) >= 1 && msg.ReplyToMessage == nil {
@@ -187,15 +166,11 @@ func ExtractWelcome(msg *gotgbot.Message, greetingType string, language string) 
 		}
 	}
 
-	// pre-fix the data before sending it back
 	preFixes(_buttons, "Greeting", &result.Text, &result.DataType, result.FileID, &result.Buttons, &result.ErrorMsg, language)
 
 	return result
 }
 
-// NotesParser parses special note options from message text using regex patterns.
-// Detects {private}, {noprivate}, {admin}, {preview}, {protect}, {nonotif} tags.
-// Returns boolean flags for each option and the text with tags removed.
 func NotesParser(sent string) (pvtOnly, grpOnly, adminOnly, webPrev, protectedContent, noNotif bool, sentBack string) {
 	pvtOnly = strings.Contains(sent, "{private}")
 	grpOnly = strings.Contains(sent, "{noprivate}")
@@ -216,13 +191,9 @@ func NotesParser(sent string) (pvtOnly, grpOnly, adminOnly, webPrev, protectedCo
 	return pvtOnly, grpOnly, adminOnly, webPrev, protectedContent, noNotif, sent
 }
 
-// preFixes validates and preprocesses message content before database storage.
-// Checks message length limits using UTF-8 character count (not bytes), validates button URLs,
-// sets default button names, and filters invalid content. Modifies parameters by reference.
 func preFixes(buttons []tgmd2html.ButtonV2, defaultNameButton string, text *string, dataType *int, fileid string, dbButtons *[]db.Button, errorMsg *string, language string) {
 	tr := i18n.MustNewTranslator(language)
 
-	// Use utf8.RuneCountInString to count UTF-8 characters instead of len() for bytes
 	textRuneCount := utf8.RuneCountInString(*text)
 
 	if *dataType == db.TEXT && textRuneCount > 4096 {
@@ -240,9 +211,7 @@ func preFixes(buttons []tgmd2html.ButtonV2, defaultNameButton string, text *stri
 			}
 		}
 
-		// buttonUrlFixer filters out non-URL buttons from the keyboard, keeping only valid URL buttons.
 		buttonUrlFixer := func(_buttons *[]tgmd2html.ButtonV2) {
-			// Validate URLs using Go's net/url parser instead of regex for proper validation
 			validButtons := make([]tgmd2html.ButtonV2, 0, len(*_buttons))
 			for _, btn := range *_buttons {
 				u, err := url.Parse(btn.Content)
@@ -256,8 +225,6 @@ func preFixes(buttons []tgmd2html.ButtonV2, defaultNameButton string, text *stri
 		buttonUrlFixer(&buttons)
 		*dbButtons = ConvertButtonV2ToDbButton(buttons)
 
-		// trim the characters \n, \t, \r and space from the text
-		// also, set the dataType to -1 to make note invalid
 		*text = strings.Trim(*text, "\n\t\r ")
 		if *text == "" && fileid == "" {
 			*dataType = -1
@@ -265,21 +232,18 @@ func preFixes(buttons []tgmd2html.ButtonV2, defaultNameButton string, text *stri
 	}
 }
 
-// setRawText extracts raw markdown text from a Telegram message.
-// Handles both direct message text/caption and replied message content.
-// Sets rawText parameter by reference with the extracted content.
 func setRawText(msg *gotgbot.Message, args []string, rawText *string) {
 	replyMsg := msg.ReplyToMessage
 	if replyMsg == nil {
 		if msg.Text == "" && msg.Caption != "" {
 			parts := strings.SplitN(msg.OriginalCaptionMDV2(), " ", 2)
 			if len(parts) >= 2 {
-				*rawText = parts[1] // remove the command
+				*rawText = parts[1]
 			}
 		} else if msg.Text != "" && msg.Caption == "" {
 			parts := strings.SplitN(msg.OriginalMDV2(), " ", 2)
 			if len(parts) >= 2 {
-				*rawText = parts[1] // remove the command
+				*rawText = parts[1]
 			}
 		}
 	} else {
@@ -288,7 +252,7 @@ func setRawText(msg *gotgbot.Message, args []string, rawText *string) {
 		} else if replyMsg.Caption == "" && len(args) >= 2 {
 			parts := strings.SplitN(msg.OriginalMDV2(), " ", 3)
 			if len(parts) >= 3 {
-				*rawText = parts[2] // remove the command and first arg
+				*rawText = parts[2]
 			}
 		} else {
 			*rawText = replyMsg.OriginalMDV2()
@@ -296,8 +260,6 @@ func setRawText(msg *gotgbot.Message, args []string, rawText *string) {
 	}
 }
 
-// convertButtonV2ToDbButton converts markdown parser button format to database button format.
-// Maps ButtonV2 fields to corresponding db.Button fields.
 func ConvertButtonV2ToDbButton(buttons []tgmd2html.ButtonV2) (btns []db.Button) {
 	btns = make([]db.Button, len(buttons))
 	for i, btn := range buttons {
@@ -310,8 +272,6 @@ func ConvertButtonV2ToDbButton(buttons []tgmd2html.ButtonV2) (btns []db.Button) 
 	return
 }
 
-// RevertButtons converts database button format back to markdown button string format.
-// Generates markdown buttonurl syntax for each button with proper same-line handling.
 func RevertButtons(buttons []db.Button) string {
 	var sb strings.Builder
 	for _, btn := range buttons {
@@ -324,15 +284,11 @@ func RevertButtons(buttons []db.Button) string {
 	return sb.String()
 }
 
-// inlineKeyboardToButtonV2 converts Telegram inline keyboard to markdown button format.
-// Filters out non-URL buttons and handles same-line button positioning.
 func inlineKeyboardToButtonV2(replyMarkup *gotgbot.InlineKeyboardMarkup) (btns []tgmd2html.ButtonV2) {
 	btns = make([]tgmd2html.ButtonV2, 0)
 	for _, inlineKeyboard := range replyMarkup.InlineKeyboard {
 		if len(inlineKeyboard) > 1 {
 			for i, button := range inlineKeyboard {
-				// if any button has anything other than url, it's not a valid button
-				// skip options such as CallbackData, CallbackUrl, etc.
 				if button.Url == "" {
 					continue
 				}

--- a/alita/utils/content/content_test.go
+++ b/alita/utils/content/content_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/db"
 )
 
-// ---------------------------------------------------------------------------
-// ExtractNoteAndFilter
-// ---------------------------------------------------------------------------
-
 func TestExtractNoteAndFilterNilMessage(t *testing.T) {
 	t.Parallel()
 
@@ -102,7 +98,6 @@ func TestExtractNoteAndFilterFilterMode(t *testing.T) {
 	if result.DataType != db.TEXT {
 		t.Fatalf("expected dataType=%d for filter, got %d", db.TEXT, result.DataType)
 	}
-	// Filters should not parse note options
 	if result.PvtOnly {
 		t.Fatal("expected PvtOnly=false for filter")
 	}
@@ -110,10 +105,6 @@ func TestExtractNoteAndFilterFilterMode(t *testing.T) {
 		t.Fatal("expected AdminOnly=false for filter")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// ExtractWelcome
-// ---------------------------------------------------------------------------
 
 func TestExtractWelcomeDirectText(t *testing.T) {
 	t.Parallel()
@@ -165,10 +156,6 @@ func TestExtractWelcomeNoContent(t *testing.T) {
 		t.Fatal("expected errorMsg for no content")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// extractMediaFromReply
-// ---------------------------------------------------------------------------
 
 func TestExtractMediaFromReply(t *testing.T) {
 	tests := []struct {
@@ -267,10 +254,6 @@ func TestExtractMediaFromReply(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// setRawText
-// ---------------------------------------------------------------------------
-
 func TestSetRawText(t *testing.T) {
 	tests := []struct {
 		name string
@@ -324,10 +307,6 @@ func TestSetRawText(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// preFixes
-// ---------------------------------------------------------------------------
 
 func TestPreFixesTextTooLong(t *testing.T) {
 	t.Parallel()
@@ -427,10 +406,6 @@ func TestPreFixesEmptyTextWithFile(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// NotesParser
-// ---------------------------------------------------------------------------
-
 func TestNotesParser(t *testing.T) {
 	t.Parallel()
 
@@ -455,7 +430,6 @@ func TestNotesParser(t *testing.T) {
 	if !noNotif {
 		t.Fatal("expected noNotif=true")
 	}
-	// Each tag is replaced by an empty string, leaving spaces between them.
 	if clean != "Hello      " {
 		t.Fatalf("expected clean text %q, got %q", "Hello      ", clean)
 	}
@@ -474,10 +448,6 @@ func TestNotesParserNone(t *testing.T) {
 		t.Fatalf("expected clean text unchanged, got %q", clean)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// ConvertButtonV2ToDbButton
-// ---------------------------------------------------------------------------
 
 func TestConvertButtonV2ToDbButton(t *testing.T) {
 	t.Parallel()
@@ -498,10 +468,6 @@ func TestConvertButtonV2ToDbButton(t *testing.T) {
 		t.Fatal("second button mismatch")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// RevertButtons
-// ---------------------------------------------------------------------------
 
 func TestRevertButtons(t *testing.T) {
 	t.Parallel()
@@ -527,10 +493,6 @@ func TestRevertButtonsEmpty(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// InlineKeyboardToDbButtons
-// ---------------------------------------------------------------------------
-
 func TestInlineKeyboardToDbButtons(t *testing.T) {
 	t.Parallel()
 
@@ -548,7 +510,6 @@ func TestInlineKeyboardToDbButtons(t *testing.T) {
 	}
 
 	buttons := InlineKeyboardToDbButtons(replyMarkup)
-	// Invalid URL is filtered by empty check; bad URL is filtered by URL validation.
 	if len(buttons) != 2 {
 		t.Fatalf("expected 2 valid buttons (filtered invalid), got %d", len(buttons))
 	}
@@ -560,7 +521,6 @@ func TestInlineKeyboardToDbButtons(t *testing.T) {
 	}
 }
 
-// isValidURL checks if a button URL is a valid HTTP/HTTPS URL with a non-empty host.
 func isValidURL(rawURL string) bool {
 	if rawURL == "" {
 		return false
@@ -572,9 +532,6 @@ func isValidURL(rawURL string) bool {
 	return true
 }
 
-// InlineKeyboardToDbButtons converts Telegram inline keyboard directly to database button format.
-// Filters out non-URL buttons, validates URLs, and handles same-line button positioning.
-// This is a test helper - not used in production code.
 func InlineKeyboardToDbButtons(replyMarkup *gotgbot.InlineKeyboardMarkup) []db.Button {
 	if replyMarkup == nil {
 		return nil
@@ -631,10 +588,6 @@ func TestInlineKeyboardToDbButtonsSameLine(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// inlineKeyboardToButtonV2
-// ---------------------------------------------------------------------------
-
 func TestInlineKeyboardToButtonV2(t *testing.T) {
 	t.Parallel()
 
@@ -651,7 +604,6 @@ func TestInlineKeyboardToButtonV2(t *testing.T) {
 	}
 
 	buttons := inlineKeyboardToButtonV2(replyMarkup)
-	// Callback button has no URL, so it is filtered out.
 	if len(buttons) != 2 {
 		t.Fatalf("expected 2 buttons (callback filtered), got %d", len(buttons))
 	}

--- a/alita/utils/error_handling/error_handling.go
+++ b/alita/utils/error_handling/error_handling.go
@@ -9,13 +9,10 @@ import (
 
 var onErrorCallback atomic.Value
 
-// SetOnErrorCallback registers a callback to be called when an error is recovered from panic
 func SetOnErrorCallback(cb func()) {
 	onErrorCallback.Store(cb)
 }
 
-// RecoverFromPanic recovers from a panic and logs it as an error.
-// This should be used with defer in goroutines to prevent crashes.
 func RecoverFromPanic(funcName, modName string) {
 	if r := recover(); r != nil {
 		stackTrace := string(debug.Stack())

--- a/alita/utils/error_handling/error_handling_test.go
+++ b/alita/utils/error_handling/error_handling_test.go
@@ -88,7 +88,7 @@ func TestRecoverFromPanic_InvokesOnErrorCallback(t *testing.T) {
 	SetOnErrorCallback(func() {
 		called.Store(true)
 	})
-	defer SetOnErrorCallback(nil) // cleanup
+	defer SetOnErrorCallback(nil)
 
 	done := make(chan struct{})
 	go func() {
@@ -110,10 +110,9 @@ func TestRecoverFromPanic_DoesNotInvokeOnErrorCallbackWithoutPanic(t *testing.T)
 	SetOnErrorCallback(func() {
 		called.Store(true)
 	})
-	defer SetOnErrorCallback(nil) // cleanup
+	defer SetOnErrorCallback(nil)
 
 	defer RecoverFromPanic("testFunc", "testMod")
-	// No panic
 
 	if called.Load() {
 		t.Error("onErrorCallback should NOT have been invoked when no panic occurs")

--- a/alita/utils/extraction/extraction.go
+++ b/alita/utils/extraction/extraction.go
@@ -35,8 +35,6 @@ const (
 	maxTemporaryDurationSeconds int64 = 366 * 24 * 60 * 60
 )
 
-// TemporaryUntilDate returns a Telegram-safe until_date for a temporary
-// moderation action.
 func TemporaryUntilDate(now, durationSeconds int64) (int64, bool) {
 	if durationSeconds < minTemporaryDurationSeconds ||
 		durationSeconds > maxTemporaryDurationSeconds ||
@@ -46,9 +44,6 @@ func TemporaryUntilDate(now, durationSeconds int64) (int64, bool) {
 	return now + durationSeconds, true
 }
 
-// ExtractChat extracts and validates a chat from command arguments.
-// Supports both numeric chat IDs and chat usernames for chat identification.
-// Returns nil if chat is not found or arguments are invalid.
 func ExtractChat(b *gotgbot.Bot, ctx *ext.Context) *gotgbot.Chat {
 	msg := ctx.EffectiveMessage
 	args := ctx.Args()[1:]
@@ -65,7 +60,7 @@ func ExtractChat(b *gotgbot.Bot, ctx *ext.Context) *gotgbot.Chat {
 				}
 				return nil
 			}
-			_chat := chat.ToChat() // need to convert to Chat type
+			_chat := chat.ToChat()
 			return &_chat
 		} else {
 			chat, err := chat_status.GetChat(b, args[0])
@@ -92,17 +87,11 @@ func ExtractChat(b *gotgbot.Bot, ctx *ext.Context) *gotgbot.Chat {
 	return nil
 }
 
-// ExtractUser extracts a user ID from the message context.
-// Uses ExtractUserAndText internally, returning only the user ID.
 func ExtractUser(b *gotgbot.Bot, ctx *ext.Context) int64 {
 	userId, _ := ExtractUserAndText(b, ctx)
 	return userId
 }
 
-// ExtractUserAndText extracts both user ID and accompanying text from various message formats.
-// Handles text mentions, usernames, numeric IDs, and reply messages.
-// Returns user ID and associated text. Validation of user existence is delegated to the calling
-// command, which can verify membership when needed via Telegram API.
 func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 	msg := ctx.EffectiveMessage
 	args := ctx.Args()
@@ -110,7 +99,6 @@ func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 
 	splitText := strings.SplitN(msg.Text, " ", 2)
 
-	// Early return if no arguments provided
 	if len(splitText) < 2 {
 		return IdFromReply(msg)
 	}
@@ -118,7 +106,6 @@ func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 	textToParse := splitText[1]
 	hasArgs := len(args) >= 2
 
-	// trimTextNewline trims leading/trailing newlines to fix parsing issues with '\n' before and after text
 	trimTextNewline := func(str string) string {
 		return strings.Trim(str, "\n")
 	}
@@ -139,7 +126,6 @@ func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 		ent = nil
 	}
 
-	// only parse if the entity is a text mention
 	if entities != nil && ent != nil && int(ent.Offset) == (len(msg.Text)-len(textToParse)) {
 		ent = &entities[0]
 		userId = ent.User.Id
@@ -192,9 +178,6 @@ func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 		}
 	}
 
-	// Only validate DB existence for username lookups, not for numeric IDs or text mentions.
-	// Numeric IDs from replies, text_mention entities, or direct input are trusted.
-	// The actual command will verify membership via Telegram API when executing the action.
 	if userId == 0 {
 		return 0, ""
 	}
@@ -202,20 +185,13 @@ func ExtractUserAndText(b *gotgbot.Bot, ctx *ext.Context) (int64, string) {
 	return userId, trimTextNewline(text)
 }
 
-// GetUserId retrieves a user ID from a username string.
-// Searches both user and channel databases for the username.
-// If not found in DB, queries Telegram API as fallback.
-// Returns 0 if username is invalid or not found.
 func GetUserId(b *gotgbot.Bot, username string) int64 {
-	// Remove '@' prefix first
 	username = strings.TrimPrefix(username, "@")
 
-	// Telegram usernames must be at least 5 characters
 	if len(username) < 5 {
 		return 0
 	}
 
-	// Try local database first for performance
 	user := user.GetUserIdByUserName(username)
 	if user != 0 {
 		return user
@@ -226,27 +202,19 @@ func GetUserId(b *gotgbot.Bot, username string) int64 {
 		return channel
 	}
 
-	// Fallback to Telegram API if not in local database
 	chat, err := chat_status.GetChat(b, "@"+username)
 	if err != nil {
 		log.Debugf("[Extraction] Failed to get user @%s from Telegram API: %v", username, err)
 		return 0
 	}
 
-	// Successfully found user via Telegram API
 	userId := chat.Id
 
-	// Optionally cache the user for future lookups
-	// Note: The bot's message handlers should already be caching users
-	// when they interact with the bot, but this provides a fallback
 	log.Debugf("[Extraction] Found user @%s (ID: %d) via Telegram API", username, userId)
 
 	return userId
 }
 
-// GetUserInfo retrieves user information (username and name) from a user ID.
-// Searches both user and channel databases for the ID.
-// Returns username, display name, and whether the user was found.
 func GetUserInfo(userId int64) (username, name string, found bool) {
 	username, name, found = user.GetUserInfoById(userId)
 	if found {
@@ -261,9 +229,6 @@ func GetUserInfo(userId int64) (username, name string, found bool) {
 	return "", "", false
 }
 
-// IdFromReply extracts user ID and text from a replied-to message.
-// Gets the sender ID from the reply and remaining command text.
-// Returns (0, "") if no reply message exists.
 func IdFromReply(m *gotgbot.Message) (int64, string) {
 	prevMessage := m.ReplyToMessage
 
@@ -273,7 +238,6 @@ func IdFromReply(m *gotgbot.Message) (int64, string) {
 		return 0, ""
 	}
 
-	// get's the Id for both user and channel
 	replySender := prevMessage.GetSender()
 	if replySender == nil {
 		return 0, ""
@@ -287,18 +251,12 @@ func IdFromReply(m *gotgbot.Message) (int64, string) {
 	return userId, res[1]
 }
 
-// ExtractQuotes extracts quoted text or words from a sentence using regex patterns.
-// When matchQuotes is true, extracts text between double quotes.
-// When matchWord is true, extracts the first word/token and remaining text.
 func ExtractQuotes(sentence string, matchQuotes, matchWord bool) (inQuotes, afterWord string) {
-	// Check for empty string to prevent panic
 	if len(sentence) == 0 {
 		return
 	}
 
-	// if first character is a double quote and matchQuotes is true
 	if sentence[0] == '"' && matchQuotes {
-		// regex pattern to match text between strings
 		pattern, err := regexp.Compile(`(?s)(\s+)?"(.*?)"\s?(.*)?`)
 		if err != nil {
 			log.Error(err)
@@ -306,13 +264,10 @@ func ExtractQuotes(sentence string, matchQuotes, matchWord bool) (inQuotes, afte
 		}
 		if pattern.MatchString(sentence) {
 			pat := pattern.FindStringSubmatch(sentence)
-			// pat[0] would be the whole matched string
-			// pat[1] is the spaces
 			inQuotes, afterWord = pat[2], pat[3]
 			return
 		}
 	} else if matchWord {
-		// regex pattern to detect all words and special character which do not have spaces but can contain special characters
 		pattern, err := regexp.Compile(`(?s)(\s+)?([A-Za-z0-9-_+=}\][{;:'",<.>?/|*\\()]+)\s?(.*)?`)
 		if err != nil {
 			log.Error(err)
@@ -320,8 +275,6 @@ func ExtractQuotes(sentence string, matchQuotes, matchWord bool) (inQuotes, afte
 		}
 		if pattern.MatchString(sentence) {
 			pat := pattern.FindStringSubmatch(sentence)
-			// pat[0] would be the whole matched string
-			// pat[1] is the spaces
 			inQuotes, afterWord = pat[2], pat[3]
 			return
 		}
@@ -330,9 +283,6 @@ func ExtractQuotes(sentence string, matchQuotes, matchWord bool) (inQuotes, afte
 	return
 }
 
-// ExtractTime parses time duration strings for temporary actions like bans.
-// Supports formats: Nm (minutes), Nh (hours), Nd (days), Nw (weeks).
-// Returns Unix timestamp, formatted time string, and reason text.
 func ExtractTime(b *gotgbot.Bot, ctx *ext.Context, inputVal string) (banTime int64, timeStr, reason string) {
 	msg := ctx.EffectiveMessage
 	timeNow := time.Now().Unix()

--- a/alita/utils/extraction/extraction_test.go
+++ b/alita/utils/extraction/extraction_test.go
@@ -776,7 +776,6 @@ func TestIdFromReply_NilReply(t *testing.T) {
 	msg := &gotgbot.Message{
 		ReplyToMessage: nil,
 	}
-	// Should not panic, should return zero values
 	gotId, gotText := IdFromReply(msg)
 	if gotId != 0 {
 		t.Errorf("expected userId=0 for nil reply, got %d", gotId)

--- a/alita/utils/formatting/formatting.go
+++ b/alita/utils/formatting/formatting.go
@@ -1,6 +1,3 @@
-// Package formatting provides text-formatting helpers for Telegram messages,
-// including HTML / Markdown option builders, message splitting, HTML↔Markdown
-// conversion, and user/chat placeholder replacement.
 package formatting
 
 import (
@@ -20,18 +17,15 @@ import (
 	"github.com/divkix/Alita_Robot/alita/i18n"
 )
 
-// Parse-mode constants and the Telegram message length limit.
 const (
 	Markdown             = "Markdown"
 	HTML                 = "HTML"
 	MaxMessageLength int = 4096
 )
 
-// precompiled regexes and replacer for ReverseHTML2MD.
 var (
-	linkRegex     = regexp.MustCompile(`<a href="(.*?)">(.*?)</a>`)
-	rulesBtnRegex = regexp.MustCompile(`(?s){rules(:(same|up))?}`)
-	// htmlToMdReplacer efficiently replaces HTML tags with Markdown in a single pass.
+	linkRegex        = regexp.MustCompile(`<a href="(.*?)">(.*?)</a>`)
+	rulesBtnRegex    = regexp.MustCompile(`(?s){rules(:(same|up))?}`)
 	htmlToMdReplacer = strings.NewReplacer(
 		"<b>", "*",
 		"</b>", "*",
@@ -56,13 +50,10 @@ type memberCountEntry struct {
 const defaultMemberCountCacheTTL = 60 * time.Second
 
 var (
-	memberCountCache    sync.Map // map[int64]memberCountEntry
+	memberCountCache    sync.Map
 	memberCountCacheTTL = defaultMemberCountCacheTTL
 )
 
-// cachedMemberCount returns member count with a short TTL per chat to avoid an
-// API call per message. Expired entries are deleted on read and via AfterFunc
-// so idle chats cannot accumulate forever.
 func cachedMemberCount(b *gotgbot.Bot, chat *gotgbot.Chat) string {
 	if v, ok := memberCountCache.Load(chat.Id); ok {
 		if e, ok := v.(memberCountEntry); ok && time.Since(e.at) < memberCountCacheTTL {
@@ -86,8 +77,6 @@ func expireMemberCount(chatID int64, entry memberCountEntry) {
 	})
 }
 
-// Shtml returns SendMessageOpts configured with HTML parse mode, disabled link preview,
-// and reply parameters that allow sending without reply.
 func Shtml() *gotgbot.SendMessageOpts {
 	return &gotgbot.SendMessageOpts{
 		ParseMode: HTML,
@@ -100,8 +89,6 @@ func Shtml() *gotgbot.SendMessageOpts {
 	}
 }
 
-// Smarkdown returns SendMessageOpts configured with Markdown parse mode, disabled link preview,
-// and reply parameters that allow sending without reply.
 func Smarkdown() *gotgbot.SendMessageOpts {
 	return &gotgbot.SendMessageOpts{
 		ParseMode: Markdown,
@@ -114,9 +101,6 @@ func Smarkdown() *gotgbot.SendMessageOpts {
 	}
 }
 
-// SplitMessage splits a message into multiple messages if it exceeds MaxMessageLength.
-// It splits on newlines to preserve message structure when possible.
-// Uses utf8.RuneCountInString to correctly count UTF-8 characters instead of bytes.
 func SplitMessage(msg string) []string {
 	totalRunes := utf8.RuneCountInString(msg)
 	if totalRunes <= MaxMessageLength {
@@ -128,7 +112,6 @@ func SplitMessage(msg string) []string {
 		lines = lines[:len(lines)-1]
 	}
 
-	// Pre-allocate result with a heuristic capacity
 	result := make([]string, 0, totalRunes/MaxMessageLength+1)
 
 	smallMsg := ""
@@ -169,25 +152,18 @@ func SplitMessage(msg string) []string {
 	return result
 }
 
-// MentionHtml creates an HTML mention link for a user using their Telegram user ID.
 func MentionHtml(userId int64, name string) string {
 	return MentionUrl(fmt.Sprintf("tg://user?id=%d", userId), name)
 }
 
-// MentionUrl creates an HTML link with the given URL and display name.
-// Both the URL and name are HTML-escaped for safety.
 func MentionUrl(url, name string) string {
 	return fmt.Sprintf("<a href=\"%s\">%s</a>", html.EscapeString(url), html.EscapeString(name))
 }
 
-// HtmlEscape escapes special HTML characters in a string to prevent injection.
-// Used when inserting untrusted content into HTML-formatted messages.
 func HtmlEscape(s string) string {
 	return html.EscapeString(s)
 }
 
-// ReverseHTML2MD converts HTML-formatted text back to markdown format.
-// Handles common HTML tags like bold, italic, underline, strikethrough, code, pre, and links.
 func ReverseHTML2MD(text string) string {
 	if linkRegex.MatchString(text) {
 		matches := linkRegex.FindAllStringSubmatch(text, -1)
@@ -203,9 +179,6 @@ func ReverseHTML2MD(text string) string {
 	return htmlToMdReplacer.Replace(text)
 }
 
-// FormattingReplacer processes message text and replaces placeholders with actual user/chat data.
-// Handles variables like {first}, {last}, {username}, {mention}, {count}, {chatname}, {id}.
-// Also processes rules button insertion with various positioning options.
 func FormattingReplacer(b *gotgbot.Bot, chat *gotgbot.Chat, user *gotgbot.User, oldMsg string, buttons []db.Button) (res string, btns []db.Button) {
 	const language = "en"
 	var (
@@ -271,7 +244,6 @@ func FormattingReplacer(b *gotgbot.Bot, chat *gotgbot.Chat, user *gotgbot.User, 
 	}
 
 	res = r.Replace(rulesBtnRegex.ReplaceAllString(oldMsg, ""))
-	// Copy buttons to avoid mutating cached slice underlying array.
 	btns = append([]db.Button(nil), buttons...)
 
 	rulesDb := rules.GetChatRulesInfo(chat.Id)
@@ -305,8 +277,6 @@ func FormattingReplacer(b *gotgbot.Bot, chat *gotgbot.Chat, user *gotgbot.User, 
 	return res, btns
 }
 
-// GetFullName combines first name and last name into a full name.
-// If last name is empty, returns only the first name.
 func GetFullName(firstName, lastName string) string {
 	if lastName != "" {
 		return firstName + " " + lastName

--- a/alita/utils/helpers/command_pipeline.go
+++ b/alita/utils/helpers/command_pipeline.go
@@ -11,11 +11,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 )
 
-// CommandPipeline provides declarative command registration with pre-flight permission checks.
-
-// CommandContext holds the decomposed context for a command handler.
-// It provides pre-extracted common objects so that permission checks and
-// business logic receive a clean, uniform input.
 type CommandContext struct {
 	Bot  *gotgbot.Bot
 	Ctx  *ext.Context
@@ -25,10 +20,6 @@ type CommandContext struct {
 	Tr   *i18n.Translator
 }
 
-// BuildCommandContext populates a CommandContext from a raw gotgbot update.
-// It extracts the user via chat_status.RequireUser, constructs the translator,
-// and returns the populated struct. If user extraction fails, an error sentinel
-// is returned so the wrapper can return ext.EndGroups without invoking checks.
 func BuildCommandContext(b *gotgbot.Bot, ctx *ext.Context) (*CommandContext, error) {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -47,13 +38,8 @@ func BuildCommandContext(b *gotgbot.Bot, ctx *ext.Context) (*CommandContext, err
 	}, nil
 }
 
-// CheckFunc is a permission gate. Returns true if the gate passes.
-// On failure it must already have sent any required error messages.
 type CheckFunc func(c *CommandContext) bool
 
-// CommandDescriptor declares what a command needs before business logic runs.
-// It is used by WrapCommand to wire checks, alias registration, and group
-// assignment declaratively.
 type CommandDescriptor struct {
 	Name           string
 	Aliases        []string
@@ -62,12 +48,6 @@ type CommandDescriptor struct {
 	Disableable    bool
 }
 
-// WrapCommand registers a command with the dispatcher, running all declared
-// checks before invoking the business logic handler. If a check returns false,
-// the pipeline short-circuits with ext.EndGroups.
-//
-// The handler receives a pre-built *CommandContext containing Bot, Ctx, Chat,
-// Msg, User, and Tr.
 func WrapCommand(
 	dispatcher *ext.Dispatcher,
 	desc CommandDescriptor,
@@ -89,7 +69,6 @@ func WrapCommand(
 	register(dispatcher, desc, h)
 }
 
-// register wires a handler (already wrapped) into the dispatcher.
 func register(dispatcher *ext.Dispatcher, desc CommandDescriptor, h handlers.Response) {
 	cmds := append([]string{desc.Name}, desc.Aliases...)
 	for _, c := range cmds {
@@ -104,13 +83,6 @@ func register(dispatcher *ext.Dispatcher, desc CommandDescriptor, h handlers.Res
 	}
 }
 
-// --- pre-built check function builders ---
-// All wrappers call pure permission checks and explicitly invoke
-// PermissionResponder when checks fail. This absorbs the messaging
-// responsibility so module handlers using the pipeline need no changes.
-
-// CheckDisabled returns a CheckFunc that blocks the command when
-// chat_status.CheckDisabledCmd reports it disabled in the current chat.
 func CheckDisabled(cmdName string) CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.Msg == nil || c.Bot == nil {
@@ -120,8 +92,6 @@ func CheckDisabled(cmdName string) CheckFunc {
 	}
 }
 
-// RequireGroup returns a CheckFunc that ensures the chat is a group
-// (not private). If the check fails, an error message is sent automatically.
 func RequireGroup() CheckFunc {
 	return func(c *CommandContext) bool {
 		result := chat_status.RequireGroup(c.Bot, c.Ctx, nil)
@@ -132,8 +102,6 @@ func RequireGroup() CheckFunc {
 	}
 }
 
-// RequireBotAdmin returns a CheckFunc that ensures the bot has admin
-// privileges in the chat.
 func RequireBotAdmin() CheckFunc {
 	return func(c *CommandContext) bool {
 		result := chat_status.RequireBotAdmin(c.Bot, c.Ctx, nil)
@@ -144,8 +112,6 @@ func RequireBotAdmin() CheckFunc {
 	}
 }
 
-// RequireUserAdmin returns a CheckFunc that ensures the invoking user
-// has admin privileges in the chat.
 func RequireUserAdmin() CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.User == nil {
@@ -159,8 +125,6 @@ func RequireUserAdmin() CheckFunc {
 	}
 }
 
-// CanUserPromote returns a CheckFunc that ensures the invoking user
-// can promote/demote other members.
 func CanUserPromote() CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.User == nil {
@@ -174,8 +138,6 @@ func CanUserPromote() CheckFunc {
 	}
 }
 
-// CanBotPromote returns a CheckFunc that ensures the bot can promote/demote
-// members.
 func CanBotPromote() CheckFunc {
 	return func(c *CommandContext) bool {
 		result := chat_status.CanBotPromote(c.Bot, c.Ctx, nil)
@@ -186,8 +148,6 @@ func CanBotPromote() CheckFunc {
 	}
 }
 
-// CanUserPin returns a CheckFunc that ensures the invoking user
-// can pin messages.
 func CanUserPin() CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.User == nil {
@@ -201,7 +161,6 @@ func CanUserPin() CheckFunc {
 	}
 }
 
-// CanBotPin returns a CheckFunc that ensures the bot can pin messages.
 func CanBotPin() CheckFunc {
 	return func(c *CommandContext) bool {
 		result := chat_status.CanBotPin(c.Bot, c.Ctx, nil)
@@ -212,8 +171,6 @@ func CanBotPin() CheckFunc {
 	}
 }
 
-// CanInvite returns a CheckFunc that ensures the bot and user have
-// permissions to generate invite links.
 func CanInvite() CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.Msg == nil {
@@ -227,8 +184,6 @@ func CanInvite() CheckFunc {
 	}
 }
 
-// CanUserChangeInfo returns a CheckFunc that ensures the invoking user
-// can change chat title, photo, or description.
 func CanUserChangeInfo() CheckFunc {
 	return func(c *CommandContext) bool {
 		if c.User == nil {
@@ -246,8 +201,6 @@ func CanUserChangeInfo() CheckFunc {
 	}
 }
 
-// CanBotChangeInfo returns a CheckFunc that ensures the bot can change
-// chat title, photo, or description.
 func CanBotChangeInfo() CheckFunc {
 	return func(c *CommandContext) bool {
 		result := chat_status.CanBotChangeInfo(c.Bot, c.Ctx, nil)

--- a/alita/utils/helpers/command_pipeline_test.go
+++ b/alita/utils/helpers/command_pipeline_test.go
@@ -139,10 +139,6 @@ func TestCheckFuncNilGuards(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Bot client mock for true-branch coverage
-// ---------------------------------------------------------------------------
-
 type cpBotClient struct{}
 
 func (cpBotClient) RequestWithContext(_ context.Context, _ string, method string, params map[string]any, _ *gotgbot.RequestOpts) (json.RawMessage, error) {
@@ -203,10 +199,6 @@ func makeCpContextWithUser(chatType string, userId int64) *ext.Context {
 	}
 	return ext.NewContext(newCpBot(999), &gotgbot.Update{Message: msg}, nil)
 }
-
-// ---------------------------------------------------------------------------
-// True-branch CheckFunc tests
-// ---------------------------------------------------------------------------
 
 func TestCheckFuncTrueBranches(t *testing.T) {
 	tests := []struct {

--- a/alita/utils/helpers/decorators.go
+++ b/alita/utils/helpers/decorators.go
@@ -7,20 +7,17 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 )
 
-// Global command tracking variables
 var (
 	DisableCmds = make([]string, 0)
 	cmdsMu      = &sync.Mutex{}
 )
 
-// MultiCommand registers multiple command aliases with the same handler function.
 func MultiCommand(dispatcher *ext.Dispatcher, alias []string, r handlers.Response) {
 	for _, cmd := range alias {
 		dispatcher.AddHandler(handlers.NewCommand(cmd, r))
 	}
 }
 
-// AddCmdToDisableable adds a command to the list of commands that can be disabled.
 func AddCmdToDisableable(cmd string) {
 	cmdsMu.Lock()
 	DisableCmds = append(DisableCmds, cmd)

--- a/alita/utils/helpers/helpers_extra_test.go
+++ b/alita/utils/helpers/helpers_extra_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 )
 
-// ---------------------------------------------------------------------------
-// AddCmdToDisableable
-// ---------------------------------------------------------------------------
-
 func TestAddCmdToDisableable(t *testing.T) {
 	const testCmd = "test_disableable_cmd_42"
 
@@ -76,10 +72,6 @@ func TestAddCmdToDisableableThreadSafe(t *testing.T) {
 		t.Fatalf("expected %d commands in DisableCmds, got %d", len(orig)+n, count)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// MultiCommand
-// ---------------------------------------------------------------------------
 
 func TestMultiCommand(t *testing.T) {
 	t.Parallel()

--- a/alita/utils/helpers/ptr.go
+++ b/alita/utils/helpers/ptr.go
@@ -1,8 +1,5 @@
 package helpers
 
-// Ptr returns a pointer to the given value.
-// Used for converting bool constants and other literals to pointer types
-// required by gotgbot API structs (e.g., *bool fields).
 func Ptr[T any](v T) *T {
 	return &v
 }

--- a/alita/utils/helpers/telegram_helpers.go
+++ b/alita/utils/helpers/telegram_helpers.go
@@ -27,8 +27,6 @@ func DeleteMessageWithErrorHandling(bot *gotgbot.Bot, chatId, messageId int64) e
 	return nil
 }
 
-// IsPermissionError reports whether the Telegram error string indicates that the
-// bot lacks permission to send messages in a chat.
 func IsPermissionError(errStr string) bool {
 	return strings.Contains(errStr, "not enough rights to send text messages") ||
 		strings.Contains(errStr, "have no rights to send a message") ||
@@ -37,12 +35,7 @@ func IsPermissionError(errStr string) bool {
 		strings.Contains(errStr, "need administrator rights in the channel chat")
 }
 
-// SendMessageWithErrorHandling wraps bot.SendMessage with graceful error handling for expected permission errors.
-// This handles cases when the bot lacks send message permissions in a chat.
-// Returns (nil, nil) for suppressed permission errors — callers MUST nil-check the returned message.
-// This sentinel avoids error spam but is indistinguishable from success without the extra nil check.
 func SendMessageWithErrorHandling(bot *gotgbot.Bot, chatId int64, text string, opts *gotgbot.SendMessageOpts) (*gotgbot.Message, error) {
-	// Short-circuit if bot is known to be restricted in this chat.
 	if cache.IsChatRestricted(chatId) {
 		log.WithField("chat_id", chatId).Debug("[Helpers] Skipping send to restricted chat")
 		return nil, nil
@@ -50,7 +43,6 @@ func SendMessageWithErrorHandling(bot *gotgbot.Bot, chatId int64, text string, o
 	msg, err := bot.SendMessage(chatId, text, opts)
 	if err != nil {
 		errStr := err.Error()
-		// Check for expected permission-related errors
 		if IsPermissionError(errStr) {
 			cache.MarkChatRestricted(chatId)
 			log.WithFields(log.Fields{
@@ -65,8 +57,6 @@ func SendMessageWithErrorHandling(bot *gotgbot.Bot, chatId int64, text string, o
 	return msg, nil
 }
 
-// IsExpectedTelegramError checks if an error is an expected Telegram API error.
-// Returns true for expected errors that occur during normal bot operations.
 func IsExpectedTelegramError(err error) bool {
 	if err == nil {
 		return false
@@ -74,40 +64,32 @@ func IsExpectedTelegramError(err error) bool {
 
 	errStr := err.Error()
 
-	// Check for expected Telegram API errors
 	expectedErrors := []string{
-		// Bot access errors (kicked, banned, or restricted)
 		"CHAT_RESTRICTED",
 		"bot was kicked from the",
 		"bot was blocked by the user",
 		"Forbidden: bot was kicked",
 		"Forbidden: bot is not a member",
 
-		// Thread/topic errors
 		"message thread not found",
 		"thread not found",
 
-		// Chat state errors
 		"group chat was deactivated",
 		"chat not found",
 		"group chat was upgraded to a supergroup",
 
-		// Network and timeout errors (expected during Telegram API slowness)
 		"timeout awaiting response headers",
 		"http2: timeout",
 		"context deadline exceeded",
 
-		// Permission errors (expected when bot lacks required permissions)
 		"not enough rights to restrict/unrestrict chat member",
 		"not enough rights to send text messages",
 		"not enough rights to",
 		"bot lacks permission",
 
-		// Message deletion errors (expected for old messages or already deleted)
 		"message can't be deleted",
 		"message to delete not found",
 
-		// Forum topic errors (expected when topic is closed or deleted)
 		"TOPIC_CLOSED",
 	}
 

--- a/alita/utils/helpers/telegram_helpers_test.go
+++ b/alita/utils/helpers/telegram_helpers_test.go
@@ -293,9 +293,7 @@ func TestIsPermissionError(t *testing.T) {
 	}
 }
 
-// TestIsExpectedTelegramError_ErrNoPermission verifies that the ErrNoPermission
-// sentinel value from the media package is classified as an expected Telegram error
-// so the dispatcher logs it at Warn instead of Error.
+// ErrNoPermission is classified as expected so the dispatcher logs it at Warn instead of Error.
 func TestIsExpectedTelegramError_ErrNoPermission(t *testing.T) {
 	t.Parallel()
 

--- a/alita/utils/httpserver/server.go
+++ b/alita/utils/httpserver/server.go
@@ -33,7 +33,6 @@ import (
 // This prevents DoS attacks where attackers send gigabytes of data to cause OOM
 const maxRequestBodySize = 10 * 1024 * 1024
 
-// Server represents a unified HTTP server that consolidates health, webhook, and metrics endpoints
 type Server struct {
 	mux              *http.ServeMux
 	server           *http.Server
@@ -48,9 +47,6 @@ type Server struct {
 	dispatchWG       sync.WaitGroup
 }
 
-// New creates a new unified HTTP server on the specified port
-// The startTime parameter should be the application's process start time,
-// used for accurate uptime reporting in health checks.
 func New(port int, startTime time.Time) *Server {
 	return &Server{
 		mux:       http.NewServeMux(),
@@ -59,7 +55,6 @@ func New(port int, startTime time.Time) *Server {
 	}
 }
 
-// HealthStatus represents the health status of the application
 type HealthStatus struct {
 	Status  string          `json:"status"`
 	Checks  map[string]bool `json:"checks"`
@@ -67,7 +62,6 @@ type HealthStatus struct {
 	Uptime  string          `json:"uptime"`
 }
 
-// checkDatabase checks if the database connection is healthy
 func checkDatabase() bool {
 	if db.DB == nil {
 		return false
@@ -84,7 +78,6 @@ func checkDatabase() bool {
 	return sqlDB.PingContext(ctx) == nil
 }
 
-// checkRedis checks if the Redis connection is healthy
 func checkRedis() bool {
 	if cache.Manager == nil {
 		return false
@@ -93,7 +86,6 @@ func checkRedis() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// Try to set and get a test key
 	testKey := "health_check_test"
 	err := cache.Manager.Set(ctx, testKey, "ok", store.WithExpiration(5*time.Second))
 	if err != nil {
@@ -101,13 +93,11 @@ func checkRedis() bool {
 	}
 
 	_, err = cache.Manager.Get(ctx, testKey)
-	// Delete the test key
 	_ = cache.Manager.Delete(ctx, testKey)
 
 	return err == nil
 }
 
-// RegisterHealth registers the /health endpoint
 func (s *Server) RegisterHealth() {
 	s.mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -138,19 +128,15 @@ func (s *Server) RegisterHealth() {
 	log.Info("[HTTPServer] Registered /health endpoint")
 }
 
-// SetMetricsAuthToken configures the bearer token required to access /metrics and /db_metrics.
-// When empty, the endpoints are registered but a warning is logged.
 func (s *Server) SetMetricsAuthToken(token string) {
 	s.metricsAuthToken = token
 }
 
 // requireMetricsAuth is a middleware that enforces bearer-token authentication
 // for metrics endpoints using constant-time comparison to prevent timing attacks.
-// When no token is configured it allows the request through (with a startup warning).
 func (s *Server) requireMetricsAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.metricsAuthToken == "" {
-			// No token configured — allow access (startup warning already logged).
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -169,9 +155,6 @@ func (s *Server) requireMetricsAuth(next http.Handler) http.Handler {
 	})
 }
 
-// RegisterMetrics registers the /metrics endpoint for Prometheus.
-// If a MetricsAuthToken is configured (via SetMetricsAuthToken), requests must supply
-// "Authorization: Bearer <token>". Otherwise the endpoint is open but a warning is logged.
 func (s *Server) RegisterMetrics() {
 	if s.metricsAuthToken == "" {
 		log.Warn("[HTTPServer] METRICS_AUTH_TOKEN is not set — /metrics is unauthenticated")
@@ -180,9 +163,6 @@ func (s *Server) RegisterMetrics() {
 	log.Info("[HTTPServer] Registered /metrics endpoint")
 }
 
-// RegisterDBMetrics registers the /db_metrics endpoint for database monitoring.
-// If a MetricsAuthToken is configured (via SetMetricsAuthToken), requests must supply
-// "Authorization: Bearer <token>". Otherwise the endpoint is open but a warning is logged.
 func (s *Server) RegisterDBMetrics() {
 	if s.metricsAuthToken == "" {
 		log.Warn("[HTTPServer] METRICS_AUTH_TOKEN is not set — /db_metrics is unauthenticated")
@@ -202,8 +182,6 @@ func (s *Server) RegisterDBMetrics() {
 	log.Info("[HTTPServer] Registered /db_metrics endpoint")
 }
 
-// RegisterPPROF registers pprof endpoints for performance profiling.
-// This should only be enabled in development environments.
 func (s *Server) RegisterPPROF() {
 	s.mux.Handle("/debug/pprof/", http.DefaultServeMux)
 
@@ -211,34 +189,27 @@ func (s *Server) RegisterPPROF() {
 	log.Info("[HTTPServer] Registered /debug/pprof/* endpoints")
 }
 
-// RegisterWebhook registers the webhook endpoint and configures the Telegram webhook
 func (s *Server) RegisterWebhook(bot *gotgbot.Bot, dispatcher *ext.Dispatcher, secret, domain string) error {
 	s.bot = bot
 	s.dispatcher = dispatcher
 	s.secret = secret
 	s.webhookEnabled = true
 
-	// Register the webhook handler at a static path — the secret is NOT in the URL.
-	// Authentication is enforced by validateWebhook via the X-Telegram-Bot-Api-Secret-Token header.
 	webhookPath := "/webhook"
 	s.mux.HandleFunc(webhookPath, s.webhookHandler)
 
-	// Set the webhook URL on Telegram — safe to log because the path is now secret-free.
 	webhookURL := fmt.Sprintf("%s%s", domain, webhookPath)
 	log.Infof("[HTTPServer] Setting webhook URL: %s", webhookURL)
 
-	// Configure webhook options
 	webhookOpts := &gotgbot.SetWebhookOpts{
 		AllowedUpdates:     config.AppConfig.AllowedUpdates,
 		DropPendingUpdates: config.AppConfig.DropPendingUpdates,
 	}
 
-	// Set secret token if configured
 	if secret != "" {
 		webhookOpts.SecretToken = secret
 	}
 
-	// Set the webhook with Telegram
 	if _, err := bot.SetWebhook(webhookURL, webhookOpts); err != nil {
 		return fmt.Errorf("failed to set webhook: %w", err)
 	}
@@ -247,9 +218,7 @@ func (s *Server) RegisterWebhook(bot *gotgbot.Bot, dispatcher *ext.Dispatcher, s
 	return nil
 }
 
-// webhookHandler handles incoming webhook requests from Telegram
 func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract trace context from the incoming request and record the stable route.
 	ctx := tracing.GetPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 	_, span := tracing.StartSpan(
 		ctx,
@@ -270,16 +239,12 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate the webhook secret BEFORE reading the body. The secret is in a
-	// header available without consuming the body, so rejecting early avoids
-	// buffering up to 10MB for unauthenticated requests (resource exhaustion).
 	if !s.validateWebhook(r) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		span.SetStatus(codes.Error, "unauthorized")
 		return
 	}
 
-	// Read the request body with size limit to prevent DoS attacks
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBodySize))
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -295,7 +260,6 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Parse the update
 	var update gotgbot.Update
 	if err := json.Unmarshal(body, &update); err != nil {
 		log.WithFields(log.Fields{
@@ -306,7 +270,6 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Add update-specific attributes without recording message or callback content.
 	if update.Message != nil {
 		text := update.Message.Text
 		attrs := []attribute.KeyValue{
@@ -324,26 +287,17 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	// Process the update through the dispatcher with trace context
-	// NOTE: ProcessUpdate does not support context cancellation. Long-running handlers
-	// will complete even if the HTTP response has already been sent. This is by design
-	// as Telegram expects a quick 200 OK response while processing happens async.
-	// Pass the trace context to the goroutine for proper span parenting
 	s.dispatchWG.Add(1)
 	go func(requestCtx context.Context) {
 		defer s.dispatchWG.Done()
 		defer error_handling.RecoverFromPanic("ProcessUpdate", "HTTPServer")
 
-		// Bound the async span and the context exposed to opt-in handlers.
-		// ProcessUpdate itself does not observe this cancellation.
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(requestCtx), 30*time.Second)
 		defer cancel()
 
-		// Start a new child span for the async processing using the request context
 		asyncCtx, asyncSpan := tracing.StartSpan(ctx, "dispatcher.processUpdate")
 		defer asyncSpan.End()
 
-		// Pass context in the data map for handlers to use
 		data := map[string]any{
 			tracing.ContextDataKey: asyncCtx,
 		}
@@ -355,21 +309,18 @@ func (s *Server) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}(ctx)
 
-	// Send OK response to Telegram
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("OK")); err != nil {
 		log.Errorf("[HTTPServer] Failed to write response: %v", err)
 	}
 }
 
-// validateWebhook validates the incoming webhook request using the secret token
 func (s *Server) validateWebhook(r *http.Request) bool {
 	if s.secret == "" {
 		log.Error("[HTTPServer] Webhook secret is required but not configured - rejecting request")
 		return false
 	}
 
-	// Get the X-Telegram-Bot-Api-Secret-Token header
 	secretToken := r.Header.Get("X-Telegram-Bot-Api-Secret-Token")
 	if subtle.ConstantTimeCompare([]byte(secretToken), []byte(s.secret)) != 1 {
 		log.Error("[HTTPServer] Invalid secret token")
@@ -379,7 +330,6 @@ func (s *Server) validateWebhook(r *http.Request) bool {
 	return true
 }
 
-// Start starts the unified HTTP server
 func (s *Server) Start() error {
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.port),
@@ -389,7 +339,6 @@ func (s *Server) Start() error {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Log the registered endpoints
 	endpoints := []string{"/health", "/metrics"}
 	if s.pprofEnabled {
 		endpoints = append(endpoints, "/debug/pprof/*")
@@ -399,14 +348,11 @@ func (s *Server) Start() error {
 	}
 	log.Infof("[HTTPServer] Starting unified HTTP server on port %d with endpoints: %v", s.port, endpoints)
 
-	// Use a channel to communicate startup errors
 	errChan := make(chan error, 1)
 
-	// Start the server in a goroutine
 	go func() {
 		defer error_handling.RecoverFromPanic("HTTPServer", "main")
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			// Non-blocking send to prevent goroutine leak if error occurs after timeout
 			select {
 			case errChan <- err:
 			default:
@@ -415,7 +361,6 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	// Wait briefly to catch immediate startup errors (e.g., port conflicts)
 	startupTimer := time.NewTimer(100 * time.Millisecond)
 	defer startupTimer.Stop()
 	select {
@@ -426,7 +371,6 @@ func (s *Server) Start() error {
 	}
 }
 
-// Stop gracefully stops the HTTP server
 func (s *Server) Stop() error {
 	log.Info("[HTTPServer] Shutting down server...")
 

--- a/alita/utils/httpserver/server_test.go
+++ b/alita/utils/httpserver/server_test.go
@@ -393,8 +393,6 @@ func TestRegisterHealth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rr := httptest.NewRecorder()
 
-	// This test intentionally calls a handler that may panic with nil db/cache.
-	// We catch the panic and report it via Logf because the route still responds.
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("recovered panic in /health handler: %v", r)
@@ -413,7 +411,6 @@ func TestRegisterHealth(t *testing.T) {
 }
 
 func TestRegisterMetrics(t *testing.T) {
-	// No token configured: endpoint should be open (with a startup warning).
 	s := New(8080, time.Now())
 	s.RegisterMetrics()
 
@@ -433,7 +430,6 @@ func TestRegisterMetrics(t *testing.T) {
 func TestRegisterDBMetrics(t *testing.T) {
 	setupHTTPServerDB(t)
 
-	// No token configured: endpoint should be open (with a startup warning).
 	s := New(8080, time.Now())
 	s.RegisterDBMetrics()
 
@@ -452,8 +448,6 @@ func TestRegisterDBMetrics(t *testing.T) {
 	}
 }
 
-// TestMetricsRequiresToken verifies that /metrics returns 401 without the correct bearer
-// token and 200 when the correct bearer token is supplied.
 func TestMetricsRequiresToken(t *testing.T) {
 	t.Parallel()
 
@@ -463,7 +457,6 @@ func TestMetricsRequiresToken(t *testing.T) {
 	s.SetMetricsAuthToken(token)
 	s.RegisterMetrics()
 
-	// No Authorization header → 401.
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
@@ -471,7 +464,6 @@ func TestMetricsRequiresToken(t *testing.T) {
 		t.Errorf("no auth header: expected 401, got %d", rr.Code)
 	}
 
-	// Wrong token → 401.
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	req.Header.Set("Authorization", "Bearer wrong-token")
 	rr = httptest.NewRecorder()
@@ -480,7 +472,6 @@ func TestMetricsRequiresToken(t *testing.T) {
 		t.Errorf("wrong token: expected 401, got %d", rr.Code)
 	}
 
-	// Correct token → 200.
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr = httptest.NewRecorder()
@@ -490,8 +481,6 @@ func TestMetricsRequiresToken(t *testing.T) {
 	}
 }
 
-// TestDBMetricsRequiresToken verifies that /db_metrics returns 401 without the correct bearer
-// token and 200 when the correct bearer token is supplied.
 func TestDBMetricsRequiresToken(t *testing.T) {
 	setupHTTPServerDB(t)
 
@@ -501,7 +490,6 @@ func TestDBMetricsRequiresToken(t *testing.T) {
 	s.SetMetricsAuthToken(token)
 	s.RegisterDBMetrics()
 
-	// No Authorization header → 401.
 	req := httptest.NewRequest(http.MethodGet, "/db_metrics", nil)
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
@@ -509,7 +497,6 @@ func TestDBMetricsRequiresToken(t *testing.T) {
 		t.Errorf("no auth header: expected 401, got %d", rr.Code)
 	}
 
-	// Wrong token → 401.
 	req = httptest.NewRequest(http.MethodGet, "/db_metrics", nil)
 	req.Header.Set("Authorization", "Bearer wrong-token")
 	rr = httptest.NewRecorder()
@@ -518,7 +505,6 @@ func TestDBMetricsRequiresToken(t *testing.T) {
 		t.Errorf("wrong token: expected 401, got %d", rr.Code)
 	}
 
-	// Correct token → 200.
 	req = httptest.NewRequest(http.MethodGet, "/db_metrics", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rr = httptest.NewRecorder()
@@ -528,13 +514,9 @@ func TestDBMetricsRequiresToken(t *testing.T) {
 	}
 }
 
-// TestDBMetricsDoesNotLeakError verifies that when GetCurrentMetrics fails the response body
-// contains the static string "internal error" and NOT the raw Go error string.
 func TestDBMetricsDoesNotLeakError(t *testing.T) {
 	t.Parallel()
 
-	// Build a server without setting up a real DB, so monitoring.GetCurrentMetrics will fail.
-	// Temporarily nil out db.DB to force an error.
 	s := New(9102, time.Now())
 	s.RegisterDBMetrics()
 
@@ -542,8 +524,6 @@ func TestDBMetricsDoesNotLeakError(t *testing.T) {
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
 
-	// The handler either returns 200 (DB is set up via shared test DB) or 500 (no DB).
-	// We only check the error-path guarantee when it actually errors.
 	if rr.Code == http.StatusInternalServerError {
 		body := strings.TrimSpace(rr.Body.String())
 		if body != "internal error" {
@@ -602,7 +582,6 @@ func TestRegisterWebhookConfiguresTelegramWebhook(t *testing.T) {
 		t.Fatal("setWebhook was not called")
 	}
 
-	// The webhook is now registered at the static path /webhook (no secret in URL).
 	req := httptest.NewRequest(http.MethodGet, "/webhook", nil)
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
@@ -610,7 +589,6 @@ func TestRegisterWebhookConfiguresTelegramWebhook(t *testing.T) {
 		t.Fatalf("registered webhook route status = %d, want 405 for GET", rr.Code)
 	}
 
-	// The old secret-bearing path must NOT be registered.
 	req2 := httptest.NewRequest(http.MethodGet, "/webhook/secret-token", nil)
 	rr2 := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr2, req2)
@@ -670,9 +648,6 @@ func TestStopWaitsForWebhookDispatches(t *testing.T) {
 	}
 }
 
-// TestWebhookValidatesHeaderNotPath verifies that the webhook endpoint is served at the
-// static path /webhook (with no secret in the URL) and that access control is enforced
-// entirely via the X-Telegram-Bot-Api-Secret-Token header, not by the URL path.
 func TestWebhookValidatesHeaderNotPath(t *testing.T) {
 	t.Parallel()
 
@@ -717,7 +692,6 @@ func TestWebhookValidatesHeaderNotPath(t *testing.T) {
 	})
 
 	t.Run("secret-bearing path is not routed", func(t *testing.T) {
-		// The old /webhook/<secret> path must not be registered.
 		req := httptest.NewRequest(http.MethodPost, "/webhook/my-secret", strings.NewReader(validBody))
 		req.Header.Set("X-Telegram-Bot-Api-Secret-Token", "my-secret")
 		rr := httptest.NewRecorder()

--- a/alita/utils/keyboard/keyboard.go
+++ b/alita/utils/keyboard/keyboard.go
@@ -1,4 +1,3 @@
-// Package keyboard provides utilities for building Telegram inline keyboards.
 package keyboard
 
 import (
@@ -14,8 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
 )
 
-// GetLangFormat returns a formatted language display string with name and flag emoji.
-// Uses i18n system to get localized language name and flag for the given language code.
 func GetLangFormat(langCode string) string {
 	tr := i18n.MustNewTranslator(langCode)
 	langName, _ := tr.GetString("language_name")
@@ -23,8 +20,6 @@ func GetLangFormat(langCode string) string {
 	return langName + " " + langFlag
 }
 
-// BuildKeyboard constructs an inline keyboard from a slice of database button objects.
-// Handles button grouping based on the SameLine property for proper layout.
 func BuildKeyboard(buttons []db.Button) [][]gotgbot.InlineKeyboardButton {
 	keyb := make([][]gotgbot.InlineKeyboardButton, 0)
 	for _, btn := range buttons {
@@ -39,8 +34,6 @@ func BuildKeyboard(buttons []db.Button) [][]gotgbot.InlineKeyboardButton {
 	return keyb
 }
 
-// MakeLanguageKeyboard creates an inline keyboard with all available language options.
-// Uses valid language codes from config and chunks them into 2-column layout.
 func MakeLanguageKeyboard() [][]gotgbot.InlineKeyboardButton {
 	var kb []gotgbot.InlineKeyboardButton
 
@@ -62,17 +55,15 @@ func MakeLanguageKeyboard() [][]gotgbot.InlineKeyboardButton {
 	return slices.Collect(slices.Chunk(kb, 2))
 }
 
-// InitButtons creates an inline keyboard markup for the connection menu.
-// Shows admin commands button if the user is an admin, otherwise shows only user commands.
 func InitButtons(b *gotgbot.Bot, chatId, userId int64) gotgbot.InlineKeyboardMarkup {
 	tr := i18n.MustNewTranslator("en")
 	adminText, _ := tr.GetString("helpers_admin_commands")
 	if adminText == "" {
-		adminText = "Admin commands" // fallback
+		adminText = "Admin commands"
 	}
 	userText, _ := tr.GetString("helpers_user_commands")
 	if userText == "" {
-		userText = "User commands" // fallback
+		userText = "User commands"
 	}
 
 	var connButtons [][]gotgbot.InlineKeyboardButton

--- a/alita/utils/keyword_matcher/cache.go
+++ b/alita/utils/keyword_matcher/cache.go
@@ -10,7 +10,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 )
 
-// Cache manages keyword matchers for different chats
 type Cache struct {
 	matchers   map[int64]*KeywordMatcher
 	mu         sync.RWMutex
@@ -27,11 +26,7 @@ func newCache(ttl time.Duration) *Cache {
 	}
 }
 
-// GetOrCreateMatcher gets or creates a keyword matcher for the given chat.
-// Uses RWMutex for concurrent read access and only takes write lock when
-// creating a new matcher or when patterns have changed.
 func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatcher {
-	// Fast path: read-only check with RLock
 	c.mu.RLock()
 	matcher, exists := c.matchers[chatID]
 	if exists {
@@ -44,10 +39,8 @@ func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatc
 	}
 	c.mu.RUnlock()
 
-	// Slow path: need write lock to create or update
 	c.mu.Lock()
 
-	// Double-check after acquiring write lock
 	if matcher, exists := c.matchers[chatID]; exists {
 		if slices.Equal(matcher.patterns, patterns) {
 			c.mu.Unlock()
@@ -56,7 +49,6 @@ func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatc
 		}
 	}
 
-	// Create new matcher
 	matcher = newKeywordMatcher(patterns)
 	c.matchers[chatID] = matcher
 	c.mu.Unlock()
@@ -70,20 +62,15 @@ func (c *Cache) GetOrCreateMatcher(chatID int64, patterns []string) *KeywordMatc
 	return matcher
 }
 
-// touchLastUsed records the current time for a chat under a separate mutex.
-// The lastUsed map is read by the cleanup goroutine but written by many
-// concurrent request handlers, so it needs its own lock.
 func (c *Cache) touchLastUsed(chatID int64) {
 	c.lastUsedMu.Lock()
 	c.lastUsed[chatID] = time.Now()
 	c.lastUsedMu.Unlock()
 }
 
-// cleanupExpired removes expired matchers based on TTL.
 func (c *Cache) cleanupExpired() {
 	now := time.Now()
 
-	// Step 1: snapshot expired IDs under lastUsedMu
 	c.lastUsedMu.Lock()
 	expiredChats := make([]int64, 0)
 	for chatID, lastUsed := range c.lastUsed {
@@ -97,7 +84,6 @@ func (c *Cache) cleanupExpired() {
 		return
 	}
 
-	// Step 2: delete from matchers under mu (re-check to avoid deleting revived chats)
 	c.mu.Lock()
 	for _, chatID := range expiredChats {
 		c.lastUsedMu.Lock()
@@ -111,7 +97,6 @@ func (c *Cache) cleanupExpired() {
 	}
 	c.mu.Unlock()
 
-	// Step 3: delete from lastUsed under lastUsedMu (re-check)
 	c.lastUsedMu.Lock()
 	for _, chatID := range expiredChats {
 		if lu, ok := c.lastUsed[chatID]; ok && time.Since(lu) > c.ttl {
@@ -123,16 +108,11 @@ func (c *Cache) cleanupExpired() {
 	log.WithField("expired_count", len(expiredChats)).Debug("Cleaned up expired keyword matchers")
 }
 
-// namedCaches is a registry of named caches, each isolated from the others.
 var (
 	namedCaches   = make(map[string]*Cache)
 	namedCachesMu sync.Mutex
 )
 
-// GetNamedCache returns a per-name singleton keyword matcher cache.
-// Each distinct name gets its own independent Cache instance with its own
-// 30-minute TTL and cleanup goroutine, so consumers with different pattern
-// sets (e.g. "filters" vs "blacklists") can never evict each other's entries.
 func GetNamedCache(name string) *Cache {
 	namedCachesMu.Lock()
 	c, ok := namedCaches[name]
@@ -144,8 +124,6 @@ func GetNamedCache(name string) *Cache {
 	namedCaches[name] = c
 	namedCachesMu.Unlock()
 
-	// Start the cleanup goroutine outside the mutex to avoid holding it
-	// for the goroutine's lifetime.
 	go func() {
 		defer error_handling.RecoverFromPanic("GetNamedCache.cleanupRoutine["+name+"]", "keyword_matcher")
 		ticker := time.NewTicker(10 * time.Minute)

--- a/alita/utils/keyword_matcher/cache_named_test.go
+++ b/alita/utils/keyword_matcher/cache_named_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 )
 
-// TestNamedCachesDoNotCollide verifies that two different named caches sharing
-// the same chatID store independent matchers and never evict each other's
-// entries. It also confirms the "same cache, same patterns" fast-path returns
-// the identical pointer (no rebuild).
 func TestNamedCachesDoNotCollide(t *testing.T) {
 	t.Parallel()
 
@@ -21,7 +17,6 @@ func TestNamedCachesDoNotCollide(t *testing.T) {
 	filtersCache := GetNamedCache("filters_test_collision")
 	blacklistsCache := GetNamedCache("blacklists_test_collision")
 
-	// Populate each named cache with its own patterns for the same chatID.
 	mA1 := filtersCache.GetOrCreateMatcher(chatID, patternsA)
 	mB1 := blacklistsCache.GetOrCreateMatcher(chatID, patternsB)
 
@@ -32,7 +27,6 @@ func TestNamedCachesDoNotCollide(t *testing.T) {
 		t.Fatal("blacklists cache returned nil matcher")
 	}
 
-	// Re-fetch each with the same patterns: must get the same pointer (no rebuild).
 	mA2 := filtersCache.GetOrCreateMatcher(chatID, patternsA)
 	mB2 := blacklistsCache.GetOrCreateMatcher(chatID, patternsB)
 
@@ -43,13 +37,10 @@ func TestNamedCachesDoNotCollide(t *testing.T) {
 		t.Error("blacklists cache: re-fetch with same patterns returned a different pointer — unexpected rebuild")
 	}
 
-	// Cross-check: the matchers in the two caches must be distinct objects,
-	// confirming they don't share state.
 	if mA1 == mB1 {
 		t.Error("filters and blacklists caches returned the same matcher pointer for the same chatID — namespacing is broken")
 	}
 
-	// Verify stored patterns differ (each cache keeps its own patterns).
 	if slices.Equal(mA1.patterns, mB1.patterns) {
 		t.Errorf("expected different patterns for different pattern sets; got %v", mA1.patterns)
 	}

--- a/alita/utils/keyword_matcher/cache_test.go
+++ b/alita/utils/keyword_matcher/cache_test.go
@@ -99,7 +99,6 @@ func TestGetOrCreateMatcher(t *testing.T) {
 
 		wg.Wait()
 
-		// All should have received a non-nil matcher
 		for i, m := range matchers {
 			if m == nil {
 				t.Errorf("goroutine %d got nil matcher", i)
@@ -117,7 +116,6 @@ func TestCleanupExpired(t *testing.T) {
 		c := newCache(time.Millisecond)
 		c.GetOrCreateMatcher(1001, []string{"pattern"})
 
-		// Wait for TTL to expire
 		time.Sleep(5 * time.Millisecond)
 
 		c.cleanupExpired()
@@ -152,7 +150,6 @@ func TestCleanupExpired(t *testing.T) {
 		t.Parallel()
 
 		c := newCache(time.Minute)
-		// Should not panic or have side effects on empty cache
 		c.cleanupExpired()
 
 		c.mu.RLock()
@@ -186,7 +183,6 @@ func TestCleanupExpired(t *testing.T) {
 	})
 }
 
-// patternsEqual checks if two pattern slices are equal using O(n) direct comparison.
 func patternsEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/alita/utils/keyword_matcher/matcher.go
+++ b/alita/utils/keyword_matcher/matcher.go
@@ -9,7 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// KeywordMatcher provides efficient multi-pattern matching using Aho-Corasick algorithm
 type KeywordMatcher struct {
 	matcher   *ahocorasick.Matcher
 	patterns  []string
@@ -17,7 +16,6 @@ type KeywordMatcher struct {
 	lastBuild time.Time
 }
 
-// newKeywordMatcher creates a keyword matcher with the given patterns.
 func newKeywordMatcher(patterns []string) *KeywordMatcher {
 	km := &KeywordMatcher{
 		patterns: make([]string, len(patterns)),
@@ -27,7 +25,6 @@ func newKeywordMatcher(patterns []string) *KeywordMatcher {
 	return km
 }
 
-// build compiles the patterns into an Aho-Corasick matcher
 func (km *KeywordMatcher) build() {
 	start := time.Now()
 	if len(km.patterns) == 0 {
@@ -35,7 +32,6 @@ func (km *KeywordMatcher) build() {
 		return
 	}
 
-	// Convert patterns to lowercase for case-insensitive matching
 	lowerPatterns := make([]string, len(km.patterns))
 	for i, pattern := range km.patterns {
 		lowerPatterns[i] = strings.ToLower(pattern)
@@ -50,10 +46,6 @@ func (km *KeywordMatcher) build() {
 	}).Debug("Built Aho-Corasick matcher")
 }
 
-// FirstMatch returns the first pattern that matches the given text.
-// ahocorasick.Matcher.Match is not safe for concurrent use, so we hold an
-// exclusive lock across the Match call. ToLower is done outside the lock to
-// reduce contention.
 func (km *KeywordMatcher) FirstMatch(text string) (string, bool) {
 	lowerText := strings.ToLower(text)
 

--- a/alita/utils/logredact/logredact.go
+++ b/alita/utils/logredact/logredact.go
@@ -31,13 +31,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Placeholder is the token substituted in place of redacted secrets.
 const Placeholder = "[REDACTED]"
 
-// minSecretLen is the shortest exact secret we will register for redaction.
-// Very short values (e.g. a 2-character password) are too likely to collide
-// with ordinary log text, so we skip them to avoid corrupting messages. The
-// structural patterns below still cover credentials embedded in URLs.
 const minSecretLen = 6
 
 // structuralPatterns redacts credentials that are identifiable by their shape,
@@ -74,20 +69,11 @@ var structuralPatterns = []struct {
 	},
 }
 
-// registry holds exact secret strings registered from configuration. It is
-// guarded by a RWMutex because RegisterSecret may run during startup while log
-// entries are concurrently scrubbed by the hook.
 var registry = struct {
 	mu      sync.RWMutex
 	secrets []string
 }{}
 
-// RegisterSecret records one or more exact secret values that must be redacted
-// from all subsequent log output. Empty values, and values shorter than
-// minSecretLen, are ignored. Duplicate values are deduplicated. Secrets are
-// matched longest-first so that a secret which is a substring of another (for
-// example a password that also appears inside a DSN) does not leave a partial
-// leak behind.
 func RegisterSecret(values ...string) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
@@ -108,28 +94,20 @@ func RegisterSecret(values ...string) {
 		registry.secrets = append(registry.secrets, v)
 	}
 
-	// Longest-first ensures we redact the most specific (largest) secret before
-	// any of its substrings.
 	slices.SortFunc(registry.secrets, func(a, b string) int { return len(b) - len(a) })
 }
 
-// reset clears all registered secrets. It exists for tests.
 func reset() {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
 	registry.secrets = nil
 }
 
-// Scrub returns s with all known secrets and credential-shaped substrings
-// replaced by Placeholder. It is safe for concurrent use and is the single
-// entry point used by both the logrus hook and any caller that wants to
-// pre-sanitize a string (such as a URL) before logging it.
 func Scrub(s string) string {
 	if s == "" {
 		return s
 	}
 
-	// Exact registered secrets first: these are guaranteed leaks.
 	registry.mu.RLock()
 	for _, secret := range registry.secrets {
 		if strings.Contains(s, secret) {
@@ -138,11 +116,6 @@ func Scrub(s string) string {
 	}
 	registry.mu.RUnlock()
 
-	// Then structural patterns for secrets we cannot enumerate. Guard each
-	// replacement with MatchString: unlike strings.ReplaceAll, regexp's
-	// ReplaceAllString always copies the input even when nothing matches, so on
-	// the common (no-secret) path the guard avoids three full-length string
-	// allocations per log field at the cost of one extra (allocation-free) scan.
 	for _, p := range structuralPatterns {
 		if p.re.MatchString(s) {
 			s = p.re.ReplaceAllString(s, p.repl)
@@ -152,18 +125,12 @@ func Scrub(s string) string {
 	return s
 }
 
-// hook is a logrus.Hook that scrubs the message and string fields of every log
-// entry before it is written to any output.
 type hook struct{}
 
-// Levels reports that the hook fires for all log levels.
 func (hook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-// Fire scrubs the entry message and every string-valued field in place. Errors
-// stored in fields are re-wrapped as scrubbed strings because their underlying
-// type cannot be mutated.
 func (hook) Fire(entry *logrus.Entry) error {
 	entry.Message = Scrub(entry.Message)
 
@@ -181,16 +148,8 @@ func (hook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-// stdInstallOnce ensures the hook is registered on the logrus standard logger
-// at most once, since logrus.AddHook unconditionally appends and the empty
-// hook struct has no identity to deduplicate on.
 var stdInstallOnce sync.Once
 
-// Install registers the redaction hook on the supplied logger. Passing nil
-// installs the hook on the logrus standard logger; that path is guarded by a
-// sync.Once so repeated calls do not stack duplicate hooks (which would scrub
-// every entry multiple times). For an explicit logger the caller owns
-// deduplication, so the hook is added directly.
 func Install(logger *logrus.Logger) {
 	if logger == nil {
 		stdInstallOnce.Do(func() {

--- a/alita/utils/logredact/logredact_test.go
+++ b/alita/utils/logredact/logredact_test.go
@@ -97,7 +97,7 @@ func TestRegisterSecretIgnoresShortAndEmpty(t *testing.T) {
 	reset()
 	t.Cleanup(reset)
 
-	RegisterSecret("", "abc") // both below minSecretLen / empty
+	RegisterSecret("", "abc")
 	registry.mu.RLock()
 	n := len(registry.secrets)
 	registry.mu.RUnlock()

--- a/alita/utils/media/sender.go
+++ b/alita/utils/media/sender.go
@@ -1,5 +1,3 @@
-// Package media provides a unified interface for sending different types of Telegram media.
-// It consolidates the duplicate logic from NotesEnumFuncMap, GreetingsEnumFuncMap, and FiltersEnumFuncMap.
 package media
 
 import (
@@ -20,9 +18,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/keyboard"
 )
 
-// resolveSendResult handles the shared error-handling path for all send methods.
-// It marks the chat as restricted on permission errors, clears it on success,
-// and wraps unhandled errors with context.
 func resolveSendResult[T any](result T, err error, chatID int64, mediaType string) (T, error) {
 	if err == nil {
 		cache.MarkChatNotRestricted(chatID)
@@ -43,46 +38,38 @@ func resolveSendResult[T any](result T, err error, chatID int64, mediaType strin
 	return result, errors.Wrapf(err, "failed to send %s to chat %d", mediaType, chatID)
 }
 
-// Sentinel errors
 var ErrNoPermission = fmt.Errorf("bot lacks permission to send messages")
 
-// Content represents the media content to be sent.
 type Content struct {
-	Text    string // Text content or caption
-	FileID  string // File ID for media types
-	MsgType int    // One of db.TEXT, db.STICKER, etc.
-	Name    string // Optional name for logging (note name, filter keyword, etc.)
+	Text    string
+	FileID  string
+	MsgType int
+	Name    string
 }
 
-// Options configures how the media is sent.
 type Options struct {
 	ChatID            int64
 	ReplyMsgID        int64
 	ThreadID          int64
 	Keyboard          *gotgbot.InlineKeyboardMarkup
-	NoFormat          bool // If true, don't parse HTML
-	NoNotif           bool // Disable notification
-	WebPreview        bool // Enable link preview (TEXT only)
-	IsProtected       bool // Protect content from forwarding
-	AllowWithoutReply bool // Allow sending if reply message is deleted
+	NoFormat          bool
+	NoNotif           bool
+	WebPreview        bool
+	IsProtected       bool
+	AllowWithoutReply bool
 }
 
-// Send sends media content using the appropriate Telegram API method.
-// Returns the sent message and any error encountered.
 func Send(b *gotgbot.Bot, content Content, opts Options) (*gotgbot.Message, error) {
-	// Short-circuit if bot is known to be restricted in this chat.
 	if cache.IsChatRestricted(opts.ChatID) {
 		log.WithField("chat_id", opts.ChatID).Debug("[Media] Skipping send to restricted chat")
 		return nil, ErrNoPermission
 	}
 
-	// Determine parse mode
 	parseMode := formatting.HTML
 	if opts.NoFormat {
 		parseMode = ""
 	}
 
-	// Build reply parameters if reply message ID is set
 	var replyParams *gotgbot.ReplyParameters
 	if opts.ReplyMsgID > 0 {
 		replyParams = &gotgbot.ReplyParameters{
@@ -92,7 +79,7 @@ func Send(b *gotgbot.Bot, content Content, opts Options) (*gotgbot.Message, erro
 	}
 
 	switch content.MsgType {
-	case db.TEXT, 0: // 0 is fallback for uninitialized/legacy records
+	case db.TEXT, 0:
 		return sendText(b, content, opts, parseMode, replyParams)
 	case db.STICKER:
 		return sendSticker(b, content, opts, replyParams)
@@ -114,7 +101,6 @@ func Send(b *gotgbot.Bot, content Content, opts Options) (*gotgbot.Message, erro
 	}
 }
 
-// sendText sends a text message with error handling for expected permission errors.
 func sendText(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	msg, err := b.SendMessage(opts.ChatID, content.Text, &gotgbot.SendMessageOpts{
 		ParseMode: parseMode,
@@ -130,7 +116,6 @@ func sendText(b *gotgbot.Bot, content Content, opts Options, parseMode string, r
 	return resolveSendResult(msg, err, opts.ChatID, "text")
 }
 
-// sendSticker sends a sticker or falls back to text if FileID is empty.
 func sendSticker(b *gotgbot.Bot, content Content, opts Options, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for STICKER '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -146,7 +131,6 @@ func sendSticker(b *gotgbot.Bot, content Content, opts Options, replyParams *got
 	return resolveSendResult(msg, err, opts.ChatID, "sticker")
 }
 
-// sendDocument sends a document or falls back to text if FileID is empty.
 func sendDocument(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for DOCUMENT '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -164,7 +148,6 @@ func sendDocument(b *gotgbot.Bot, content Content, opts Options, parseMode strin
 	return resolveSendResult(msg, err, opts.ChatID, "document")
 }
 
-// sendPhoto sends a photo or falls back to text if FileID is empty.
 func sendPhoto(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for PHOTO '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -182,7 +165,6 @@ func sendPhoto(b *gotgbot.Bot, content Content, opts Options, parseMode string, 
 	return resolveSendResult(msg, err, opts.ChatID, "photo")
 }
 
-// sendAudio sends an audio file or falls back to text if FileID is empty.
 func sendAudio(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for AUDIO '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -200,7 +182,6 @@ func sendAudio(b *gotgbot.Bot, content Content, opts Options, parseMode string, 
 	return resolveSendResult(msg, err, opts.ChatID, "audio")
 }
 
-// sendVoice sends a voice message or falls back to text if FileID is empty.
 func sendVoice(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for VOICE '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -218,7 +199,6 @@ func sendVoice(b *gotgbot.Bot, content Content, opts Options, parseMode string, 
 	return resolveSendResult(msg, err, opts.ChatID, "voice")
 }
 
-// sendVideo sends a video or falls back to text if FileID is empty.
 func sendVideo(b *gotgbot.Bot, content Content, opts Options, parseMode string, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for VIDEO '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -236,7 +216,6 @@ func sendVideo(b *gotgbot.Bot, content Content, opts Options, parseMode string, 
 	return resolveSendResult(msg, err, opts.ChatID, "video")
 }
 
-// sendVideoNote sends a video note or falls back to text if FileID is empty.
 func sendVideoNote(b *gotgbot.Bot, content Content, opts Options, replyParams *gotgbot.ReplyParameters) (*gotgbot.Message, error) {
 	if content.FileID == "" {
 		log.Warnf("[Media] Empty FileID for VideoNote '%s' in chat %d, falling back to text", content.Name, opts.ChatID)
@@ -252,19 +231,14 @@ func sendVideoNote(b *gotgbot.Bot, content Content, opts Options, replyParams *g
 	return resolveSendResult(msg, err, opts.ChatID, "video note")
 }
 
-// SendNote sends a note with full preprocessing (randomization, formatting, keyboard, options).
-// The chat parameter provides the group context for formatting placeholders like {chatname};
-// ctx.EffectiveChat is used as the actual send target.
 func SendNote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, note *db.Notes, replyMsgID, threadID int64) (*gotgbot.Message, error) {
 	var (
 		buttons []db.Button
 		sent    string
 	)
 
-	// copy just in case
 	buttons = note.Buttons
 
-	// Random data selection
 	rstrings := strings.Split(note.NoteContent, "%%%")
 	if len(rstrings) == 1 {
 		sent = rstrings[0]
@@ -273,7 +247,6 @@ func SendNote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, note *db.Not
 		sent = rstrings[n]
 	}
 
-	// Avoid mutating the original note
 	noteCopy := *note
 	noteCopy.NoteContent, buttons = formatting.FormattingReplacer(b, chat, ctx.EffectiveUser, sent, buttons)
 	_, _, _, _, _, _, noteCopy.NoteContent = content.NotesParser(noteCopy.NoteContent)
@@ -291,7 +264,7 @@ func SendNote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, note *db.Not
 		ReplyMsgID:        replyMsgID,
 		ThreadID:          threadID,
 		Keyboard:          &keyboardMarkup,
-		NoFormat:          false, // Notes use formatting by default
+		NoFormat:          false,
 		NoNotif:           noteCopy.NoNotif,
 		WebPreview:        noteCopy.WebPreview,
 		IsProtected:       noteCopy.IsProtected,
@@ -299,7 +272,6 @@ func SendNote(b *gotgbot.Bot, ctx *ext.Context, chat *gotgbot.Chat, note *db.Not
 	})
 }
 
-// SendFilter sends a filter with full preprocessing (randomization, formatting, keyboard).
 func SendFilter(b *gotgbot.Bot, ctx *ext.Context, filter *db.ChatFilters, replyMsgID int64) (*gotgbot.Message, error) {
 	if filter == nil {
 		return nil, fmt.Errorf("filter data is nil")
@@ -315,7 +287,6 @@ func SendFilter(b *gotgbot.Bot, ctx *ext.Context, filter *db.ChatFilters, replyM
 	tmpfilterData = *filter
 	buttons = tmpfilterData.Buttons
 
-	// Random data selection
 	rstrings := strings.Split(tmpfilterData.FilterReply, "%%%")
 	if len(rstrings) == 1 {
 		sent = rstrings[0]
@@ -338,15 +309,14 @@ func SendFilter(b *gotgbot.Bot, ctx *ext.Context, filter *db.ChatFilters, replyM
 		ReplyMsgID:        replyMsgID,
 		ThreadID:          ctx.Message.MessageThreadId,
 		Keyboard:          &keyboardMarkup,
-		NoFormat:          false, // Filters use formatting by default
+		NoFormat:          false,
 		NoNotif:           tmpfilterData.NoNotif,
-		WebPreview:        false, // Filters disable web preview by default
-		IsProtected:       false, // Filters don't support protection
+		WebPreview:        false,
+		IsProtected:       false,
 		AllowWithoutReply: true,
 	})
 }
 
-// SendGreeting is a convenience function for sending welcome/goodbye messages.
 func SendGreeting(b *gotgbot.Bot, chatID int64, text, fileID string, msgType int, keyboard *gotgbot.InlineKeyboardMarkup, threadID int64) (*gotgbot.Message, error) {
 	return Send(b, Content{
 		Text:    text,
@@ -355,13 +325,13 @@ func SendGreeting(b *gotgbot.Bot, chatID int64, text, fileID string, msgType int
 		Name:    "greeting",
 	}, Options{
 		ChatID:            chatID,
-		ReplyMsgID:        0, // Greetings don't reply to messages
+		ReplyMsgID:        0,
 		ThreadID:          threadID,
 		Keyboard:          keyboard,
-		NoFormat:          false, // Greetings use formatting
-		NoNotif:           false, // Greetings notify by default
-		WebPreview:        false, // Greetings disable web preview
-		IsProtected:       false, // Greetings don't support protection
+		NoFormat:          false,
+		NoNotif:           false,
+		WebPreview:        false,
+		IsProtected:       false,
 		AllowWithoutReply: true,
 	})
 }

--- a/alita/utils/media/sender_test.go
+++ b/alita/utils/media/sender_test.go
@@ -408,7 +408,6 @@ func TestSendNoteRandomization(t *testing.T) {
 		MsgType:     db.TEXT,
 	}
 
-	// Call many times to verify all options are possible outcomes.
 	seen := make(map[string]bool)
 	for i := 0; i < 50; i++ {
 		_, err := SendNote(bot, ctx, ctx.EffectiveChat, note, 0, 0)
@@ -542,12 +541,10 @@ func TestSendNoteUsesChatForFormattingButCtxForSendTarget(t *testing.T) {
 		t.Fatalf("send error = %v", err)
 	}
 
-	// Verify formatting used the group chat title
 	if got := client.params["text"]; got != "Welcome to "+groupTitle+"!" {
 		t.Fatalf("formatted text = %q, want %q", got, "Welcome to "+groupTitle+"!")
 	}
 
-	// Verify the message was sent to the private chat (ctx.EffectiveChat)
 	if got := client.params["chat_id"]; got != privateChatID {
 		t.Fatalf("chat_id = %v, want %d", got, privateChatID)
 	}

--- a/alita/utils/monitoring/activity_monitor.go
+++ b/alita/utils/monitoring/activity_monitor.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// ActivityMonitor handles automatic tracking and cleanup of chat activity
 type ActivityMonitor struct {
 	ctx                   context.Context
 	cancel                context.CancelFunc
@@ -25,7 +24,6 @@ type ActivityMonitor struct {
 	lastMetricsCalculated time.Time
 }
 
-// ActivityMetrics holds calculated activity metrics
 type ActivityMetrics struct {
 	DailyActiveGroups   int64
 	WeeklyActiveGroups  int64
@@ -39,15 +37,12 @@ type ActivityMetrics struct {
 	CalculatedAt        time.Time
 }
 
-// NewActivityMonitor creates a new activity monitor instance
 func NewActivityMonitor() *ActivityMonitor {
 	ctx, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel stored in struct field, called in Stop()
 
-	// Default values, can be overridden by environment variables
 	checkInterval := 1 * time.Hour
-	inactivityThreshold := 30 * 24 * time.Hour // 30 days
+	inactivityThreshold := 30 * 24 * time.Hour
 
-	// Check for environment variable overrides
 	if config.AppConfig.ActivityCheckInterval > 0 {
 		checkInterval = time.Duration(config.AppConfig.ActivityCheckInterval) * time.Hour
 	}
@@ -65,7 +60,6 @@ func NewActivityMonitor() *ActivityMonitor {
 	}
 }
 
-// Start begins the activity monitoring background job
 func (am *ActivityMonitor) Start() {
 	log.Info("[ActivityMonitor] Starting activity monitoring service")
 	log.Infof("[ActivityMonitor] Check interval: %v, Inactivity threshold: %v, Auto-cleanup: %v",
@@ -74,11 +68,9 @@ func (am *ActivityMonitor) Start() {
 	am.wg.Add(1)
 	go am.monitorLoop()
 
-	// Calculate initial metrics
 	am.calculateMetrics()
 }
 
-// Stop gracefully stops the activity monitor
 func (am *ActivityMonitor) Stop() {
 	am.stopOnce.Do(func() {
 		log.Info("[ActivityMonitor] Stopping activity monitoring service")
@@ -87,7 +79,6 @@ func (am *ActivityMonitor) Stop() {
 	})
 }
 
-// monitorLoop runs the periodic activity check
 func (am *ActivityMonitor) monitorLoop() {
 	defer am.wg.Done()
 
@@ -107,12 +98,10 @@ func (am *ActivityMonitor) monitorLoop() {
 	}
 }
 
-// performActivityCheck checks all chats for activity and marks inactive ones
 func (am *ActivityMonitor) performActivityCheck() {
 	startTime := time.Now()
 	log.Info("[ActivityMonitor] Starting activity check")
 
-	// Calculate current metrics
 	am.calculateMetrics()
 
 	if !am.enableAutoCleanup {
@@ -120,7 +109,6 @@ func (am *ActivityMonitor) performActivityCheck() {
 		return
 	}
 
-	// Find and mark inactive chats
 	inactiveThreshold := time.Now().Add(-am.inactivityThreshold)
 
 	result := db.DB.Model(&db.Chat{}).
@@ -137,7 +125,6 @@ func (am *ActivityMonitor) performActivityCheck() {
 			result.RowsAffected, am.inactivityThreshold)
 	}
 
-	// Reactivate chats that have recent activity
 	reactivateResult := db.DB.Model(&db.Chat{}).
 		Where("is_inactive = ? AND last_activity >= ?", true, inactiveThreshold).
 		Update("is_inactive", false)
@@ -155,7 +142,6 @@ func (am *ActivityMonitor) performActivityCheck() {
 	log.Infof("[ActivityMonitor] Activity check completed in %v", elapsed)
 }
 
-// countAsync runs a single COUNT query in a goroutine and logs on error.
 func countAsync(wg *sync.WaitGroup, query func() error, errMsg string) {
 	wg.Add(1)
 	go func() {
@@ -167,9 +153,6 @@ func countAsync(wg *sync.WaitGroup, query func() error, errMsg string) {
 	}()
 }
 
-// calculateMetrics calculates activity metrics in parallel for improved performance.
-// Executes 9 database COUNT queries concurrently using goroutines.
-// Each goroutine writes to its own local variable to avoid data races on struct fields.
 func (am *ActivityMonitor) calculateMetrics() {
 	now := time.Now()
 	dayAgo := now.Add(-24 * time.Hour)
@@ -183,8 +166,7 @@ func (am *ActivityMonitor) calculateMetrics() {
 
 	var wg sync.WaitGroup
 
-	// Windowed activity counts (distinct buckets; runs concurrently via
-	// countAsync). The daily/weekly/monthly predicates are index-friendly
+	// The daily/weekly/monthly predicates are index-friendly
 	// on (is_inactive, last_activity).
 	countAsync(&wg, func() error {
 		return db.DB.Model(&db.Chat{}).
@@ -226,7 +208,6 @@ func (am *ActivityMonitor) calculateMetrics() {
 	// Windowless total: cheap reltuples estimate (pg_class).
 	totalUsers = db.TableRowCount("users")
 
-	// Wait for all queries to complete
 	wg.Wait()
 
 	metrics := &ActivityMetrics{
@@ -242,7 +223,6 @@ func (am *ActivityMonitor) calculateMetrics() {
 		CalculatedAt:        now,
 	}
 
-	// Store metrics
 	am.metricsLock.Lock()
 	am.lastMetrics = metrics
 	am.lastMetricsCalculated = now

--- a/alita/utils/monitoring/activity_monitor_test.go
+++ b/alita/utils/monitoring/activity_monitor_test.go
@@ -35,10 +35,6 @@ func setupMonitoringDB(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// NewActivityMonitor
-// ---------------------------------------------------------------------------
-
 func TestNewActivityMonitor(t *testing.T) {
 	// Cannot run in parallel because NewActivityMonitor reads global config.
 
@@ -76,7 +72,7 @@ func TestNewActivityMonitor(t *testing.T) {
 		am2 := NewActivityMonitor()
 		// sync.Once has no exported state, but we can verify Stop() works twice
 		am2.Stop()
-		am2.Stop() // should not panic
+		am2.Stop()
 	})
 
 	t.Run("metrics fields are zero value", func(t *testing.T) {
@@ -251,10 +247,6 @@ func requireCleanMonitoringTables(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Start
-// ---------------------------------------------------------------------------
-
 func TestStart(t *testing.T) {
 	if db.DB == nil {
 		t.Skip("requires PostgreSQL connection")
@@ -264,9 +256,6 @@ func TestStart(t *testing.T) {
 	am.Start()
 	defer am.Stop()
 
-	// Verify the monitor is running: lastMetrics should eventually be populated.
-	// calculateMetrics runs synchronously inside Start, so lastMetricsCalculated
-	// should be set immediately (or very shortly, since it spawns goroutines).
 	done := make(chan struct{})
 	quit := make(chan struct{})
 	go func() {
@@ -289,7 +278,6 @@ func TestStart(t *testing.T) {
 
 	select {
 	case <-done:
-		// success
 	case <-time.After(5 * time.Second):
 		close(quit)
 		t.Fatal("timeout waiting for metrics calculation after Start()")
@@ -304,17 +292,11 @@ func TestStart_DoesNotPanic(t *testing.T) {
 	am := NewActivityMonitor()
 	defer am.Stop()
 
-	// The sole purpose of this test is to ensure Start() itself does not panic.
 	am.Start()
 }
 
-// ---------------------------------------------------------------------------
-// Stop
-// ---------------------------------------------------------------------------
-
 func TestStop_WithoutStart(t *testing.T) {
 	am := NewActivityMonitor()
-	// Should not panic even if Start() was never called.
 	am.Stop()
 }
 
@@ -326,7 +308,7 @@ func TestStop_Idempotent(t *testing.T) {
 	am := NewActivityMonitor()
 	am.Start()
 	am.Stop()
-	am.Stop() // second call must not panic
+	am.Stop()
 }
 
 func TestStop_GracefullyStopsRunningMonitor(t *testing.T) {
@@ -337,7 +319,6 @@ func TestStop_GracefullyStopsRunningMonitor(t *testing.T) {
 	am := NewActivityMonitor()
 	am.Start()
 
-	// Stop should complete without hanging.
 	done := make(chan struct{})
 	go func() {
 		am.Stop()
@@ -346,15 +327,10 @@ func TestStop_GracefullyStopsRunningMonitor(t *testing.T) {
 
 	select {
 	case <-done:
-		// success
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop() hung or timed out")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// monitorLoop lifecycle (no DB required)
-// ---------------------------------------------------------------------------
 
 func TestMonitorLoop_ExitsOnCancel(t *testing.T) {
 	am := NewActivityMonitor()
@@ -369,12 +345,10 @@ func TestMonitorLoop_ExitsOnCancel(t *testing.T) {
 		close(done)
 	}()
 
-	// cancel the context to trigger monitorLoop exit
 	am.cancel()
 
 	select {
 	case <-done:
-		// success
 	case <-time.After(2 * time.Second):
 		t.Fatal("monitorLoop did not exit after context cancellation")
 	}
@@ -393,15 +367,10 @@ func TestMonitorLoop_ExitsViaStop(t *testing.T) {
 
 	select {
 	case <-done:
-		// success
 	case <-time.After(2 * time.Second):
 		t.Fatal("Stop() did not complete after starting monitorLoop")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// ActivityMetrics struct fields
-// ---------------------------------------------------------------------------
 
 func TestActivityMetrics_Fields(t *testing.T) {
 	t.Parallel()

--- a/alita/utils/monitoring/auto_remediation.go
+++ b/alita/utils/monitoring/auto_remediation.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// logResourceUsage logs current goroutine count and memory at the given level.
 func logResourceUsage(level log.Level, msg string) {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
@@ -21,9 +20,6 @@ func logResourceUsage(level log.Level, msg string) {
 	}).Log(level, msg)
 }
 
-// remediationAction is a single remediation step. The manager holds these in a
-// fixed slice ordered by ascending severity, so the lowest-severity applicable
-// action is always chosen first without any runtime sorting.
 type remediationAction struct {
 	name       string
 	severity   int
@@ -31,7 +27,6 @@ type remediationAction struct {
 	execute    func()
 }
 
-// AutoRemediationManager handles automatic remediation of performance issues
 type AutoRemediationManager struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
@@ -46,7 +41,6 @@ type AutoRemediationManager struct {
 	collector       *BackgroundStatsCollector
 }
 
-// NewAutoRemediationManager creates a new auto-remediation manager
 func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemediationManager {
 	ctx, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel stored in struct field, called in Stop()
 
@@ -55,19 +49,16 @@ func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemedia
 		cancel:          cancel,
 		enabled:         config.AppConfig.EnablePerformanceMonitoring,
 		lastActionTime:  make(map[string]time.Time),
-		actionCooldown:  5 * time.Minute, // Minimum time between same actions
+		actionCooldown:  5 * time.Minute,
 		monitorInterval: 1 * time.Minute,
 		collector:       collector,
 	}
 
-	// Built-in remediation actions, ordered by ascending severity so the check
-	// cycle picks the least severe applicable action first.
 	manager.actions = []remediationAction{
 		{
 			name:     "log_warning",
 			severity: 0,
 			canExecute: func(metrics SystemMetrics) bool {
-				// Log warning when resources are above 80% goroutines / 50% memory.
 				goroutineThreshold := int(float64(config.AppConfig.ResourceMaxGoroutines) * 0.8)
 				memoryThreshold := float64(config.AppConfig.ResourceMaxMemoryMB) * 0.5
 				return metrics.GoroutineCount > goroutineThreshold || metrics.MemoryAllocMB > memoryThreshold
@@ -80,7 +71,6 @@ func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemedia
 			name:     "garbage_collection",
 			severity: 1,
 			canExecute: func(metrics SystemMetrics) bool {
-				// Trigger GC when memory is above 60% of max threshold.
 				gcThreshold := float64(config.AppConfig.ResourceMaxMemoryMB) * 0.6
 				return metrics.MemoryAllocMB > gcThreshold || metrics.GCPauseMs > 50
 			},
@@ -93,19 +83,16 @@ func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemedia
 			name:     "memory_cleanup",
 			severity: 2,
 			canExecute: func(metrics SystemMetrics) bool {
-				// Trigger cleanup when memory is above the GC threshold.
 				return metrics.MemoryAllocMB > float64(config.AppConfig.ResourceGCThresholdMB)
 			},
 			execute: func() {
 				log.Info("[AutoRemediation] Performing memory cleanup operations")
 
-				// Trigger multiple GC cycles for thorough cleanup.
 				for range 3 {
 					runtime.GC()
 					time.Sleep(100 * time.Millisecond)
 				}
 
-				// Force release of unused memory back to OS.
 				runtime.GC()
 			},
 		},
@@ -113,7 +100,6 @@ func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemedia
 			name:     "restart_recommendation",
 			severity: 10,
 			canExecute: func(metrics SystemMetrics) bool {
-				// Recommend restart when resources are above 150% goroutines / 160% memory.
 				goroutineThreshold := int(float64(config.AppConfig.ResourceMaxGoroutines) * 1.5)
 				memoryThreshold := float64(config.AppConfig.ResourceMaxMemoryMB) * 1.6
 				return metrics.GoroutineCount > goroutineThreshold || metrics.MemoryAllocMB > memoryThreshold
@@ -127,7 +113,6 @@ func NewAutoRemediationManager(collector *BackgroundStatsCollector) *AutoRemedia
 	return manager
 }
 
-// Start begins monitoring for issues requiring remediation
 func (m *AutoRemediationManager) Start() {
 	if !m.enabled {
 		log.Info("[AutoRemediation] Auto-remediation is disabled")
@@ -139,7 +124,6 @@ func (m *AutoRemediationManager) Start() {
 	go m.monitorAndRemediate()
 }
 
-// monitorAndRemediate continuously monitors metrics and applies remediation
 func (m *AutoRemediationManager) monitorAndRemediate() {
 	defer m.wg.Done()
 
@@ -159,9 +143,6 @@ func (m *AutoRemediationManager) monitorAndRemediate() {
 	}
 }
 
-// checkAndRemediate checks current metrics and applies appropriate remediation.
-// Actions are evaluated in ascending-severity order; the first applicable action
-// that is past its cooldown runs, and only one action runs per check cycle.
 func (m *AutoRemediationManager) checkAndRemediate() {
 	if m.collector == nil {
 		return
@@ -169,8 +150,6 @@ func (m *AutoRemediationManager) checkAndRemediate() {
 
 	metrics := m.collector.GetCurrentMetrics()
 
-	// Surface unusually long GC pauses; this is the one signal not already
-	// covered by the goroutine/memory remediation thresholds below.
 	if metrics.GCPauseMs > 100 {
 		log.WithField("gc_pause_ms", metrics.GCPauseMs).Warn("[AutoRemediation] Long GC pause detected")
 	}
@@ -192,12 +171,10 @@ func (m *AutoRemediationManager) checkAndRemediate() {
 
 		log.WithField("action", action.name).Info("[AutoRemediation] Successfully executed remediation action")
 
-		// Only execute one action per check cycle.
 		break
 	}
 }
 
-// shouldExecuteAction determines if an action should be executed based on cooldown
 func (m *AutoRemediationManager) shouldExecuteAction(name string) bool {
 	m.mu.RLock()
 	lastExecution, exists := m.lastActionTime[name]
@@ -210,14 +187,12 @@ func (m *AutoRemediationManager) shouldExecuteAction(name string) bool {
 	return time.Since(lastExecution) >= m.actionCooldown
 }
 
-// markActionExecuted records when an action was last executed
 func (m *AutoRemediationManager) markActionExecuted(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.lastActionTime[name] = time.Now()
 }
 
-// Stop gracefully shuts down the auto-remediation manager
 func (m *AutoRemediationManager) Stop() {
 	m.stopOnce.Do(func() {
 		log.Info("[AutoRemediation] Stopping auto-remediation monitoring")

--- a/alita/utils/monitoring/auto_remediation_test.go
+++ b/alita/utils/monitoring/auto_remediation_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/config"
 )
 
-// findAction returns the built-in action with the given name, or fails the test.
 func findAction(t *testing.T, m *AutoRemediationManager, name string) remediationAction {
 	t.Helper()
 	for _, a := range m.actions {
@@ -19,10 +18,6 @@ func findAction(t *testing.T, m *AutoRemediationManager, name string) remediatio
 	t.Fatalf("action %q not found in manager.actions", name)
 	return remediationAction{}
 }
-
-// ---------------------------------------------------------------------------
-// Built-in action ordering
-// ---------------------------------------------------------------------------
 
 func TestBuiltInActionsAreSeverityOrdered(t *testing.T) {
 	// Cannot run in parallel because it reads global config.AppConfig.
@@ -53,10 +48,6 @@ func TestBuiltInActionsAreSeverityOrdered(t *testing.T) {
 		}
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Threshold conditions select the right action
-// ---------------------------------------------------------------------------
 
 func TestActionThresholds(t *testing.T) {
 	// Cannot run in parallel because it reads global config.AppConfig.
@@ -127,10 +118,6 @@ func TestActionThresholds(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Built-in execute bodies do not panic
-// ---------------------------------------------------------------------------
-
 func TestBuiltInActionsExecuteDoNotPanic(t *testing.T) {
 	// Cannot run in parallel because it reads global config.AppConfig.
 
@@ -141,10 +128,6 @@ func TestBuiltInActionsExecuteDoNotPanic(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Disabled monitoring — Start does nothing, Stop does not deadlock
-// ---------------------------------------------------------------------------
 
 func TestNewAutoRemediationManager_Disabled_StartDoesNothing(t *testing.T) {
 	// Do not use t.Parallel() - tests global config state.
@@ -161,15 +144,9 @@ func TestNewAutoRemediationManager_Disabled_StartDoesNothing(t *testing.T) {
 		t.Fatal("expected manager.enabled to be false when EnablePerformanceMonitoring is false")
 	}
 
-	// Start() should return immediately without spawning goroutines.
 	manager.Start()
-	// Stop should not deadlock even though Start() did nothing.
 	manager.Stop()
 }
-
-// ---------------------------------------------------------------------------
-// Constructor wiring
-// ---------------------------------------------------------------------------
 
 func TestNewAutoRemediationManager_WithCollector(t *testing.T) {
 	// Do not use t.Parallel() - tests global config state.
@@ -191,32 +168,21 @@ func TestNewAutoRemediationManager_WithCollector(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Cooldown prevents re-execution
-// ---------------------------------------------------------------------------
-
 func TestAutoRemediationManager_Cooldown(t *testing.T) {
 	// Do not use t.Parallel() - tests global config state.
 
 	manager := NewAutoRemediationManager(NewBackgroundStatsCollector())
 
-	// First execution should be allowed.
 	if !manager.shouldExecuteAction("garbage_collection") {
 		t.Fatal("expected shouldExecuteAction to be true on first call")
 	}
 
-	// Record execution.
 	manager.markActionExecuted("garbage_collection")
 
-	// Second execution should be blocked by cooldown.
 	if manager.shouldExecuteAction("garbage_collection") {
 		t.Fatal("expected shouldExecuteAction to be false immediately after execution")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// checkAndRemediate behavior
-// ---------------------------------------------------------------------------
 
 func TestCheckAndRemediateExecutesLowestSeverityAction(t *testing.T) {
 	// Do not use t.Parallel() - tests global config state.
@@ -254,12 +220,8 @@ func TestCheckAndRemediateHandlesNilCollector(t *testing.T) {
 	t.Parallel()
 
 	manager := NewAutoRemediationManager(nil)
-	manager.checkAndRemediate() // must not panic
+	manager.checkAndRemediate()
 }
-
-// ---------------------------------------------------------------------------
-// Start runs the monitor loop on the configured interval
-// ---------------------------------------------------------------------------
 
 func TestAutoRemediationManagerStartRunsMonitorLoop(t *testing.T) {
 	// Do not use t.Parallel() - tests global config state.

--- a/alita/utils/monitoring/background_stats.go
+++ b/alita/utils/monitoring/background_stats.go
@@ -15,34 +15,27 @@ import (
 
 var globalCollector atomic.Value
 
-// SystemMetrics holds various system performance metrics
 type SystemMetrics struct {
-	// Runtime metrics
 	GoroutineCount int
 	MemoryAllocMB  float64
 	MemorySysMB    float64
 	GCPauseMs      float64
 	CPUCount       int
 
-	// Database metrics
 	DatabaseConnections int
 
-	// Bot metrics
 	ProcessedMessages int64
 	ErrorCount        int64
 
-	// Performance metrics
 	PeakMemoryUsageMB float64
 	UptimeSeconds     int64
 
-	// Cache metrics
 	RestrictedChatHits   int64
 	RestrictedChatMisses int64
 
 	Timestamp time.Time
 }
 
-// BackgroundStatsCollector collects and reports system statistics
 type BackgroundStatsCollector struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
@@ -52,28 +45,23 @@ type BackgroundStatsCollector struct {
 	metrics     SystemMetrics
 	metricsLock sync.RWMutex
 
-	// Collection intervals
 	systemStatsInterval   time.Duration
 	databaseStatsInterval time.Duration
 	reportingInterval     time.Duration
 
-	// Counters for runtime metrics
 	messageCounter int64
 	errorCounter   int64
 	startTime      time.Time
 
-	// Performance tracking
 	peakMemoryUsage uint64
 }
 
-// DatabaseStats holds database-specific metrics
 type DatabaseStats struct {
 	ActiveConnections int
 	IdleConnections   int
 	Timestamp         time.Time
 }
 
-// NewBackgroundStatsCollector creates a new background statistics collector
 func NewBackgroundStatsCollector() *BackgroundStatsCollector {
 	ctx, cancel := context.WithCancel(context.Background()) // #nosec G118 -- cancel stored in struct field, called in Stop()
 
@@ -87,7 +75,6 @@ func NewBackgroundStatsCollector() *BackgroundStatsCollector {
 	}
 }
 
-// Start begins the background statistics collection
 func (collector *BackgroundStatsCollector) Start() {
 	if !collector.started.CompareAndSwap(false, true) {
 		log.Warn("BackgroundStatsCollector already started, ignoring duplicate Start")
@@ -95,7 +82,6 @@ func (collector *BackgroundStatsCollector) Start() {
 	}
 	log.Info("Starting background statistics collection")
 
-	// Start collection goroutines
 	collector.wg.Add(1)
 	go collector.systemStatsCollector()
 
@@ -106,7 +92,6 @@ func (collector *BackgroundStatsCollector) Start() {
 	go collector.reportingWorker()
 }
 
-// systemStatsCollector collects system-level statistics
 func (collector *BackgroundStatsCollector) systemStatsCollector() {
 	defer collector.wg.Done()
 
@@ -126,7 +111,6 @@ func (collector *BackgroundStatsCollector) systemStatsCollector() {
 	}
 }
 
-// databaseStatsCollector collects database statistics
 func (collector *BackgroundStatsCollector) databaseStatsCollector() {
 	defer collector.wg.Done()
 
@@ -146,7 +130,6 @@ func (collector *BackgroundStatsCollector) databaseStatsCollector() {
 	}
 }
 
-// collectSystemStats gathers system-level metrics
 func (collector *BackgroundStatsCollector) collectSystemStats() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
@@ -163,27 +146,22 @@ func (collector *BackgroundStatsCollector) collectSystemStats() {
 		Timestamp:         time.Now(),
 	}
 
-	// Track peak memory usage
 	currentMemory := m.Alloc
 	if currentMemory > atomic.LoadUint64(&collector.peakMemoryUsage) {
 		atomic.StoreUint64(&collector.peakMemoryUsage, currentMemory)
 	}
 	metrics.PeakMemoryUsageMB = float64(atomic.LoadUint64(&collector.peakMemoryUsage)) / 1024 / 1024
 
-	// Pull restricted chat cache counters for monitoring.
 	metrics.RestrictedChatHits, metrics.RestrictedChatMisses = cache.GetRestrictedCacheStats()
 
 	collector.updateSystemMetrics(metrics)
 }
 
-// collectDatabaseStats gathers database-specific metrics
 func (collector *BackgroundStatsCollector) collectDatabaseStats() {
-	// Get database statistics (this requires extending the database package)
 	stats := DatabaseStats{
 		Timestamp: time.Now(),
 	}
 
-	// Try to get database connection pool stats
 	if sqlDB, err := db.DB.DB(); err == nil {
 		dbStats := sqlDB.Stats()
 		stats.ActiveConnections = dbStats.OpenConnections
@@ -193,12 +171,10 @@ func (collector *BackgroundStatsCollector) collectDatabaseStats() {
 	collector.updateDatabaseMetrics(stats)
 }
 
-// updateSystemMetrics updates the stored system metrics
 func (collector *BackgroundStatsCollector) updateSystemMetrics(metrics SystemMetrics) {
 	collector.metricsLock.Lock()
 	defer collector.metricsLock.Unlock()
 
-	// Update system metrics
 	collector.metrics.GoroutineCount = metrics.GoroutineCount
 	collector.metrics.MemoryAllocMB = metrics.MemoryAllocMB
 	collector.metrics.MemorySysMB = metrics.MemorySysMB
@@ -213,7 +189,6 @@ func (collector *BackgroundStatsCollector) updateSystemMetrics(metrics SystemMet
 	collector.metrics.RestrictedChatMisses = metrics.RestrictedChatMisses
 }
 
-// updateDatabaseMetrics updates the stored database metrics
 func (collector *BackgroundStatsCollector) updateDatabaseMetrics(dbStats DatabaseStats) {
 	collector.metricsLock.Lock()
 	defer collector.metricsLock.Unlock()
@@ -221,7 +196,6 @@ func (collector *BackgroundStatsCollector) updateDatabaseMetrics(dbStats Databas
 	collector.metrics.DatabaseConnections = dbStats.ActiveConnections
 }
 
-// reportingWorker periodically reports collected statistics
 func (collector *BackgroundStatsCollector) reportingWorker() {
 	defer collector.wg.Done()
 
@@ -241,7 +215,6 @@ func (collector *BackgroundStatsCollector) reportingWorker() {
 	}
 }
 
-// reportStats logs the current statistics
 func (collector *BackgroundStatsCollector) reportStats() {
 	collector.metricsLock.RLock()
 	metrics := collector.metrics
@@ -262,17 +235,14 @@ func (collector *BackgroundStatsCollector) reportStats() {
 	}).Info("Background system statistics")
 }
 
-// RecordError increments the error counter
 func (collector *BackgroundStatsCollector) RecordError() {
 	atomic.AddInt64(&collector.errorCounter, 1)
 }
 
-// RecordMessage increments the processed message counter
 func (collector *BackgroundStatsCollector) RecordMessage() {
 	atomic.AddInt64(&collector.messageCounter, 1)
 }
 
-// GetCurrentMetrics returns the current metrics (thread-safe)
 func (collector *BackgroundStatsCollector) GetCurrentMetrics() SystemMetrics {
 	collector.metricsLock.RLock()
 	defer collector.metricsLock.RUnlock()
@@ -280,36 +250,30 @@ func (collector *BackgroundStatsCollector) GetCurrentMetrics() SystemMetrics {
 	return collector.metrics
 }
 
-// Stop gracefully shuts down the background stats collector
 func (collector *BackgroundStatsCollector) Stop() {
 	collector.stopOnce.Do(func() {
 		log.Info("Stopping background statistics collection")
 
 		collector.cancel()
 
-		// Wait for the collector goroutines to exit before the final report.
 		collector.wg.Wait()
 
-		// Log final statistics
 		collector.reportStats()
 
 		log.Info("Background statistics collection stopped")
 	})
 }
 
-// SetGlobalCollector sets the global stats collector instance
 func SetGlobalCollector(collector *BackgroundStatsCollector) {
 	globalCollector.Store(collector)
 }
 
-// GlobalRecordError increments the global error counter if collector is initialized
 func GlobalRecordError() {
 	if c, ok := globalCollector.Load().(*BackgroundStatsCollector); ok && c != nil {
 		c.RecordError()
 	}
 }
 
-// GlobalRecordMessage increments the global message counter if collector is initialized
 func GlobalRecordMessage() {
 	if c, ok := globalCollector.Load().(*BackgroundStatsCollector); ok && c != nil {
 		c.RecordMessage()

--- a/alita/utils/monitoring/background_stats_test.go
+++ b/alita/utils/monitoring/background_stats_test.go
@@ -6,10 +6,6 @@ import (
 	"time"
 )
 
-// ---------------------------------------------------------------------------
-// NewBackgroundStatsCollector
-// ---------------------------------------------------------------------------
-
 func TestNewBackgroundStatsCollector(t *testing.T) {
 	t.Parallel()
 
@@ -51,10 +47,6 @@ func TestNewBackgroundStatsCollector(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// RecordMessage
-// ---------------------------------------------------------------------------
-
 func TestRecordMessage(t *testing.T) {
 	t.Parallel()
 
@@ -69,10 +61,6 @@ func TestRecordMessage(t *testing.T) {
 		t.Fatalf("expected messageCounter >= %d, got %d", calls, c.messageCounter)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// RecordError
-// ---------------------------------------------------------------------------
 
 func TestRecordError(t *testing.T) {
 	t.Parallel()
@@ -89,17 +77,12 @@ func TestRecordError(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// GetCurrentMetrics
-// ---------------------------------------------------------------------------
-
 func TestGetCurrentMetrics(t *testing.T) {
 	t.Parallel()
 
 	c := NewBackgroundStatsCollector()
 	metrics := c.GetCurrentMetrics()
 
-	// Initial metrics should be zero-value
 	if metrics.GoroutineCount != 0 {
 		t.Fatalf("expected GoroutineCount=0 initially, got %d", metrics.GoroutineCount)
 	}
@@ -165,10 +148,6 @@ func TestUpdateDatabaseMetricsAndReport(t *testing.T) {
 	c.reportStats()
 }
 
-// ---------------------------------------------------------------------------
-// ConcurrentRecordMessage
-// ---------------------------------------------------------------------------
-
 func TestConcurrentRecordMessage(t *testing.T) {
 	t.Parallel()
 
@@ -199,12 +178,6 @@ func TestConcurrentRecordMessage(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Additional: TestCollectSystemStats
-// ---------------------------------------------------------------------------
-
-// TestCollectSystemStats verifies that collectSystemStats stores metrics with
-// sensible runtime values (goroutines > 0, memory >= 0).
 func TestCollectSystemStats(t *testing.T) {
 	t.Parallel()
 
@@ -227,18 +200,11 @@ func TestCollectSystemStats(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Additional: TestRecordMessageAndError
-// ---------------------------------------------------------------------------
-
-// TestRecordMessageAndError verifies that RecordMessage and RecordError
-// increment their respective counters independently.
 func TestRecordMessageAndError(t *testing.T) {
 	t.Parallel()
 
 	c := NewBackgroundStatsCollector()
 
-	// Record 3 messages and 2 errors
 	c.RecordMessage()
 	c.RecordMessage()
 	c.RecordMessage()
@@ -252,7 +218,6 @@ func TestRecordMessageAndError(t *testing.T) {
 		t.Fatalf("expected errorCounter=2, got %d", c.errorCounter)
 	}
 
-	// Verify counters are independent
 	c.RecordMessage()
 	if c.errorCounter != 2 {
 		t.Fatalf("RecordMessage() should not affect errorCounter, got %d", c.errorCounter)
@@ -264,10 +229,6 @@ func TestRecordMessageAndError(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// GetCurrentMetrics with recorded values
-// ---------------------------------------------------------------------------
-
 func TestGetCurrentMetrics_AfterRecording(t *testing.T) {
 	t.Parallel()
 
@@ -277,7 +238,6 @@ func TestGetCurrentMetrics_AfterRecording(t *testing.T) {
 	c.RecordMessage()
 	c.RecordError()
 
-	// collectSystemStats reads atomic counters and stores them.
 	c.collectSystemStats()
 
 	result := c.GetCurrentMetrics()
@@ -296,17 +256,11 @@ func TestGetCurrentMetrics_AfterRecording(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Global recorders (wiring tests for main.go callback setup)
-// ---------------------------------------------------------------------------
-
 func TestGlobalRecorders_NoCollector_NoOp(t *testing.T) {
 	// Do not use t.Parallel() - tests global state
 
-	// Ensure no collector is set
 	SetGlobalCollector(nil)
 
-	// These should not panic
 	GlobalRecordError()
 	GlobalRecordMessage()
 }
@@ -316,9 +270,8 @@ func TestGlobalRecorders_WithCollector_IncrementCounters(t *testing.T) {
 
 	collector := NewBackgroundStatsCollector()
 	SetGlobalCollector(collector)
-	defer SetGlobalCollector(nil) // cleanup
+	defer SetGlobalCollector(nil)
 
-	// Initial state
 	if collector.errorCounter != 0 {
 		t.Fatal("expected initial errorCounter to be 0")
 	}
@@ -326,11 +279,9 @@ func TestGlobalRecorders_WithCollector_IncrementCounters(t *testing.T) {
 		t.Fatal("expected initial messageCounter to be 0")
 	}
 
-	// Record via global functions
 	GlobalRecordError()
 	GlobalRecordMessage()
 
-	// Verify
 	if collector.errorCounter != 1 {
 		t.Errorf("expected errorCounter=1 after GlobalRecordError, got %d", collector.errorCounter)
 	}
@@ -355,7 +306,6 @@ func TestSetGlobalCollector_ReplacesCollector(t *testing.T) {
 		t.Errorf("expected collectorB.messageCounter=0, got %d", collectorB.messageCounter)
 	}
 
-	// Replace with collectorB
 	SetGlobalCollector(collectorB)
 	GlobalRecordMessage()
 
@@ -366,12 +316,8 @@ func TestSetGlobalCollector_ReplacesCollector(t *testing.T) {
 		t.Errorf("expected collectorB.messageCounter=1, got %d", collectorB.messageCounter)
 	}
 
-	defer SetGlobalCollector(nil) // cleanup
+	defer SetGlobalCollector(nil)
 }
-
-// ---------------------------------------------------------------------------
-// SystemMetrics — RestrictedChatHits / RestrictedChatMisses fields
-// ---------------------------------------------------------------------------
 
 func TestSystemMetrics_RestrictedChatCounters(t *testing.T) {
 	t.Parallel()

--- a/alita/utils/ratelimit/backup_ratelimit.go
+++ b/alita/utils/ratelimit/backup_ratelimit.go
@@ -13,18 +13,15 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/cache"
 )
 
-// BackupRateLimiter provides rate limiting for backup operations
 type BackupRateLimiter struct {
 	mu sync.RWMutex
 }
 
 var (
-	// Singleton instance
 	backupLimiter *BackupRateLimiter
 	once          = &sync.Once{}
 )
 
-// GetBackupRateLimiter returns the singleton rate limiter instance
 func GetBackupRateLimiter() *BackupRateLimiter {
 	once.Do(func() {
 		backupLimiter = &BackupRateLimiter{}
@@ -32,31 +29,26 @@ func GetBackupRateLimiter() *BackupRateLimiter {
 	return backupLimiter
 }
 
-// Cache key prefixes for rate limiting
 const (
 	exportRatePrefix = "backup:export:"
 	importRatePrefix = "backup:import:"
 	resetRatePrefix  = "backup:reset:"
 )
 
-// Default cooldown periods
 const (
 	DefaultExportCooldown = 5 * time.Minute
 	DefaultImportCooldown = 10 * time.Minute
 	DefaultResetCooldown  = 1 * time.Hour
 )
 
-// AcquireExport atomically reserves the export cooldown for a chat.
 func (r *BackupRateLimiter) AcquireExport(chatID int64) (bool, time.Duration) {
 	return r.acquireOperation(exportRatePrefix+strconv.FormatInt(chatID, 10), DefaultExportCooldown)
 }
 
-// AcquireImport atomically reserves the import cooldown for a chat.
 func (r *BackupRateLimiter) AcquireImport(chatID int64) (bool, time.Duration) {
 	return r.acquireOperation(importRatePrefix+strconv.FormatInt(chatID, 10), DefaultImportCooldown)
 }
 
-// AcquireReset atomically reserves the reset cooldown for a chat.
 func (r *BackupRateLimiter) AcquireReset(chatID int64) (bool, time.Duration) {
 	return r.acquireOperation(resetRatePrefix+strconv.FormatInt(chatID, 10), DefaultResetCooldown)
 }
@@ -97,7 +89,6 @@ func (r *BackupRateLimiter) acquireOperation(cacheKey string, cooldown time.Dura
 	return true, 0
 }
 
-// FormatCooldown formats a duration as a human-readable string
 func FormatCooldown(duration time.Duration) string {
 	if duration < time.Minute {
 		seconds := int(duration.Seconds())

--- a/alita/utils/ratelimit/backup_ratelimit_test.go
+++ b/alita/utils/ratelimit/backup_ratelimit_test.go
@@ -41,7 +41,6 @@ func TestFormatCooldown(t *testing.T) {
 }
 
 func TestGetBackupRateLimiter_Singleton(t *testing.T) {
-	// Save original limiter and once for restoration.
 	origBackupLimiter := backupLimiter
 	origOnce := once
 
@@ -50,7 +49,6 @@ func TestGetBackupRateLimiter_Singleton(t *testing.T) {
 		once = origOnce
 	})
 
-	// Reset the singleton state for a clean test.
 	once = &sync.Once{}
 	backupLimiter = nil
 

--- a/alita/utils/shutdown/graceful.go
+++ b/alita/utils/shutdown/graceful.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Manager handles graceful shutdown of the application
 type Manager struct {
 	handlers        []func() error
 	mu              sync.RWMutex
@@ -28,14 +27,12 @@ var (
 	shutdownTimeout = 60 * time.Second
 )
 
-// NewManager creates a new shutdown manager
 func NewManager() *Manager {
 	return &Manager{
 		handlers: make([]func() error, 0),
 	}
 }
 
-// RegisterHandler registers a shutdown handler
 func (m *Manager) RegisterHandler(handler func() error) {
 	if m.shutdownStarted.Load() {
 		log.Warn("[Shutdown] RegisterHandler called after shutdown started - handler may not run")
@@ -45,24 +42,19 @@ func (m *Manager) RegisterHandler(handler func() error) {
 	m.handlers = append(m.handlers, handler)
 }
 
-// WaitForShutdown waits for shutdown signals and executes handlers
 func (m *Manager) WaitForShutdown() {
 	sigChan := make(chan os.Signal, 1)
 	notifySignals(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
-	// Wait for signal
 	sig := <-sigChan
 	log.Infof("[Shutdown] Received signal: %v", sig)
 
-	// Stop receiving signals - prevents duplicate shutdown calls
 	stopSignals(sigChan)
 	close(sigChan)
 
 	m.shutdown()
 }
 
-// executeHandler safely executes a single shutdown handler with panic recovery.
-// Returns the error from the handler, or nil if the handler panicked (panic is logged separately).
 func (m *Manager) executeHandler(handler func() error, index int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -72,7 +64,6 @@ func (m *Manager) executeHandler(handler func() error, index int) (err error) {
 	return handler()
 }
 
-// shutdown performs graceful shutdown
 func (m *Manager) shutdown() {
 	m.once.Do(func() {
 		defer error_handling.RecoverFromPanic("shutdown", "shutdown")
@@ -80,19 +71,14 @@ func (m *Manager) shutdown() {
 		m.shutdownStarted.Store(true)
 		log.Info("[Shutdown] Starting graceful shutdown...")
 
-		// Create context with timeout for shutdown
-		// Use 60 seconds to allow time for database connections and large cleanup tasks
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 
-		// Execute shutdown handlers in reverse order - need exclusive lock to
-		// copy safely while preventing concurrent RegisterHandler races.
 		m.mu.Lock()
 		handlers := make([]func() error, len(m.handlers))
 		copy(handlers, m.handlers)
 		m.mu.Unlock()
 
-		// Execute handlers in reverse order (LIFO) with per-handler timeout
 		for i := len(handlers) - 1; i >= 0; i-- {
 			hCtx, hCancel := context.WithTimeout(ctx, 10*time.Second)
 			done := make(chan error, 1)

--- a/alita/utils/shutdown/graceful_test.go
+++ b/alita/utils/shutdown/graceful_test.go
@@ -35,7 +35,6 @@ func TestRegisterHandler(t *testing.T) {
 		t.Fatalf("expected 3 handlers, got %d", len(m.handlers))
 	}
 
-	// Verify registration order (FIFO) by executing directly
 	for i, h := range m.handlers {
 		if err := h(); err != nil {
 			t.Fatalf("handler %d returned error: %v", i, err)
@@ -116,7 +115,6 @@ func TestExecuteHandler(t *testing.T) {
 func TestExecuteHandlerPanicRecovery(t *testing.T) {
 	m := NewManager()
 
-	// Test panic recovery - handler should not propagate panic
 	executed := false
 	err := m.executeHandler(func() error {
 		executed = true
@@ -134,20 +132,17 @@ func TestExecuteHandlerPanicRecovery(t *testing.T) {
 func TestHandlersExecuteInLIFOOrder(t *testing.T) {
 	m := NewManager()
 
-	// Use a channel to record execution order
 	orderCh := make(chan int, 3)
 
 	m.RegisterHandler(func() error { orderCh <- 1; return nil })
 	m.RegisterHandler(func() error { orderCh <- 2; return nil })
 	m.RegisterHandler(func() error { orderCh <- 3; return nil })
 
-	// Simulate shutdown's reverse iteration without calling shutdown() directly
 	m.mu.RLock()
 	handlers := make([]func() error, len(m.handlers))
 	copy(handlers, m.handlers)
 	m.mu.RUnlock()
 
-	// Execute in reverse order (LIFO) as shutdown() does
 	for i := len(handlers) - 1; i >= 0; i-- {
 		if err := m.executeHandler(handlers[i], i); err != nil {
 			t.Fatalf("handler %d returned error: %v", i, err)
@@ -165,7 +160,6 @@ func TestHandlersExecuteInLIFOOrder(t *testing.T) {
 		t.Fatalf("expected 3 executions, got %d", len(order))
 	}
 
-	// LIFO: last registered (3) should execute first
 	expected := []int{3, 2, 1}
 	for i, v := range expected {
 		if order[i] != v {

--- a/alita/utils/tracing/processor.go
+++ b/alita/utils/tracing/processor.go
@@ -11,49 +11,34 @@ import (
 
 var onProcessUpdateCallback atomic.Value
 
-// ContextDataKey is the ext.Context.Data key used to carry tracing context.
 const ContextDataKey = "context"
 
-// SetOnProcessUpdateCallback registers a callback to be called when an update is processed
 func SetOnProcessUpdateCallback(cb func()) {
 	onProcessUpdateCallback.Store(cb)
 }
 
-// TracingProcessor wraps ext.BaseProcessor to inject trace context into every
-// update processed by the dispatcher. This ensures that polling mode updates
-// get a root trace span, matching the behavior of the webhook handler.
 type TracingProcessor struct {
 	ext.BaseProcessor
 }
 
-// runOnProcessUpdateCallback executes the registered callback if set.
-// Extracted for testability without requiring full dispatcher integration.
 func runOnProcessUpdateCallback() {
 	if cb, ok := onProcessUpdateCallback.Load().(func()); ok && cb != nil {
 		cb()
 	}
 }
 
-// ProcessUpdate starts a trace span for the update (in polling mode) and injects the
-// trace context into ctx.Data[ContextDataKey] before delegating to the base processor.
-// If a context already exists in ctx.Data (e.g., from webhook handler), it is reused and
-// no new span is created here to avoid duplicating dispatcher.processUpdate spans.
 func (tp TracingProcessor) ProcessUpdate(d *ext.Dispatcher, b *gotgbot.Bot, ctx *ext.Context) (err error) {
 	if ctx == nil {
 		return tp.BaseProcessor.ProcessUpdate(d, b, ctx)
 	}
-	// Record message for monitoring
 	runOnProcessUpdateCallback()
 
-	// If an existing context is present (e.g., webhook request), just delegate without
-	// creating a new root span so that we don't break trace parenting or duplicate spans.
 	if ctx.Data != nil {
 		if _, exists := ctx.Data[ContextDataKey]; exists {
 			return tp.BaseProcessor.ProcessUpdate(d, b, ctx)
 		}
 	}
 
-	// No existing context: create a new root span and propagate its context.
 	traceCtx, span := StartSpan(context.Background(), "dispatcher.processUpdate")
 	defer func() {
 		if err != nil {

--- a/alita/utils/tracing/processor_test.go
+++ b/alita/utils/tracing/processor_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-// injectTraceContext replicates the context injection logic from TracingProcessor.ProcessUpdate.
-// This is extracted so we can test the injection behavior without needing a full Dispatcher.
 func injectTraceContext(ctx *ext.Context) (skipped bool) {
 	if ctx != nil && ctx.Data != nil {
 		if _, exists := ctx.Data[ContextDataKey]; exists {
@@ -38,7 +36,6 @@ func TestTracingProcessor_InjectsContext(t *testing.T) {
 		t.Fatal("should not skip injection when no context exists")
 	}
 
-	// Assert ctx.Data has a context key of type context.Context
 	raw, ok := ctx.Data[ContextDataKey]
 	if !ok {
 		t.Fatal("ctx.Data must contain the trace context entry after injection")
@@ -62,7 +59,6 @@ func TestTracingProcessor_PreservesExistingContext(t *testing.T) {
 		t.Fatal("should skip injection when context already exists")
 	}
 
-	// The existing context should NOT be overwritten
 	extracted, ok := ctx.Data[ContextDataKey].(context.Context)
 	if !ok {
 		t.Fatal("existing trace context entry must be a context.Context")
@@ -104,7 +100,6 @@ func TestTracingProcessor_SkipsSpanForWebhookContext(t *testing.T) {
 		t.Fatal("should skip span creation when webhook context already exists")
 	}
 
-	// Verify the original webhook context is untouched
 	raw := ctx.Data[ContextDataKey]
 	if raw != webhookCtx {
 		t.Fatal("webhook context must not be replaced")
@@ -167,12 +162,7 @@ func TestTracingProcessorProcessUpdateRunsCallback(t *testing.T) {
 	}
 }
 
-// contextTestKey is a custom type for context keys to avoid collisions.
 type contextTestKey string
-
-// ---------------------------------------------------------------------------
-// Callback tests (wiring tests for main.go monitoring setup)
-// ---------------------------------------------------------------------------
 
 func TestRunOnProcessUpdateCallback_InvokesRegisteredCallback(t *testing.T) {
 	// Do not use t.Parallel() - tests global state
@@ -181,7 +171,7 @@ func TestRunOnProcessUpdateCallback_InvokesRegisteredCallback(t *testing.T) {
 	SetOnProcessUpdateCallback(func() {
 		called.Add(1)
 	})
-	defer SetOnProcessUpdateCallback(nil) // cleanup
+	defer SetOnProcessUpdateCallback(nil)
 
 	runOnProcessUpdateCallback()
 
@@ -189,7 +179,6 @@ func TestRunOnProcessUpdateCallback_InvokesRegisteredCallback(t *testing.T) {
 		t.Errorf("expected callback to be called exactly once, got %d calls", called.Load())
 	}
 
-	// Call again to verify multiple invocations work
 	runOnProcessUpdateCallback()
 	if called.Load() != 2 {
 		t.Errorf("expected callback to be called twice, got %d calls", called.Load())
@@ -199,9 +188,7 @@ func TestRunOnProcessUpdateCallback_InvokesRegisteredCallback(t *testing.T) {
 func TestRunOnProcessUpdateCallback_NoCallback_NoOp(t *testing.T) {
 	// Do not use t.Parallel() - tests global state
 
-	// Ensure no callback is set
 	SetOnProcessUpdateCallback(nil)
 
-	// Should not panic
 	runOnProcessUpdateCallback()
 }

--- a/alita/utils/tracing/tracing.go
+++ b/alita/utils/tracing/tracing.go
@@ -27,16 +27,9 @@ var (
 	enabled        bool
 )
 
-// InitTracing initializes the OpenTelemetry tracing provider.
-// It configures exporters based on environment variables:
-// - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP gRPC endpoint (e.g., localhost:4317)
-// - OTEL_EXPORTER_CONSOLE: Enable console exporter (true/false, default: false)
-// - OTEL_SERVICE_NAME: Service name (default: alita_robot)
-// - OTEL_TRACES_SAMPLE_RATE: Trace sample rate (default: 1.0)
 func InitTracing() error {
 	ctx := context.Background()
 
-	// Get configuration from environment
 	serviceName := os.Getenv("OTEL_SERVICE_NAME")
 	if serviceName == "" {
 		serviceName = "alita_robot"
@@ -48,7 +41,6 @@ func InitTracing() error {
 			log.Warnf("[Tracing] Failed to parse OTEL_TRACES_SAMPLE_RATE: %v, using default 1.0", err)
 			sampleRate = 1.0
 		}
-		// Clamp sampleRate to [0.0, 1.0] to ensure a safe sampling ratio
 		if sampleRate < 0.0 {
 			log.Warnf("[Tracing] OTEL_TRACES_SAMPLE_RATE %.4f is less than 0.0, clamping to 0.0", sampleRate)
 			sampleRate = 0.0
@@ -58,7 +50,6 @@ func InitTracing() error {
 		}
 	}
 
-	// Create resource with service name
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
@@ -69,14 +60,12 @@ func InitTracing() error {
 		return fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	// Determine which exporter to use
 	var exporter sdktrace.SpanExporter
 	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	useConsole := os.Getenv("OTEL_EXPORTER_CONSOLE") == "true"
 	otlpInsecure := os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "true"
 
 	if otlpEndpoint != "" {
-		// Use OTLP exporter
 		log.Infof("[Tracing] Using OTLP exporter with endpoint: %s", otlpEndpoint)
 		opts := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(otlpEndpoint),
@@ -90,7 +79,6 @@ func InitTracing() error {
 			return fmt.Errorf("failed to create OTLP exporter: %w", err)
 		}
 	} else if useConsole {
-		// Use console exporter for debugging
 		log.Info("[Tracing] Using console exporter")
 		exporter, err = stdouttrace.New(
 			stdouttrace.WithPrettyPrint(),
@@ -100,7 +88,6 @@ func InitTracing() error {
 			return fmt.Errorf("failed to create console exporter: %w", err)
 		}
 	} else {
-		// No exporter configured, tracing disabled but we still set up the propagator
 		log.Info("[Tracing] No OTLP endpoint or console exporter configured, tracing is disabled")
 		propagator = propagation.NewCompositeTextMapPropagator(
 			propagation.TraceContext{},
@@ -111,25 +98,21 @@ func InitTracing() error {
 		return nil
 	}
 
-	// Create tracer provider with sampling
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
 		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(sampleRate))),
 	)
 
-	// Set global tracer provider
 	otel.SetTracerProvider(tp)
 	tracerProvider = tp
 
-	// Set up propagator for trace context propagation
 	propagator = propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},
 	)
 	otel.SetTextMapPropagator(propagator)
 
-	// Create tracer instance
 	tracer = otel.Tracer(serviceName)
 	enabled = true
 
@@ -138,7 +121,6 @@ func InitTracing() error {
 	return nil
 }
 
-// Shutdown gracefully shuts down the tracer provider.
 func Shutdown(ctx context.Context) error {
 	if tracerProvider == nil {
 		return nil
@@ -156,7 +138,6 @@ func Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// GetPropagator returns the global text map propagator for trace context propagation.
 func GetPropagator() propagation.TextMapPropagator {
 	if propagator == nil {
 		return propagation.NewCompositeTextMapPropagator(
@@ -167,16 +148,10 @@ func GetPropagator() propagation.TextMapPropagator {
 	return propagator
 }
 
-// WorkingModeAttribute returns a span attribute for the current working mode.
-// This reads config.AppConfig.WorkingMode at call time, so it reflects the
-// actual runtime value (webhook/polling) rather than the default set at init.
 func WorkingModeAttribute() attribute.KeyValue {
 	return attribute.String("bot.working_mode", config.AppConfig.WorkingMode)
 }
 
-// StartSpan starts a new span with the given name and options.
-// It uses the global tracer if available.
-// When tracing is disabled, returns the input context and a no-op span to avoid overhead.
 func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	if !enabled {
 		return ctx, trace.SpanFromContext(ctx)

--- a/alita/utils/tracing/tracing_test.go
+++ b/alita/utils/tracing/tracing_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/config"
 )
 
-// resetTracingState saves the current tracing globals, resets them to nil/false,
-// and registers a t.Cleanup to restore the original values.
 func resetTracingState(t *testing.T) {
 	t.Helper()
 	origTracerProvider := tracerProvider
@@ -28,7 +26,6 @@ func resetTracingState(t *testing.T) {
 	enabled = false
 }
 
-// ensureAppConfig initializes config.AppConfig if it is nil.
 func ensureAppConfig(t *testing.T) {
 	t.Helper()
 	if config.AppConfig == nil {
@@ -50,8 +47,6 @@ func TestWorkingModeAttribute_ReturnsCorrectKeyAndValue(t *testing.T) {
 		t.Errorf("expected key 'bot.working_mode', got %q", attr.Key)
 	}
 
-	// When config.AppConfig.WorkingMode is unset (empty string in test env),
-	// the value should still be a valid string attribute.
 	_, ok := attr.Value.AsInterface().(string)
 	if !ok {
 		t.Errorf("expected attribute value to be a string, got %T", attr.Value.AsInterface())
@@ -64,17 +59,14 @@ func TestStartSpan_WhenDisabled_ReturnsSameContext(t *testing.T) {
 	inputCtx := context.Background()
 	ctx, span := StartSpan(inputCtx, "test-span")
 
-	// When disabled, StartSpan must return the exact same context, not a new one.
 	if ctx != inputCtx {
 		t.Error("expected StartSpan to return the same context when tracing is disabled")
 	}
 
-	// Span should be a no-op (from trace.SpanFromContext on background context).
 	if span == nil {
 		t.Fatal("expected span to be non-nil")
 	}
 
-	// A no-op span has empty SpanContext.
 	if span.SpanContext().IsValid() {
 		t.Error("expected no-op span to have an invalid SpanContext")
 	}
@@ -96,7 +88,7 @@ func TestSetOnProcessUpdateCallback_StoresCallback(t *testing.T) {
 	SetOnProcessUpdateCallback(func() {
 		called.Add(1)
 	})
-	defer SetOnProcessUpdateCallback(nil) // cleanup
+	defer SetOnProcessUpdateCallback(nil)
 
 	runOnProcessUpdateCallback()
 	if called.Load() != 1 {
@@ -111,15 +103,13 @@ func TestRunOnProcessUpdateCallback_CallsStoredCallback(t *testing.T) {
 	SetOnProcessUpdateCallback(func() {
 		counter.Add(1)
 	})
-	defer SetOnProcessUpdateCallback(nil) // cleanup
+	defer SetOnProcessUpdateCallback(nil)
 
-	// First call
 	runOnProcessUpdateCallback()
 	if counter.Load() != 1 {
 		t.Errorf("expected counter=1 after first call, got %d", counter.Load())
 	}
 
-	// Second call
 	runOnProcessUpdateCallback()
 	if counter.Load() != 2 {
 		t.Errorf("expected counter=2 after second call, got %d", counter.Load())
@@ -131,14 +121,12 @@ func TestRunOnProcessUpdateCallback_NoCallback_DoesNotPanic(t *testing.T) {
 
 	SetOnProcessUpdateCallback(nil)
 
-	// Should not panic when no callback is registered
 	runOnProcessUpdateCallback()
 }
 
 func TestWorkingModeAttribute_ValueReflectsConfig(t *testing.T) {
 	ensureAppConfig(t)
 
-	// Save original pointer to restore after test
 	origApp := config.AppConfig
 	defer func() {
 		config.AppConfig = origApp
@@ -165,7 +153,6 @@ func TestWorkingModeAttribute_ValueReflectsConfig(t *testing.T) {
 }
 
 func TestInitTracing_NoEndpoint_NoConsoleExporter(t *testing.T) {
-	// Clear all tracing environment variables
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_CONSOLE", "")
 	t.Setenv("OTEL_TRACES_SAMPLE_RATE", "")
@@ -262,11 +249,9 @@ func TestInitTracingConsoleExporterEnablesTracingAndShutdown(t *testing.T) {
 }
 
 func TestShutdown_AfterFailedInit_ReturnsNil(t *testing.T) {
-	// Simulate the state after a failed InitTracing: tracerProvider is nil.
 	ensureAppConfig(t)
 	resetTracingState(t)
 
-	// Shutdown should return nil when tracerProvider is nil.
 	err := Shutdown(context.Background())
 	if err != nil {
 		t.Errorf("expected Shutdown to return nil after failed init, got %v", err)


### PR DESCRIPTION
Comment-only split of #830 (whose diff exceeded GitHub's 20k-line API limit for the lint action). No code, string, or test-name changes. Kept: go:build/embed, pedantic nolint/nosec, external-constraint notes, public-API contracts, test concurrency contracts.