### PR TITLE
chore: strip restatement comments in moderation modules

### DIFF
--- a/alita/modules/admin.go
+++ b/alita/modules/admin.go
@@ -24,13 +24,6 @@ import (
 
 var adminModule = moduleStruct{moduleName: "Admin"}
 
-/*
-	Used to list all the admin in a group
-
-Connection - false, false
-*/
-// adminlist handles the /adminlist command to display all admins in a group.
-// It returns a cached or fresh list of group administrators excluding bots and anonymous admins.
 func (m moduleStruct) adminlist(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -52,7 +45,6 @@ func (m moduleStruct) adminlist(c *helpers.CommandContext) error {
 		admin := &admins.UserInfo[i]
 		user := admin.User
 		if user.IsBot || admin.IsAnonymous {
-			// don't list bots and anonymous admins
 			continue
 		}
 		if user.Username != "" {
@@ -62,7 +54,6 @@ func (m moduleStruct) adminlist(c *helpers.CommandContext) error {
 		}
 	}
 	if sb.Len() == 0 {
-		// All admins are bots or anonymous
 		noVisibleText, _ := tr.GetString("admin_no_visible_admins")
 		text += noVisibleText
 	} else {
@@ -84,15 +75,6 @@ func (m moduleStruct) adminlist(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-/* Used to Demote a member in chat
-
-connection = true, true
-
-Bot can only Demote people it promoted! */
-
-// loadAdminCacheOrFail returns the cached admin list, or loads it from
-// Telegram. If the cache is empty after loading, it replies with an error
-// and returns a nil pointer so the caller can early-return.
 func (m moduleStruct) loadAdminCacheOrFail(c *helpers.CommandContext) *cache.AdminCache {
 	adminsAvail, admins := cache.GetAdminCacheList(c.Chat.Id)
 	if !adminsAvail {
@@ -109,9 +91,6 @@ func (m moduleStruct) loadAdminCacheOrFail(c *helpers.CommandContext) *cache.Adm
 	return &admins
 }
 
-// validateDemotionTarget checks the extracted user ID for demotion.
-// It returns the validated user ID and an error sentinel if the target is
-// invalid (the caller should return ext.EndGroups).
 func (m moduleStruct) validateDemotionTarget(c *helpers.CommandContext) (int64, error) {
 	userId := extraction.ExtractUser(c.Bot, c.Ctx)
 	if userId == -1 {
@@ -152,8 +131,6 @@ func (m moduleStruct) validateDemotionTarget(c *helpers.CommandContext) (int64, 
 		}
 		return 0, ext.EndGroups
 	}
-	// Using IsUserAdmin (not RequireUserAdmin) because we need a custom error message
-	// specific to the demote context rather than the generic permission error.
 	if !chat_status.IsUserAdmin(c.Bot, c.Chat.Id, userId) {
 		text, _ := c.Tr.GetString(strings.ToLower(m.moduleName) + "_demote_not_admin")
 		_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
@@ -167,8 +144,6 @@ func (m moduleStruct) validateDemotionTarget(c *helpers.CommandContext) (int64, 
 	return userId, nil
 }
 
-// performDemotion removes admin privileges from the target user and sends
-// a success confirmation.
 func (m moduleStruct) performDemotion(c *helpers.CommandContext, userId int64) error {
 	bb, err := c.Chat.PromoteMember(c.Bot,
 		userId,
@@ -222,8 +197,6 @@ func (m moduleStruct) performDemotion(c *helpers.CommandContext, userId int64) e
 	return ext.EndGroups
 }
 
-// demote handles the /demote command to remove admin privileges from a user.
-// The bot can only demote users it has previously promoted.
 func (m moduleStruct) demote(c *helpers.CommandContext) error {
 	admins := m.loadAdminCacheOrFail(c)
 	if admins == nil {
@@ -238,14 +211,6 @@ func (m moduleStruct) demote(c *helpers.CommandContext) error {
 	return m.performDemotion(c, userId)
 }
 
-/* Used to Promote a member in chat
-
-connection = true, true
-
-Bot will give promoted user permissions of bot*/
-
-// validatePromotionTarget extracts and validates the target user for promotion.
-// It returns the user ID, custom title, and an error sentinel (ext.EndGroups) on failure.
 func (m moduleStruct) validatePromotionTarget(c *helpers.CommandContext) (int64, string, error) {
 	userId, customTitle := extraction.ExtractUserAndText(c.Bot, c.Ctx)
 	if userId == -1 {
@@ -297,14 +262,10 @@ func (m moduleStruct) validatePromotionTarget(c *helpers.CommandContext) (int64,
 	return userId, customTitle, nil
 }
 
-// canGrantPerm returns whether the bot can grant a specific permission,
-// considering both the bot's own capability and the promoter privileges.
 func canGrantPerm(botHas, promoterHas, bypass bool) bool {
 	return botHas && (promoterHas || bypass)
 }
 
-// buildPromoteOpts constructs the permission options for PromoteMember
-// based on bot and promoter capabilities.
 func buildPromoteOpts(botMember, promoterMember gotgbot.ChatMember, user *gotgbot.User, c *helpers.CommandContext) *gotgbot.PromoteChatMemberOpts {
 	bMem := botMember.MergeChatMember()
 	pMem := promoterMember.MergeChatMember()
@@ -327,8 +288,6 @@ func buildPromoteOpts(botMember, promoterMember gotgbot.ChatMember, user *gotgbo
 	}
 }
 
-// handlePromotionSuccess sends the success reply after a promotion,
-// optionally setting a custom title and truncating it if needed.
 func (m moduleStruct) handlePromotionSuccess(c *helpers.CommandContext, userId int64, customTitle string, userMember gotgbot.ChatMember) error {
 	tr := c.Tr
 	msg := c.Msg
@@ -370,8 +329,6 @@ func (m moduleStruct) handlePromotionSuccess(c *helpers.CommandContext, userId i
 	return ext.EndGroups
 }
 
-// promote handles the /promote command to grant admin privileges to a user.
-// The bot grants permissions based on its own capabilities and the promoter's status.
 func (m moduleStruct) promote(c *helpers.CommandContext) error {
 	admins := m.loadAdminCacheOrFail(c)
 	if admins == nil {
@@ -431,8 +388,6 @@ func (m moduleStruct) promote(c *helpers.CommandContext) error {
 	return m.handlePromotionSuccess(c, userId, customTitle, userMember)
 }
 
-// getinvitelink handles the /invitelink command to retrieve the chat's invite link.
-// Returns either the public username or generates an invite link for private groups.
 func (moduleStruct) getinvitelink(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -453,7 +408,6 @@ func (moduleStruct) getinvitelink(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// setGTitle handles /setgtitle to change the current group's title.
 func (moduleStruct) setGTitle(c *helpers.CommandContext) error {
 	msg := c.Msg
 	tr := c.Tr
@@ -474,7 +428,6 @@ func (moduleStruct) setGTitle(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// setGPic handles /setgpic to set the group photo from a replied photo.
 func (moduleStruct) setGPic(c *helpers.CommandContext) error {
 	msg := c.Msg
 	tr := c.Tr
@@ -503,7 +456,6 @@ func (moduleStruct) setGPic(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// setGDesc handles /setgdesc to change the current group's description.
 func (moduleStruct) setGDesc(c *helpers.CommandContext) error {
 	msg := c.Msg
 	tr := c.Tr
@@ -519,12 +471,6 @@ func (moduleStruct) setGDesc(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-/*
-Sets a custom title for an admin.
-Only works with admins whom bot has promoted.*/
-
-// setTitle handles the /title command to set a custom administrator title.
-// Only works with admins that the bot has promoted and titles are limited to 16 characters.
 func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -581,7 +527,6 @@ func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 		return ext.EndGroups
 	}
 
-	// for managing custom title
 	var extraText string
 	if customTitle == "" {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_errors_title_empty")
@@ -592,7 +537,6 @@ func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 		}
 		return ext.EndGroups
 	} else if len([]rune(customTitle)) > 16 {
-		// trim title to 16 characters (telegram restriction) and notify user
 		runes := []rune(customTitle)
 		temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_title_truncated")
 		extraText = fmt.Sprintf(temp, len(runes))
@@ -639,8 +583,6 @@ func (m moduleStruct) setTitle(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// anonAdmin handles the /anonadmin command to toggle anonymous admin mode in groups.
-// Only chat owners can modify this setting which affects how anonymous admins are handled.
 func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -661,7 +603,6 @@ func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
 			text = fmt.Sprintf(temp, formatting.HtmlEscape(chat.Title))
 		}
 	} else {
-		// only need owner if you want to change value
 		if !chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, user.Id) {
 			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 			return ext.EndGroups
@@ -672,7 +613,6 @@ func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
 				temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_already_enabled")
 				text = fmt.Sprintf(temp, formatting.HtmlEscape(chat.Title))
 			} else {
-				// Synchronous DB write - confirm success before sending message
 				if err := admin.SetAnonAdminMode(chat.Id, true); err != nil {
 					log.Errorf("[Admin] Failed to set anon admin mode for chat %d: %v", chat.Id, err)
 					errorText, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_db_error")
@@ -687,7 +627,6 @@ func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
 				temp, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_already_disabled")
 				text = fmt.Sprintf(temp, formatting.HtmlEscape(chat.Title))
 			} else {
-				// Synchronous DB write - confirm success before sending message
 				if err := admin.SetAnonAdminMode(chat.Id, false); err != nil {
 					log.Errorf("[Admin] Failed to set anon admin mode for chat %d: %v", chat.Id, err)
 					errorText, _ := tr.GetString(strings.ToLower(m.moduleName) + "_anon_admin_db_error")
@@ -711,8 +650,6 @@ func (m moduleStruct) anonAdmin(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// adminCache handles the /admincache command to refresh the admin cache for a chat.
-// Forces a reload of admin permissions from Telegram's API.
 func (moduleStruct) adminCache(c *helpers.CommandContext) error {
 	b := c.Bot
 	chat := c.Chat
@@ -724,7 +661,6 @@ func (moduleStruct) adminCache(c *helpers.CommandContext) error {
 
 	var err error
 
-	// permission checks
 	userMember, err := chat.GetMember(b, user.Id, nil)
 	if err != nil {
 		log.Errorf("[Admin] Failed to get member %d: %v", user.Id, err)
@@ -860,8 +796,6 @@ var (
 	}
 )
 
-// LoadAdmin registers all admin module command handlers with the dispatcher.
-// Sets up commands for promotion, demotion, title setting, and admin management.
 func LoadAdmin(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap["Admin"] = true
 
@@ -876,8 +810,6 @@ func LoadAdmin(dispatcher *ext.Dispatcher) {
 	helpers.WrapCommand(dispatcher, setGPicDesc, adminModule.setGPic)
 	helpers.WrapCommand(dispatcher, setGDescDesc, adminModule.setGDesc)
 
-	// adminCache uses custom permission checking (direct member status lookup),
-	// so it remains a raw handler.
 	dispatcher.AddHandler(handlers.NewCommand("admincache", func(b *gotgbot.Bot, ctx *ext.Context) error {
 		defer error_handling.RecoverFromPanic("admincache", "admin")
 		c, err := helpers.BuildCommandContext(b, ctx)
@@ -888,8 +820,6 @@ func LoadAdmin(dispatcher *ext.Dispatcher) {
 	}))
 }
 
-// clearAdminCache handles the /clearadmincache command to delete the cached admin list.
-// Requires admin permissions and provides user feedback on success.
 func (moduleStruct) clearAdminCache(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -915,15 +845,11 @@ func (moduleStruct) clearAdminCache(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// anonymousAdmin wrappers for admin.go
 func (m moduleStruct) promoteAnonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 	c, err := helpers.BuildCommandContext(b, ctx)
 	if err != nil {
 		return ext.EndGroups
 	}
-	// Anonymous admins bypass WrapCommand's RequiredChecks, so enforce promote
-	// authorization explicitly: the anon admin must have CanPromoteMembers rights
-	// and the bot must have CanPromoteMembers rights.
 	if !chat_status.CanUserPromote(b, ctx, nil, ctx.EffectiveUser.Id) {
 		return ext.EndGroups
 	}
@@ -938,8 +864,6 @@ func (m moduleStruct) demoteAnonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 	if err != nil {
 		return ext.EndGroups
 	}
-	// Same authorization gate as promoteAnonAdmin: demoting also requires
-	// CanPromoteMembers on both the caller and the bot.
 	if !chat_status.CanUserPromote(b, ctx, nil, ctx.EffectiveUser.Id) {
 		return ext.EndGroups
 	}
@@ -954,9 +878,6 @@ func (m moduleStruct) setTitleAnonAdmin(b *gotgbot.Bot, ctx *ext.Context) error 
 	if err != nil {
 		return ext.EndGroups
 	}
-	// Anonymous admins bypass WrapCommand's RequiredChecks, so enforce promote
-	// authorization explicitly (setTitle requires CanPromoteMembers), matching
-	// promoteAnonAdmin/demoteAnonAdmin.
 	if !chat_status.CanUserPromote(b, ctx, nil, ctx.EffectiveUser.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_promote_cmd_error", "chat_status_promote_button_error")
 		return ext.EndGroups

--- a/alita/modules/admin_test.go
+++ b/alita/modules/admin_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
-// testError is a simple error implementation for testing
 type testError struct {
 	msg string
 }
@@ -22,9 +21,7 @@ func (e *testError) Error() string {
 	return e.msg
 }
 
-// TestDemoteErrorHandling verifies error handling patterns in demote logic
 func TestDemoteErrorHandling(t *testing.T) {
-	// simulateGetMemberResult simulates the return values of GetMember,
 	// returning values that staticcheck cannot statically resolve.
 	simulateGetMemberResult := func(wantErr bool) (gotgbot.ChatMember, error) {
 		if wantErr {
@@ -34,31 +31,25 @@ func TestDemoteErrorHandling(t *testing.T) {
 	}
 
 	t.Run("error takes precedence over nil member", func(t *testing.T) {
-		// When GetMember returns (nil, error), error should be checked first
-		// This is the standard pattern: check err != nil before using result
 		userMember, err := simulateGetMemberResult(true)
 
 		if err != nil {
-			// Expected: error is handled first
 			t.Logf("Error handled first: %v", err)
 			return
 		}
 
-		// Should not reach here when err != nil
 		if userMember == nil {
 			t.Fatal("Should have returned on error, not reached nil check")
 		}
 	})
 
 	t.Run("nil error with nil member", func(t *testing.T) {
-		// When GetMember returns (nil, nil), the nil member should be handled
 		userMember, err := simulateGetMemberResult(false)
 
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		// After confirming no error, check the member
 		if userMember == nil {
 			t.Log("Nil member properly detected after nil error check")
 			return

--- a/alita/modules/bans.go
+++ b/alita/modules/bans.go
@@ -30,24 +30,15 @@ func kickMember(b *gotgbot.Bot, chatID, userID int64) error {
 	return err
 }
 
-/* Used to Kick a user from group
-
-The Bot, Kicker should be admin with ban permissions in order to use this */
-
-// dkick handles the /dkick command to delete a message and kick the sender.
-// Removes the replied-to message and kicks the user from the group.
 func (m moduleStruct) dkick(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationDkick(&m).run(b, ctx)
 }
 
-// kickTargetValidation validates the target for kick commands.
-// Checks: user in chat, not ban-protected, not the bot itself.
 func kickTargetValidation(c *moderationCtx, t *target) error {
 	prefix := strings.ToLower(c.Module.moduleName)
 	return validateTarget(c, t.userID, true, prefix+"_kick_user_not_in_chat", prefix+"_kick_cannot_kick_admin", prefix+"_kick_is_bot_itself")
 }
 
-// kickReply builds and sends the success reply for kick commands.
 func kickReply(c *moderationCtx, t *target) error {
 	kickuser, err := c.Bot.GetChat(t.userID, nil)
 	if err != nil {
@@ -74,15 +65,11 @@ func kickReply(c *moderationCtx, t *target) error {
 	return nil
 }
 
-// banTargetValidation validates the target for ban commands.
-// Checks: not ban-protected, not the bot itself.
 func banTargetValidation(c *moderationCtx, t *target) error {
 	prefix := strings.ToLower(c.Module.moduleName)
 	return validateTarget(c, t.userID, false, "", prefix+"_ban_is_admin", prefix+"_ban_is_bot_itself")
 }
 
-// moderationDkick is the shared moderationCommand definition for /dkick.
-// It deletes the replied message and kicks the user.
 func moderationDkick(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -102,7 +89,6 @@ func moderationDkick(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationTban is the shared moderationCommand definition for /tban.
 func moderationTban(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -144,8 +130,6 @@ func moderationTban(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// banReplyWithButton builds and sends the success reply for ban commands
-// with an inline unban button.
 func banReplyWithButton(c *moderationCtx, t *target) error {
 	banUser, err := c.Bot.GetChat(t.userID, nil)
 	if err != nil {
@@ -183,8 +167,6 @@ func banReplyWithButton(c *moderationCtx, t *target) error {
 	return nil
 }
 
-// moderationBan is the shared moderationCommand definition for /ban.
-// Handles both regular users and anonymous channels with inline unban button.
 func moderationBan(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module: m,
@@ -250,8 +232,6 @@ func moderationBan(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationKick is the shared moderationCommand definition for /kick.
-// It is reused by both the direct handler and any aliases.
 func moderationKick(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -266,7 +246,6 @@ func moderationKick(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationKickme is the shared moderationCommand definition for /kickme.
 func moderationKickme(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module: m,
@@ -284,7 +263,6 @@ func moderationKickme(m *moduleStruct) *moderationCommand {
 			},
 		},
 		extract: func(c *moderationCtx) (target, error) {
-			// Don't allow admins to use the command
 			if chat_status.IsUserAdmin(c.Bot, c.Chat.Id, c.User.Id) {
 				text, _ := c.Tr.GetString(strings.ToLower(c.Module.moduleName) + "_kickme_is_admin")
 				_, err := c.Msg.Reply(c.Bot, text, formatting.Shtml())
@@ -313,7 +291,6 @@ func moderationKickme(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationSban is the shared moderationCommand definition for /sban.
 func moderationSban(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -333,7 +310,6 @@ func moderationSban(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationDban is the shared moderationCommand definition for /dban.
 func moderationDban(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:  m,
@@ -368,8 +344,6 @@ func moderationDban(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationUnban is the shared moderationCommand definition for /unban.
-// Supports both regular users and anonymous channels.
 func moderationUnban(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module: m,
@@ -447,66 +421,34 @@ func moderationUnban(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// kick delegates to the shared moderationKick command template.
 func (m moduleStruct) kick(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationKick(&m).run(b, ctx)
 }
 
-// kickme handles the /kickme command allowing users to remove themselves.
-// Only works for non-admin users who want to leave the group.
 func (m moduleStruct) kickme(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationKickme(&m).run(b, ctx)
 }
 
-/* Used to temporarily ban a user from chat
-
-The Bot, Kick should be admin with ban permissions in order to use this */
-
-// tBan handles the /tban command to temporarily ban a user.
-// Bans a user for a specified time period with optional reason.
 func (m moduleStruct) tBan(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationTban(&m).run(b, ctx)
 }
 
-/* Used to indefinitely ban a user from group
-
-The Bot, Banner should be admin with ban permissions in order to use this */
-
-// ban handles the /ban command to permanently ban a user from the group.
-// Supports both regular users and anonymous channels with inline unban button.
 func (m moduleStruct) ban(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationBan(&m).run(b, ctx)
 }
 
-/* Used to Silently Ban a user from group
-
-This deletes the command of Banner and also does not reply.
-
-The Bot, Banner should be admin with ban permissions in order to use this */
-
-// sBan handles the /sban command to silently ban a user.
-// Bans the user and deletes the command message without notification.
 func (m moduleStruct) sBan(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationSban(&m).run(b, ctx)
 }
 
-// dBan handles the /dban command to delete a message and ban the sender.
-// Removes the replied-to message and permanently bans the user.
 func (m moduleStruct) dBan(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationDban(&m).run(b, ctx)
 }
 
-// unban handles the /unban command to remove a ban from a user.
-// Supports both regular users and anonymous channels.
 func (m moduleStruct) unban(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationUnban(&m).run(b, ctx)
 }
 
-/* Used to Restrict members from a chat
-Shows an inline keyboard menu which shows options to kick, ban and mute */
-
-// restrict handles the /restrict command to show restriction options.
-// Displays an inline keyboard with ban, kick, and mute options for a user.
 func (moduleStruct) restrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := chat_status.RequireUser(b, ctx)
@@ -515,7 +457,6 @@ func (moduleStruct) restrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	msg := ctx.EffectiveMessage
 
-	// Permission checks
 	if !chat_status.RequireGroup(b, ctx, chat) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -544,7 +485,6 @@ func (moduleStruct) restrict(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Restriction only applies to current members.
 	if !chat_status.IsUserInChat(b, chat, userId) {
 		text, _ := tr.GetString("common_user_not_in_chat")
 		_, err := msg.Reply(b, text, formatting.Shtml())
@@ -606,9 +546,6 @@ func (moduleStruct) restrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// Handles the queries fore restrict command
-// restrictButtonHandler processes inline keyboard callbacks for restriction actions.
-// Handles ban, kick, and mute actions triggered from the restrict command keyboard.
 func (moduleStruct) restrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -624,7 +561,6 @@ func (moduleStruct) restrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) erro
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// permissions check
 	if !chat_status.CanUserRestrict(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_restrict_cmd_error", "chat_status_restrict_button_error")
 		return ext.EndGroups
@@ -726,11 +662,6 @@ func (moduleStruct) restrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) erro
 	return ext.EndGroups
 }
 
-/* Used to Unrestrict members from a chat
-Shows an inline keyboard menu which shows options to unban and unmute */
-
-// unrestrict handles the /unrestrict command to show unrestriction options.
-// Displays an inline keyboard with unban and unmute options for a user.
 func (moduleStruct) unrestrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := chat_status.RequireUser(b, ctx)
@@ -740,7 +671,6 @@ func (moduleStruct) unrestrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireGroup(b, ctx, chat) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -817,9 +747,6 @@ func (moduleStruct) unrestrict(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// Handles queries for unrestrict command
-// unrestrictButtonHandler processes inline keyboard callbacks for unrestriction actions.
-// Handles unban and unmute actions triggered from the unrestrict command keyboard.
 func (moduleStruct) unrestrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -836,7 +763,6 @@ func (moduleStruct) unrestrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) er
 		return answerInvalidCallback(b, ctx, query)
 	}
 
-	// permissions check
 	if !chat_status.CanUserRestrict(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_restrict_cmd_error", "chat_status_restrict_button_error")
 		return ext.EndGroups
@@ -952,7 +878,6 @@ func (moduleStruct) unrestrictButtonHandler(b *gotgbot.Bot, ctx *ext.Context) er
 	return ext.EndGroups
 }
 
-// moderationSkick silently kicks a user and deletes the command message.
 func moderationSkick(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -975,7 +900,6 @@ func (m moduleStruct) sKick(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationSkick(&m).run(b, ctx)
 }
 
-// moderationBanme lets a non-admin permanently ban themselves from the chat.
 func moderationBanme(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module: m,
@@ -1026,7 +950,6 @@ func (m moduleStruct) banme(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationBanme(&m).run(b, ctx)
 }
 
-// unbanAllHandler asks the chat owner to confirm unbanning every known member.
 func (m moduleStruct) unbanAllHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := chat_status.RequireUser(b, ctx)
@@ -1132,12 +1055,9 @@ func (m moduleStruct) unbanAllCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadBans registers all ban-related command handlers with the dispatcher.
-// Sets up ban, kick, restrict commands and their associated callback handlers.
 func LoadBans(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[bansModule.moduleName] = true
 
-	// ban cmds
 	dispatcher.AddHandler(handlers.NewCommand("ban", bansModule.ban))
 	dispatcher.AddHandler(handlers.NewCommand("sban", bansModule.sBan))
 	dispatcher.AddHandler(handlers.NewCommand("tban", bansModule.tBan))
@@ -1147,14 +1067,12 @@ func LoadBans(dispatcher *ext.Dispatcher) {
 	helpers.AddCmdToDisableable("banme")
 	dispatcher.AddHandler(handlers.NewCommand("unbanall", bansModule.unbanAllHandler))
 
-	// kick cmds
 	dispatcher.AddHandler(handlers.NewCommand("kick", bansModule.kick))
 	dispatcher.AddHandler(handlers.NewCommand("dkick", bansModule.dkick))
 	dispatcher.AddHandler(handlers.NewCommand("skick", bansModule.sKick))
 	dispatcher.AddHandler(handlers.NewCommand("kickme", bansModule.kickme))
 	helpers.AddCmdToDisableable("kickme")
 
-	// special commands
 	dispatcher.AddHandler(handlers.NewCommand("restrict", bansModule.restrict))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("restrict"), bansModule.restrictButtonHandler))
 	dispatcher.AddHandler(handlers.NewCommand("unrestrict", bansModule.unrestrict))

--- a/alita/modules/chat_permissions_test.go
+++ b/alita/modules/chat_permissions_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
-// derefBool safely dereferences a *bool, returning defaultVal if nil.
 func derefBool(ptr *bool, defaultVal bool) bool {
 	if ptr == nil {
 		return defaultVal

--- a/alita/modules/connections.go
+++ b/alita/modules/connections.go
@@ -23,15 +23,6 @@ import (
 
 var ConnectionsModule = moduleStruct{moduleName: "Connections"}
 
-/*
-	Check the status of connection of a user in their PM
-
-User can check if they are connected to a chat and can also bring up the keyboard for it.
-Normal use will have just one option with 'User Commands' and admin will have "Admin Commands" along the earlier as
-well.
-*/
-// connection handles the /connection command to check user's connection status.
-// Shows current connected chat and provides keyboard with available commands.
 func (m moduleStruct) connection(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	user := chat_status.RequireUser(b, ctx)
@@ -40,7 +31,6 @@ func (m moduleStruct) connection(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// permission checks
 	if !chat_status.RequirePrivate(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_pm_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -69,15 +59,6 @@ func (m moduleStruct) connection(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Allow users to connect to your chat
-
-You can give a word such as on/off/yes/no to toggle options
-
-Also, if no word is given, you will get your current setting.
-*/
-// allowConnect handles the /allowconnect command to toggle connection permissions.
-// Admins can enable/disable whether users can connect to their chat remotely.
 func (m moduleStruct) allowConnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -90,7 +71,6 @@ func (m moduleStruct) allowConnect(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	var text string
 
-	// permission checks
 	if !chat_status.IsUserAdmin(b, chat.Id, user.Id) {
 		return ext.EndGroups
 	}
@@ -131,15 +111,6 @@ func (m moduleStruct) allowConnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Connect to a chat
-
-Use this command to connect to your chat!
-
-Admins and Users both can use this.
-*/
-// connect handles the /connect command to establish connection to a chat.
-// Allows users and admins to remotely manage chats through private messages.
 func (m moduleStruct) connect(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
@@ -203,9 +174,6 @@ func (m moduleStruct) connect(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// Handler for Connection buttons
-// connectionButtons handles inline keyboard callbacks for connection management.
-// Processes admin and user command list requests from connection interface.
 func (m moduleStruct) connectionButtons(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -276,13 +244,6 @@ func (m moduleStruct) connectionButtons(b *gotgbot.Bot, ctx *ext.Context) error 
 	return ext.EndGroups
 }
 
-/*
-	Disconnect from a chat
-
-Used to disconnect from currently connected chat
-*/
-// disconnect handles the /disconnect command to end current chat connection.
-// Removes the user's connection to allow connecting to different chats.
 func (m moduleStruct) disconnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	user := chat_status.RequireUser(b, ctx)
@@ -316,13 +277,6 @@ func (m moduleStruct) disconnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to reconnect to last chat connected by user
-
-Both user and admin can use this command to connect to the previous chat
-*/
-// reconnect handles the /reconnect command to restore previous connection.
-// Reconnects users to their last connected chat if they're still a member.
 func (m moduleStruct) reconnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -345,7 +299,6 @@ func (m moduleStruct) reconnect(b *gotgbot.Bot, ctx *ext.Context) error {
 				return err
 			}
 
-			// need to convert to chat type
 			_chat := gchat.ToChat()
 
 			isMember, err := chat_status.IsUserInChatWithError(b, &_chat, user.Id)
@@ -393,8 +346,6 @@ func (m moduleStruct) reconnect(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadConnections registers all connection module handlers with the dispatcher.
-// Sets up commands for managing remote chat connections and their callbacks.
 func LoadConnections(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[ConnectionsModule.moduleName] = true
 

--- a/alita/modules/connections_auth.go
+++ b/alita/modules/connections_auth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
 )
 
-// canUserConnectToChat enforces the same authorization gate for /connect, /reconnect, and deep-link connect.
 func canUserConnectToChat(b *gotgbot.Bot, chatID, userID int64) (bool, string) {
 	settings := connections.GetChatConnectionSetting(chatID)
 	if chat_status.IsUserAdmin(b, chatID, userID) {

--- a/alita/modules/devs.go
+++ b/alita/modules/devs.go
@@ -24,8 +24,6 @@ import (
 
 var devsModule = moduleStruct{moduleName: "Dev"}
 
-// chatInfo retrieves and displays detailed information about a specific chat.
-// Only accessible by bot owner and dev users. Returns chat name, ID, member count, and invite link.
 func (moduleStruct) chatInfo(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -33,7 +31,6 @@ func (moduleStruct) chatInfo(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	memStatus := devs.GetTeamMemInfo(user.Id)
 
-	// only devs and owner can access this
 	if user.Id != config.AppConfig.OwnerId && !memStatus.IsDev {
 		return ext.ContinueGroups
 	}
@@ -54,7 +51,6 @@ func (moduleStruct) chatInfo(b *gotgbot.Bot, ctx *ext.Context) error {
 			_, _ = msg.Reply(b, err.Error(), nil)
 			return ext.EndGroups
 		}
-		// need to convert chat to group chat to use GetMemberCount
 		_chat := chat.ToChat()
 		gChat := &_chat
 		con, _ := gChat.GetMemberCount(b, nil)
@@ -72,8 +68,6 @@ func (moduleStruct) chatInfo(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// chatList generates and sends a document containing all active chats the bot is in.
-// Only accessible by bot owner and dev users. Creates a temporary file with chat IDs and names.
 func (moduleStruct) chatList(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -81,7 +75,6 @@ func (moduleStruct) chatList(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	memStatus := devs.GetTeamMemInfo(user.Id)
 
-	// only devs and owner can access this
 	if user.Id != config.AppConfig.OwnerId && !memStatus.IsDev {
 		return ext.ContinueGroups
 	}
@@ -135,8 +128,6 @@ func (moduleStruct) chatList(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// leaveChat makes the bot leave a specified chat.
-// Only accessible by bot owner and dev users. Requires chat ID as argument.
 func (moduleStruct) leaveChat(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -144,7 +135,6 @@ func (moduleStruct) leaveChat(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	memStatus := devs.GetTeamMemInfo(user.Id)
 
-	// only devs and owner can access this
 	if user.Id != config.AppConfig.OwnerId && !memStatus.IsDev {
 		return ext.ContinueGroups
 	}
@@ -182,26 +172,17 @@ func (moduleStruct) leaveChat(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-/*
-	Functions used to manage sudo/dev users in database of bot
-
-Can only be used by OWNER
-*/
-
-// teamRoleConfig holds configuration for team role management operations.
 type teamRoleConfig struct {
-	roleName      string                     // "sudo" or "dev"
-	add           bool                       // true for add, false for remove
-	checkRole     func(*db.DevSettings) bool // checks if user has role
-	alreadyMsgKey string                     // i18n key for "already has role"
-	notRoleMsgKey string                     // i18n key for "doesn't have role"
-	failMsgKey    string                     // i18n key for operation failure
-	successMsgKey string                     // i18n key for operation success
-	dbOp          func(int64) error          // database operation (AddSudo, RemDev, etc.)
+	roleName      string
+	add           bool
+	checkRole     func(*db.DevSettings) bool
+	alreadyMsgKey string
+	notRoleMsgKey string
+	failMsgKey    string
+	successMsgKey string
+	dbOp          func(int64) error
 }
 
-// manageTeamRole handles adding/removing team roles (sudo/dev).
-// Only accessible by bot owner.
 func (m moduleStruct) manageTeamRole(b *gotgbot.Bot, ctx *ext.Context, cfg teamRoleConfig) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -229,7 +210,6 @@ func (m moduleStruct) manageTeamRole(b *gotgbot.Bot, ctx *ext.Context, cfg teamR
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	var txt string
 
-	// Check if operation is valid based on current role status
 	hasRole := cfg.checkRole(memStatus)
 	if cfg.add && hasRole {
 		txt, _ = tr.GetString(cfg.alreadyMsgKey)
@@ -254,8 +234,6 @@ func (m moduleStruct) manageTeamRole(b *gotgbot.Bot, ctx *ext.Context, cfg teamR
 	return ext.ContinueGroups
 }
 
-// addSudo adds a user to the sudo users list in the bot's database.
-// Only accessible by bot owner. Grants elevated permissions to the specified user.
 func (m moduleStruct) addSudo(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.manageTeamRole(b, ctx, teamRoleConfig{
 		roleName:      "sudo",
@@ -268,8 +246,6 @@ func (m moduleStruct) addSudo(b *gotgbot.Bot, ctx *ext.Context) error {
 	})
 }
 
-// addDev adds a user to the developer users list in the bot's database.
-// Only accessible by bot owner. Grants developer-level permissions to the specified user.
 func (m moduleStruct) addDev(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.manageTeamRole(b, ctx, teamRoleConfig{
 		roleName:      "dev",
@@ -282,8 +258,6 @@ func (m moduleStruct) addDev(b *gotgbot.Bot, ctx *ext.Context) error {
 	})
 }
 
-// remSudo removes a user from the sudo users list in the bot's database.
-// Only accessible by bot owner. Revokes elevated permissions from the specified user.
 func (m moduleStruct) remSudo(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.manageTeamRole(b, ctx, teamRoleConfig{
 		roleName:      "sudo",
@@ -296,8 +270,6 @@ func (m moduleStruct) remSudo(b *gotgbot.Bot, ctx *ext.Context) error {
 	})
 }
 
-// remDev removes a user from the developer users list in the bot's database.
-// Only accessible by bot owner. Revokes developer-level permissions from the specified user.
 func (m moduleStruct) remDev(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.manageTeamRole(b, ctx, teamRoleConfig{
 		roleName:      "dev",
@@ -310,13 +282,6 @@ func (m moduleStruct) remDev(b *gotgbot.Bot, ctx *ext.Context) error {
 	})
 }
 
-/*
-	Function used to list all members of bot's development team
-
-Can only be used by existing team members
-*/
-// listTeam displays all current team members including developers and sudo users.
-// Only accessible by existing team members. Shows user mentions organized by permission level.
 func (moduleStruct) listTeam(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -394,13 +359,6 @@ func (moduleStruct) listTeam(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Function used to fetch stats of bot
-
-Can only be used by OWNER
-*/
-// getStats retrieves and displays bot statistics including user counts, chat counts, and other metrics.
-// Only accessible by bot owner and dev users. Shows comprehensive bot usage statistics.
 func (moduleStruct) getStats(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -408,7 +366,6 @@ func (moduleStruct) getStats(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	memStatus := devs.GetTeamMemInfo(user.Id)
 
-	// only devs and owner can access this
 	if user.Id != config.AppConfig.OwnerId && !memStatus.IsDev {
 		return ext.ContinueGroups
 	}
@@ -437,8 +394,6 @@ func (moduleStruct) getStats(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// LoadDev registers all development-related command handlers with the dispatcher.
-// Sets up admin commands for bot management, user management, and statistics.
 func LoadDev(dispatcher *ext.Dispatcher) {
 	dispatcher.AddHandler(handlers.NewCommand("stats", devsModule.getStats))
 	dispatcher.AddHandler(handlers.NewCommand("addsudo", devsModule.addSudo))

--- a/alita/modules/misc.go
+++ b/alita/modules/misc.go
@@ -31,7 +31,6 @@ import (
 
 var (
 	miscModule = moduleStruct{moduleName: "Misc"}
-	// HTTP client with timeout and connection pooling for external requests
 	httpClient = &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
@@ -67,8 +66,6 @@ func parseTranslateResponse(body []byte) (detectedLang, translatedText string, e
 	return detectedLang, translatedText, nil
 }
 
-// echomsg handles the /tell command to make the bot echo a message
-// as a reply to another message, requiring admin permissions.
 func (moduleStruct) echomsg(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	args := ctx.Args()[1:]
@@ -90,8 +87,6 @@ func (moduleStruct) echomsg(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	if len(args) > 0 {
-		// Send the echo first; only delete the command on success so a failed
-		// send does not destroy the admin's command with no content echoed.
 		echoText := strings.Join(strings.Split(msg.OriginalHTML(), " ")[1:], " ")
 		_, err := msg.Reply(b,
 			echoText,
@@ -104,7 +99,6 @@ func (moduleStruct) echomsg(b *gotgbot.Bot, ctx *ext.Context) error {
 		)
 		if err != nil {
 			log.Error(err)
-			// Leave the command message in place so the admin can see the echo failed.
 			return ext.EndGroups
 		}
 		if _, derr := msg.Delete(b, nil); derr != nil {
@@ -119,8 +113,6 @@ func (moduleStruct) echomsg(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// getId handles the /id command to display IDs of users, chats,
-// files, and forwarded messages with detailed information.
 func (moduleStruct) getId(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	userId := extraction.ExtractUser(b, ctx)
@@ -128,9 +120,8 @@ func (moduleStruct) getId(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 	var builder strings.Builder
-	builder.Grow(512) // Pre-allocate capacity for better performance
+	builder.Grow(512)
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "id") {
 		return ext.EndGroups
 	}
@@ -230,18 +221,15 @@ func (moduleStruct) getId(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// ping handles the /ping command to measure bot-to-Telegram API round-trip time
 func (moduleStruct) ping(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 
-	// Check if command is disabled
 	if chat_status.CheckDisabledCmd(b, msg, "ping") {
 		return ext.EndGroups
 	}
 
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Step 1: Measure sendMessage RTT (includes Telegram message processing)
 	pingingText, _ := tr.GetString("misc_pinging")
 	sendStart := time.Now()
 	sentMsg, err := msg.Reply(b, pingingText, &gotgbot.SendMessageOpts{
@@ -253,7 +241,6 @@ func (moduleStruct) ping(b *gotgbot.Bot, ctx *ext.Context) error {
 		return err
 	}
 
-	// Step 2: Measure getMe RTT (lightweight call, baseline network latency)
 	getMeStart := time.Now()
 	_, getMeErr := b.GetMe(nil)
 	getMeLatency := time.Since(getMeStart)
@@ -261,7 +248,6 @@ func (moduleStruct) ping(b *gotgbot.Bot, ctx *ext.Context) error {
 		log.WithError(getMeErr).Error("[Ping] Failed to call getMe")
 	}
 
-	// Step 3: Edit with detailed breakdown
 	text := fmt.Sprintf(
 		"🏓 <b>Pong!</b>\n\n"+
 			"<b>API RTT</b> (getMe): <code>%dms</code>\n"+
@@ -290,8 +276,6 @@ func (moduleStruct) ping(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// info handles the /info command to display detailed information
-// about a user or channel including ID, name, and special roles.
 func (moduleStruct) info(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	sender := ctx.EffectiveSender
@@ -300,14 +284,12 @@ func (moduleStruct) info(b *gotgbot.Bot, ctx *ext.Context) error {
 	case -1:
 		return ext.EndGroups
 	case 0:
-		// 0 id is for self
 		if sender == nil {
 			return ext.EndGroups
 		}
 		userId = sender.Id()
 	}
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "info") {
 		return ext.EndGroups
 	}
@@ -326,7 +308,6 @@ func (moduleStruct) info(b *gotgbot.Bot, ctx *ext.Context) error {
 			FirstName: name,
 		}
 
-		// If channel then this info
 		if chat_status.IsChannelId(userId) {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 			textTemplate, _ := tr.GetString("misc_channel_info_header")
@@ -368,13 +349,10 @@ func (moduleStruct) info(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// translate handles the /tr command to translate text using
-// Google Translate API with automatic language detection.
 func (moduleStruct) translate(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	args := ctx.Args()[1:]
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "tr") {
 		return ext.EndGroups
 	}
@@ -412,14 +390,12 @@ func (moduleStruct) translate(b *gotgbot.Bot, ctx *ext.Context) error {
 			toLang = args[0]
 		}
 	} else {
-		// args[1:] leaves the language code and takes rest of the text
 		if len(args[1:]) < 1 {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 			text, _ := tr.GetString("misc_provide_text_translate")
 			_, _ = msg.Reply(b, text, formatting.Shtml())
 			return ext.EndGroups
 		}
-		// args[0] is the language code
 		toLang = args[0]
 		origText = strings.Join(args[1:], " ")
 	}
@@ -436,7 +412,6 @@ func (moduleStruct) translate(b *gotgbot.Bot, ctx *ext.Context) error {
 			log.Error(err)
 		}
 	}(req.Body)
-	// Limit response size to 1MB to prevent memory exhaustion from malicious responses
 	all, err := io.ReadAll(io.LimitReader(req.Body, 1*1024*1024))
 	if err != nil {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -462,8 +437,6 @@ func (moduleStruct) translate(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// removeBotKeyboard handles the /removebotkeyboard command to
-// remove stuck bot keyboards from the chat interface.
 func (moduleStruct) removeBotKeyboard(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -489,8 +462,6 @@ func (moduleStruct) removeBotKeyboard(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// stat handles the /stat command to display the total number
-// of messages in the current group chat.
 func (moduleStruct) stat(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -498,7 +469,6 @@ func (moduleStruct) stat(b *gotgbot.Bot, ctx *ext.Context) error {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
 	}
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "stat") {
 		return ext.EndGroups
 	}
@@ -512,8 +482,6 @@ func (moduleStruct) stat(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadMisc registers all miscellaneous module handlers with the dispatcher,
-// including utility commands for IDs, ping, translation, and stats.
 func LoadMisc(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[miscModule.moduleName] = true
 

--- a/alita/modules/mute.go
+++ b/alita/modules/mute.go
@@ -16,14 +16,10 @@ import (
 
 var mutesModule = moduleStruct{moduleName: "Mutes"}
 
-// muteTargetValidation validates the target for mute commands.
-// Checks: user is in chat, not ban-protected, not the bot itself.
 func muteTargetValidation(c *moderationCtx, t *target) error {
 	return validateTarget(c, t.userID, true, "common_user_not_in_chat", "mutes_mute_admin_error", "mutes_restrict_self_error")
 }
 
-// muteReplyWithButton builds and sends the success reply for mute commands
-// with an inline unmute button.
 func muteReplyWithButton(c *moderationCtx, t *target) error {
 	muteUser, err := c.Bot.GetChat(t.userID, nil)
 	if err != nil {
@@ -60,8 +56,6 @@ func muteReplyWithButton(c *moderationCtx, t *target) error {
 	return nil
 }
 
-// extractUserOnly resolves the target from command arguments using ExtractUser.
-// It rejects channel IDs and validates the user ID.
 func extractUserOnly(c *moderationCtx) (target, error) {
 	uid := extraction.ExtractUser(c.Bot, c.Ctx)
 	if uid == -1 {
@@ -89,7 +83,6 @@ func extractUserOnly(c *moderationCtx) (target, error) {
 	return target{userID: uid}, nil
 }
 
-// moderationTmute is the shared moderationCommand definition for /tmute.
 func moderationTmute(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -131,7 +124,6 @@ func moderationTmute(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationMute is the shared moderationCommand definition for /mute.
 func moderationMute(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -147,7 +139,6 @@ func moderationMute(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationSmute is the shared moderationCommand definition for /smute.
 func moderationSmute(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:   m,
@@ -166,7 +157,6 @@ func moderationSmute(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationDmute is the shared moderationCommand definition for /dmute.
 func moderationDmute(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:  m,
@@ -201,7 +191,6 @@ func moderationDmute(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// moderationUnmute is the shared moderationCommand definition for /unmute.
 func moderationUnmute(m *moduleStruct) *moderationCommand {
 	return &moderationCommand{
 		module:  m,
@@ -263,38 +252,26 @@ func moderationUnmute(m *moduleStruct) *moderationCommand {
 	}
 }
 
-// tMute handles the /tmute command to temporarily mute a user
-// with a specified time duration, requiring admin permissions.
 func (m moduleStruct) tMute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationTmute(&m).run(b, ctx)
 }
 
-// mute handles the /mute command to permanently mute a user
-// from the group, requiring admin permissions.
 func (m moduleStruct) mute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationMute(&m).run(b, ctx)
 }
 
-// sMute handles the /smute command to silently mute a user
-// and delete the command message, requiring admin permissions.
 func (m moduleStruct) sMute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationSmute(&m).run(b, ctx)
 }
 
-// dMute handles the /dmute command to mute a user and delete
-// the replied message, requiring admin permissions.
 func (m moduleStruct) dMute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationDmute(&m).run(b, ctx)
 }
 
-// unmute handles the /unmute command to restore chat permissions
-// to a previously muted user, requiring admin permissions.
 func (m moduleStruct) unmute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationUnmute(&m).run(b, ctx)
 }
 
-// LoadMutes registers all mute module handlers with the dispatcher,
-// including various mute commands and their variants.
 func LoadMutes(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[mutesModule.moduleName] = true
 

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -36,8 +36,6 @@ type pinType struct {
 	DataType int
 }
 
-// checkPinned monitors channel messages and handles them according to
-// AntiChannelPin and CleanLinked settings - either unpinning or deleting.
 func (moduleStruct) checkPinned(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
@@ -63,8 +61,6 @@ func (moduleStruct) checkPinned(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// unpin handles the /unpin command to unpin messages, either the latest
-// pinned message or a specific replied message, requiring admin permissions.
 func (moduleStruct) unpin(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -113,8 +109,6 @@ func (moduleStruct) unpin(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// unpinallCallback processes callback queries for the unpin all confirmation
-// dialog, handling the user's yes/no response.
 func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -129,8 +123,6 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 		return answerInvalidCallback(b, ctx, query)
 	}
 
-	// Re-check permissions in callback to prevent non-admin users from executing
-	// an action from a forwarded/stale confirmation button.
 	if !chat_status.RequireGroup(b, ctx, chat) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -199,8 +191,6 @@ func (moduleStruct) unpinallCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// unpinAll handles the /unpinall command to unpin all messages in the chat
-// with a confirmation dialog, requiring admin permissions.
 func (moduleStruct) unpinAll(c *helpers.CommandContext) error {
 	text, _ := c.Tr.GetString("pins_unpin_all_confirm")
 	yesText, _ := c.Tr.GetString("button_yes")
@@ -224,14 +214,11 @@ func (moduleStruct) unpinAll(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// permaPin handles the /permapin command to create and pin a new message
-// with custom content and buttons, requiring admin permissions.
 func (m moduleStruct) permaPin(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
 	args := c.Ctx.Args()
 
-	// if command is empty (i.e. Without Arguments) not replied to a message, return and end group
 	if len(args) == 1 && msg.ReplyToMessage == nil {
 		text, _ := c.Tr.GetString("pins_permapin_reply_or_text")
 		_, err := msg.Reply(c.Bot, text, formatting.Shtml())
@@ -308,8 +295,6 @@ func (m moduleStruct) permaPin(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// pin handles the /pin command to pin a replied message with options
-// for silent or loud pinning, requiring admin permissions.
 func (moduleStruct) pin(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -360,13 +345,9 @@ func (moduleStruct) pin(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// antichannelpin handles the /antichannelpin command to toggle automatic
-// unpinning of channel-pinned messages, requiring admin permissions.
-//
 //nolint:dupl // antichannelpin has symmetric logic with cleanlinked
 func (moduleStruct) antichannelpin(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -440,13 +421,9 @@ func (moduleStruct) antichannelpin(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// cleanlinked handles the /cleanlinked command to toggle automatic
-// deletion of linked channel messages, requiring admin permissions.
-//
 //nolint:dupl // cleanlinked has symmetric logic with antichannelpin
 func (moduleStruct) cleanlinked(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -520,8 +497,6 @@ func (moduleStruct) cleanlinked(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// pinned handles the /pinned command to display a link to the latest
-// pinned message in the chat with a convenient button.
 func (moduleStruct) pinned(c *helpers.CommandContext) error {
 	chat := c.Chat
 	msg := c.Msg
@@ -587,10 +562,8 @@ func (moduleStruct) pinned(c *helpers.CommandContext) error {
 	return ext.EndGroups
 }
 
-// GetPinType analyzes a message to determine its content type and extract
-// relevant data for pinning, including file IDs, text, and buttons.
 func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataType int, buttons []tgmd2html.ButtonV2) {
-	dataType = -1 // not defined datatype; invalid filter
+	dataType = -1
 	var (
 		rawText string
 		args    = strings.Split(msg.Text, " ")[1:]
@@ -603,7 +576,6 @@ func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataT
 			rawText = reply.OriginalMDV2()
 		}
 	} else {
-		// Extract text safely to prevent panic on malformed input
 		var parts []string
 		if msg.Text == "" {
 			parts = strings.SplitN(msg.OriginalCaptionMDV2(), " ", 2)
@@ -613,10 +585,8 @@ func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataT
 		if len(parts) >= 2 {
 			rawText = parts[1]
 		}
-		// If len(parts) < 2, rawText stays empty - handled by later validation
 	}
 
-	// get text and buttons
 	text, buttons = tgmd2html.MD2HTMLButtonsV2(rawText)
 
 	if len(args) >= 1 && msg.ReplyToMessage == nil {
@@ -634,7 +604,7 @@ func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataT
 			fileid = msg.ReplyToMessage.Animation.FileId
 			dataType = db.DOCUMENT
 		} else if len(msg.ReplyToMessage.Photo) > 0 {
-			fileid = msg.ReplyToMessage.Photo[len(msg.ReplyToMessage.Photo)-1].FileId // using -1 index to get best photo quality
+			fileid = msg.ReplyToMessage.Photo[len(msg.ReplyToMessage.Photo)-1].FileId
 			dataType = db.PHOTO
 		} else if msg.ReplyToMessage.Audio != nil {
 			fileid = msg.ReplyToMessage.Audio.FileId
@@ -672,7 +642,6 @@ func enforcePinChecks(c *helpers.CommandContext) bool {
 	return true
 }
 
-// anonymousAdmin wrappers for pins.go
 func (m moduleStruct) pinAnonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {
 	c, err := helpers.BuildCommandContext(b, ctx)
 	if err != nil {
@@ -772,8 +741,6 @@ var (
 	}
 )
 
-// LoadPin registers all pins module handlers with the dispatcher,
-// including pin management commands and channel message monitoring.
 func LoadPin(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[pinsModule.moduleName] = true
 
@@ -783,7 +750,6 @@ func LoadPin(dispatcher *ext.Dispatcher) {
 	helpers.WrapCommand(dispatcher, permaPinDesc, pinsModule.permaPin)
 	helpers.WrapCommand(dispatcher, pinnedDesc, pinsModule.pinned)
 
-	// antichannelpin and cleanlinked modify ctx.EffectiveChat so keep raw
 	dispatcher.AddHandler(handlers.NewCommand("antichannelpin", pinsModule.antichannelpin))
 	dispatcher.AddHandler(handlers.NewCommand("cleanlinked", pinsModule.cleanlinked))
 

--- a/alita/modules/purges.go
+++ b/alita/modules/purges.go
@@ -31,11 +31,9 @@ type delMsgEntry struct {
 
 var (
 	purgesModule = moduleStruct{moduleName: "Purges"}
-	delMsgs      = sync.Map{} // Concurrent-safe map for tracking messages to delete (value is delMsgEntry)
+	delMsgs      = sync.Map{}
 )
 
-// checkPurgePermissions verifies all permissions required for purge/delete commands.
-// Returns the user and true if all checks pass, nil and false otherwise (response already sent).
 func checkPurgePermissions(bot *gotgbot.Bot, ctx *ext.Context) (*gotgbot.User, bool) {
 	user := chat_status.RequireUser(bot, ctx)
 	if user == nil {
@@ -65,17 +63,13 @@ func checkPurgePermissions(bot *gotgbot.Bot, ctx *ext.Context) (*gotgbot.User, b
 	return user, true
 }
 
-// PurgeWorker collects errors from concurrent message deletion.
 type PurgeWorker struct {
-	errors     []error // Collect errors
-	errorCount int     // Count of errors
+	errors     []error
+	errorCount int
 	mu         sync.Mutex
 }
 
-// purgeMsgsConcurrent performs concurrent message deletion with rate limiting.
-// Uses a fixed worker pool to avoid spawning up to 1000 goroutines.
 func (moduleStruct) purgeMsgsConcurrent(bot *gotgbot.Bot, chat *gotgbot.Chat, pFrom bool, msgId, deleteTo int64) bool {
-	// Handle the starting message if not pFrom
 	if !pFrom {
 		_, err := bot.DeleteMessage(chat.Id, msgId, nil)
 		if err != nil {
@@ -101,19 +95,16 @@ func (moduleStruct) purgeMsgsConcurrent(bot *gotgbot.Bot, chat *gotgbot.Chat, pF
 		}
 	}
 
-	// When !pFrom, msgId was already deleted above; skip it in the loop.
 	loopFrom := msgId
 	if !pFrom {
 		loopFrom = msgId + 1
 	}
 
-	// Calculate total messages to delete
 	totalMessages := deleteTo - loopFrom + 1
 	if totalMessages <= 0 {
 		return true
 	}
 
-	// For small ranges, use sequential deletion
 	if totalMessages <= 10 {
 		for mId := deleteTo; mId >= loopFrom; mId-- {
 			_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, mId)
@@ -121,7 +112,6 @@ func (moduleStruct) purgeMsgsConcurrent(bot *gotgbot.Bot, chat *gotgbot.Chat, pF
 		return true
 	}
 
-	// For larger ranges, use fixed worker pool
 	const maxConcurrentMsgDeletions = 10
 	worker := &PurgeWorker{
 		errors: make([]error, 0),
@@ -152,7 +142,6 @@ func (moduleStruct) purgeMsgsConcurrent(bot *gotgbot.Bot, chat *gotgbot.Chat, pF
 	}
 	wg.Wait()
 
-	// Log errors if any (excluding "not found" errors)
 	if len(worker.errors) > 0 {
 		log.WithFields(log.Fields{
 			"chat_id":       chat.Id,
@@ -164,15 +153,10 @@ func (moduleStruct) purgeMsgsConcurrent(bot *gotgbot.Bot, chat *gotgbot.Chat, pF
 	return true
 }
 
-// purgeMsgs performs the actual message deletion operation for purge commands,
-// deleting messages in the specified range with error handling for old messages.
-// This is a wrapper that calls the concurrent version for better performance.
 func (moduleStruct) purgeMsgs(bot *gotgbot.Bot, chat *gotgbot.Chat, pFrom bool, msgId, deleteTo int64) bool {
 	return purgesModule.purgeMsgsConcurrent(bot, chat, pFrom, msgId, deleteTo)
 }
 
-// purge handles the /purge command to delete all messages from a replied
-// message up to the command message, requiring admin permissions.
 func (m moduleStruct) purge(bot *gotgbot.Bot, ctx *ext.Context) error {
 	if _, ok := checkPurgePermissions(bot, ctx); !ok {
 		return ext.EndGroups
@@ -185,9 +169,8 @@ func (m moduleStruct) purge(bot *gotgbot.Bot, ctx *ext.Context) error {
 	if msg.ReplyToMessage != nil {
 		msgId := msg.ReplyToMessage.MessageId
 		deleteTo := msg.MessageId - 1
-		totalMsgs := deleteTo - msgId + 1 // adding 1 because we want to delete the message we are replying to
+		totalMsgs := deleteTo - msgId + 1
 
-		// Limit purge range to prevent abuse and API overload
 		const maxPurgeMessages = 1000
 		if totalMsgs > maxPurgeMessages {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -216,7 +199,6 @@ func (m moduleStruct) purge(bot *gotgbot.Bot, ctx *ext.Context) error {
 			if err != nil {
 				log.Error(err)
 			} else {
-				// Delete notification message after 3 seconds in background
 				go func(msgToDelete *gotgbot.Message) {
 					defer error_handling.RecoverFromPanic("purgeNotifyDelete", "purges")
 					time.Sleep(3 * time.Second)
@@ -237,8 +219,6 @@ func (m moduleStruct) purge(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// delCmd handles the /del command to delete a specific replied message
-// along with the command message, requiring admin permissions.
 func (moduleStruct) delCmd(bot *gotgbot.Bot, ctx *ext.Context) error {
 	if _, ok := checkPurgePermissions(bot, ctx); !ok {
 		return ext.EndGroups
@@ -265,8 +245,6 @@ func (moduleStruct) delCmd(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// deleteButtonHandler processes callback queries from delete buttons
-// to remove specific messages, requiring admin permissions.
 func (moduleStruct) deleteButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -297,7 +275,6 @@ func (moduleStruct) deleteButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 		return ext.EndGroups
 	}
 
-	// Parse message ID from callback data
 	msgId, err := strconv.ParseInt(msgIDRaw, 10, 64)
 	if err != nil {
 		log.Warnf("[Purges] Invalid message ID in callback: %s", msgIDRaw)
@@ -306,7 +283,6 @@ func (moduleStruct) deleteButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 		return ext.EndGroups
 	}
 
-	// permissions check
 	if !chat_status.CanUserDelete(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_delete_cmd_error", "chat_status_delete_button_error", chat_status.WithReply())
 		return ext.EndGroups
@@ -329,8 +305,6 @@ func (moduleStruct) deleteButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 	return ext.EndGroups
 }
 
-// purgeFrom handles the /purgefrom command to mark a starting message
-// for range deletion, requiring admin permissions.
 func (moduleStruct) purgeFrom(bot *gotgbot.Bot, ctx *ext.Context) error {
 	user, ok := checkPurgePermissions(bot, ctx)
 	if !ok {
@@ -349,7 +323,6 @@ func (moduleStruct) purgeFrom(bot *gotgbot.Bot, ctx *ext.Context) error {
 				_, _ = msg.Reply(bot, text, nil)
 				return ext.EndGroups
 			}
-			// Reject overwrite — inform user to use purgefrom again or clear
 			if existing != nil {
 				tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 				text, _ := tr.GetString("purges_message_marked")
@@ -377,11 +350,9 @@ func (moduleStruct) purgeFrom(bot *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		delMsgs.Store(chat.Id, delMsgEntry{userID: user.Id, timestamp: time.Now(), msgID: TodelId})
 
-		// Run cleanup in background goroutine to avoid blocking the handler
 		go func(chatId, toDelId int64, msgToDelete *gotgbot.Message) {
 			defer error_handling.RecoverFromPanic("purgeFromCleanup", "purges")
 			time.Sleep(30 * time.Second)
-			// Only clean up if the stored ID is still the same (not overwritten by another purgefrom)
 			if existingId, ok := delMsgs.Load(chatId); ok {
 				if entry, ok := existingId.(delMsgEntry); ok && entry.msgID == toDelId {
 					delMsgs.Delete(chatId)
@@ -407,8 +378,6 @@ func (moduleStruct) purgeFrom(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// purgeTo handles the /purgeto command to complete range deletion
-// from a previously marked message, requiring admin permissions.
 func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 	if _, ok := checkPurgePermissions(bot, ctx); !ok {
 		return ext.EndGroups
@@ -449,15 +418,12 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 			}
 			return ext.EndGroups
 		}
-		// Ensure msgId is the lower bound and deleteTo is the upper bound
-		// This normalizes the range regardless of which message was marked first
 		startId, endId := msgId, deleteTo
 		if deleteTo < msgId {
 			startId, endId = deleteTo, msgId
 		}
 		totalMsgs := endId - startId + 1
 
-		// Enforce same limit as /purge command to prevent abuse
 		const maxPurgeMessages = 1000
 		if totalMsgs > maxPurgeMessages {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -469,7 +435,6 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 			return ext.EndGroups
 		}
 
-		// Clear the stored purgefrom marker since we're using it now
 		delMsgs.Delete(chat.Id)
 
 		purge := m.purgeMsgs(bot, chat, true, startId, endId)
@@ -490,7 +455,6 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 			if err != nil {
 				log.Error(err)
 			} else {
-				// Delete notification message after 3 seconds in background
 				go func(msgToDelete *gotgbot.Message) {
 					defer error_handling.RecoverFromPanic("purgeNotifyDelete", "purges")
 					time.Sleep(3 * time.Second)
@@ -510,8 +474,6 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadPurges registers all purges module handlers with the dispatcher,
-// including message deletion commands and callback handlers.
 func LoadPurges(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[purgesModule.moduleName] = true
 

--- a/alita/modules/reports.go
+++ b/alita/modules/reports.go
@@ -28,12 +28,8 @@ var reportsModule = moduleStruct{
 	handlerGroup: 8,
 }
 
-// adminMentionRegex matches @admin and @admins mentions in messages.
-// Pre-compiled once at init time to avoid per-message compilation overhead.
 var adminMentionRegex = regexp.MustCompile(`(?i)(^|\s)@admins?(\s|$)`)
 
-// report handles the /report command and @admin mentions to notify
-// administrators about problematic messages with action buttons.
 func (moduleStruct) report(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	sender := ctx.EffectiveSender
@@ -43,7 +39,6 @@ func (moduleStruct) report(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := sender.User
 	msg := ctx.EffectiveMessage
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "report") {
 		return ext.EndGroups
 	}
@@ -55,7 +50,6 @@ func (moduleStruct) report(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if From is nil (channel posts, deleted users)
 	if msg.ReplyToMessage.From == nil {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("reports_cannot_report_channel")
@@ -83,7 +77,6 @@ func (moduleStruct) report(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	reportprefs := reports.GetChatReportSettings(chat.Id)
 
-	// don't let blocked users report
 	if slices.Contains(reportprefs.BlockedList, user.Id) {
 		if chat_status.CanBotDelete(b, ctx, nil) {
 			_, err := msg.Delete(b, nil)
@@ -259,12 +252,8 @@ func (moduleStruct) report(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// reports handles the /reports command to manage reporting settings
-// for both users and chats, including blocking and status changes.
-//
 //nolint:dupl // reports has symmetric block/unblock logic
 func (moduleStruct) reports(b *gotgbot.Bot, ctx *ext.Context) error {
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -336,7 +325,6 @@ func (moduleStruct) reports(b *gotgbot.Bot, ctx *ext.Context) error {
 				replyText, _ = tr.GetString("reports_group_only")
 			} else {
 				if reply := msg.ReplyToMessage; reply != nil {
-					// Check if From is nil (channel posts, deleted users, etc.)
 					if reply.From == nil {
 						replyText, _ = tr.GetString("reports_cannot_report_channel")
 					} else {
@@ -360,7 +348,6 @@ func (moduleStruct) reports(b *gotgbot.Bot, ctx *ext.Context) error {
 				replyText, _ = tr.GetString("reports_group_only")
 			} else {
 				if reply := msg.ReplyToMessage; reply != nil {
-					// Check if From is nil (channel posts, deleted users, etc.)
 					if reply.From == nil {
 						replyText, _ = tr.GetString("reports_cannot_report_channel")
 					} else {
@@ -388,7 +375,7 @@ func (moduleStruct) reports(b *gotgbot.Bot, ctx *ext.Context) error {
 					replyText, _ = tr.GetString("reports_no_blocked_users")
 				} else {
 					var builder strings.Builder
-					builder.Grow(256) // Pre-allocate capacity
+					builder.Grow(256)
 					headerText, _ := tr.GetString("reports_blocked_users_header")
 					builder.WriteString(headerText)
 					for _, blockUserId := range blockedUsers {
@@ -436,8 +423,6 @@ func (moduleStruct) reports(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// markResolvedButtonHandler processes callback queries from report action buttons
-// to kick, ban, delete messages, or mark reports as resolved.
 func (moduleStruct) markResolvedButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -455,7 +440,6 @@ func (moduleStruct) markResolvedButtonHandler(b *gotgbot.Bot, ctx *ext.Context) 
 	}
 	var replyQuery, replyText string
 
-	// permissions check
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -571,8 +555,6 @@ func (moduleStruct) markResolvedButtonHandler(b *gotgbot.Bot, ctx *ext.Context) 
 	return ext.EndGroups
 }
 
-// LoadReports registers all reports module handlers with the dispatcher,
-// including report commands and @admin mention monitoring.
 func LoadReports(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[reportsModule.moduleName] = true
 

--- a/alita/modules/users.go
+++ b/alita/modules/users.go
@@ -21,7 +21,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
 )
 
-// asyncUpdateUser wraps user.UpdateUser for async execution with error logging.
 func asyncUpdateUser(userId int64, username, name string) {
 	if err := user.UpdateUser(userId, username, name); err != nil {
 		userUpdateCache.Delete(userId)
@@ -29,7 +28,6 @@ func asyncUpdateUser(userId int64, username, name string) {
 	}
 }
 
-// asyncUpdateChat wraps chats.UpdateChat for async execution with error logging.
 func asyncUpdateChat(chatId int64, chatname string, userid int64) {
 	if err := chats.UpdateChat(chatId, chatname, userid); err != nil {
 		chatUpdateCache.Delete([2]int64{chatId, userid})
@@ -37,7 +35,6 @@ func asyncUpdateChat(chatId int64, chatname string, userid int64) {
 	}
 }
 
-// asyncUpdateChannel wraps channels.UpdateChannel for async execution with error logging.
 func asyncUpdateChannel(channelId int64, channelName, username string) {
 	if err := channels.UpdateChannel(channelId, channelName, username); err != nil {
 		channelUpdateCache.Delete(channelId)
@@ -51,22 +48,17 @@ var (
 		handlerGroup: -1,
 	}
 
-	// Rate limiting for database updates
-	// Maps user/channel IDs or chat/user pairs to their last update timestamp.
 	userUpdateCache    = &sync.Map{}
 	chatUpdateCache    = &sync.Map{}
 	channelUpdateCache = &sync.Map{}
 	userUpdateGroup    singleflight.Group
 	chatUpdateGroup    singleflight.Group
 
-	// Update intervals
 	userUpdateInterval    = constants.UserUpdateInterval
 	chatUpdateInterval    = constants.ChatUpdateInterval
 	channelUpdateInterval = constants.ChannelUpdateInterval
 )
 
-// shouldUpdateKey checks if enough time has passed since the last update
-// for rate limiting database operations to prevent excessive writes.
 func shouldUpdateKey(cache *sync.Map, key any, interval time.Duration) bool {
 	now := time.Now()
 	for {
@@ -118,8 +110,6 @@ func updateCurrentChat(chatID int64, chatName string, userID int64) {
 	})
 }
 
-// logUsers handles automatic user and chat tracking by updating
-// database records with rate limiting for all message events.
 func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -128,10 +118,8 @@ func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 
 	if user != nil {
 		if user.IsAnonymousChannel() {
-			// Only update if enough time has passed
 			if shouldUpdate(channelUpdateCache, user.Id(), channelUpdateInterval) {
 				log.Debugf("Updating channel %d in db", user.Id())
-				// update when users send a message
 				go asyncUpdateChannel(
 					user.Id(),
 					user.Name(),
@@ -139,19 +127,14 @@ func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 				)
 			}
 		} else {
-			// Don't add user to chat entry
 			if chat_status.RequireGroup(bot, ctx, chat) {
-				// The group -1 tracker must create the parent synchronously before
-				// later handlers write tables with chat foreign keys.
 				updateCurrentChat(chat.Id, chat.Title, user.Id())
 			}
 
-			// The same ordering protects user foreign keys on first-ever commands.
 			updateCurrentUser(user.Id(), user.Username(), user.Name())
 		}
 	}
 
-	// update if message is replied
 	if repliedMsg != nil {
 		replySender := repliedMsg.GetSender()
 		if replySender != nil {
@@ -177,7 +160,6 @@ func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	// update if message is forwarded
 	if msg.ForwardOrigin != nil {
 		forwarded := msg.ForwardOrigin.MergeMessageOrigin()
 		if forwarded.Chat != nil && forwarded.Chat.Type != "group" {
@@ -189,7 +171,6 @@ func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 				)
 			}
 		} else if forwarded.SenderUser != nil {
-			// if chat type is not group
 			if shouldUpdate(userUpdateCache, forwarded.SenderUser.Id, userUpdateInterval) {
 				go asyncUpdateUser(
 					forwarded.SenderUser.Id,
@@ -206,8 +187,6 @@ func (moduleStruct) logUsers(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// LoadUsers registers the user logging handler with the dispatcher
-// to automatically track users and chats across all messages.
 func LoadUsers(dispatcher *ext.Dispatcher) {
 	dispatcher.AddHandlerToGroup(handlers.NewMessage(message.All, usersModule.logUsers), usersModule.handlerGroup)
 }

--- a/alita/modules/warns.go
+++ b/alita/modules/warns.go
@@ -25,11 +25,8 @@ import (
 
 var warnsModule = moduleStruct{moduleName: "Warns"}
 
-// setWarnMode handles the /setwarnmode command to configure the action
-// taken when users reach the warning limit (ban, kick, or mute).
 func (moduleStruct) setWarnMode(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -43,7 +40,6 @@ func (moduleStruct) setWarnMode(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// permissions check
 	if !chat_status.RequireBotAdmin(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_bot_not_admin", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -86,8 +82,6 @@ func (moduleStruct) setWarnMode(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// warnThisUser is a helper function that performs the actual warning process,
-// including limit checking and enforcement of warn mode actions.
 func (moduleStruct) warnThisUser(b *gotgbot.Bot, ctx *ext.Context, userId int64, reason, warnType string) (err error) {
 	var (
 		reply    string
@@ -98,11 +92,9 @@ func (moduleStruct) warnThisUser(b *gotgbot.Bot, ctx *ext.Context, userId int64,
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Get translated button texts
 	removeWarnText, _ := tr.GetString("warns_remove_button")
 	rulesButtonText, _ := tr.GetString("common_rules_button_emoji")
 
-	// permissions check
 	if chat_status.IsUserAdmin(b, chat.Id, userId) {
 		text, _ := tr.GetString("warns_admin_warning_error")
 		_, err = msg.Reply(b, text, nil)
@@ -244,9 +236,6 @@ func (moduleStruct) warnThisUser(b *gotgbot.Bot, ctx *ext.Context, userId int64,
 	return ext.EndGroups
 }
 
-// dispatchWarn runs the standard moderation gate check then dispatches a warn
-// action of the given warnType ("warn", "swarn", or "dwarn").
-// Extracted from the three formerly-identical warnUser/sWarnUser/dWarnUser bodies.
 func (m moduleStruct) dispatchWarn(b *gotgbot.Bot, ctx *ext.Context, warnType string) error {
 	mc, err := buildModerationCtx(&warnsModule, b, ctx)
 	if err != nil {
@@ -294,26 +283,18 @@ func (m moduleStruct) dispatchWarn(b *gotgbot.Bot, ctx *ext.Context, warnType st
 	return m.warnThisUser(b, ctx, warnusr, reason, warnType)
 }
 
-// warnUser handles the /warn command to issue warnings to users
-// with optional reasons, requiring admin permissions.
 func (m moduleStruct) warnUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.dispatchWarn(b, ctx, "warn")
 }
 
-// sWarnUser handles the /swarn command to silently warn users
-// by deleting the command message, requiring admin permissions.
 func (m moduleStruct) sWarnUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.dispatchWarn(b, ctx, "swarn")
 }
 
-// dWarnUser handles the /dwarn command to warn users and delete
-// the message they replied to, requiring admin permissions.
 func (m moduleStruct) dWarnUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.dispatchWarn(b, ctx, "dwarn")
 }
 
-// warnings handles the /warnings command to display current
-// warning settings including limit and enforcement mode.
 func (moduleStruct) warnings(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
@@ -323,7 +304,6 @@ func (moduleStruct) warnings(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check permissions
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -348,14 +328,11 @@ func (moduleStruct) warnings(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// warns handles the /warns command to check the warning count
-// and reasons for a specific user or the command sender.
 func (moduleStruct) warns(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "warns") {
 		return ext.EndGroups
 	}
@@ -430,8 +407,6 @@ func (moduleStruct) warns(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// rmWarnButton processes callback queries from remove warning buttons
-// to remove the latest warning from a user, requiring admin permissions.
 func (moduleStruct) rmWarnButton(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -444,7 +419,6 @@ func (moduleStruct) rmWarnButton(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check permissions
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -499,11 +473,8 @@ func (moduleStruct) rmWarnButton(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// setWarnLimit handles the /setwarnlimit command to configure
-// the maximum number of warnings before enforcement action.
 func (moduleStruct) setWarnLimit(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -517,7 +488,6 @@ func (moduleStruct) setWarnLimit(b *gotgbot.Bot, ctx *ext.Context) error {
 	args := ctx.Args()[1:]
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check permissions
 	if !chat_status.RequireBotAdmin(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_bot_not_admin", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -561,8 +531,6 @@ func (moduleStruct) setWarnLimit(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetWarns handles the /resetwarns command to clear all warnings
-// for a specific user, requiring admin permissions.
 func (moduleStruct) resetWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -572,7 +540,6 @@ func (moduleStruct) resetWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check permissions
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -625,8 +592,6 @@ func (moduleStruct) resetWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetAllWarns handles the /resetallwarns command to clear all warnings
-// for all users in the chat with confirmation, restricted to owners.
 func (moduleStruct) resetAllWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -636,11 +601,9 @@ func (moduleStruct) resetAllWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Get translated button texts
 	yesText, _ := tr.GetString("common_yes")
 	noText, _ := tr.GetString("common_no")
 
-	// Check if group or not
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -686,8 +649,6 @@ func (moduleStruct) resetAllWarns(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// warnsButtonHandler processes callback queries for the reset all warnings
-// confirmation dialog, restricted to chat owners.
 func (moduleStruct) warnsButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -759,8 +720,6 @@ func (moduleStruct) warnsButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// removeWarn handles /rmwarn and /unwarn commands to remove the latest warning
-// from a specific user. Requires bot and user admin permissions.
 func (moduleStruct) removeWarn(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -770,7 +729,6 @@ func (moduleStruct) removeWarn(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check permissions
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -824,18 +782,14 @@ func (moduleStruct) removeWarn(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadWarns registers all warns module handlers with the dispatcher,
-// including warning commands and callback handlers.
 func LoadWarns(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[warnsModule.moduleName] = true
 
 	dispatcher.AddHandler(handlers.NewCommand("warn", warnsModule.warnUser))
 	dispatcher.AddHandler(handlers.NewCommand("swarn", warnsModule.sWarnUser))
 	dispatcher.AddHandler(handlers.NewCommand("dwarn", warnsModule.dWarnUser))
-	// Aliases for reset warnings (docs mention /resetwarn as well)
 	dispatcher.AddHandler(handlers.NewCommand("resetwarns", warnsModule.resetWarns))
 	dispatcher.AddHandler(handlers.NewCommand("resetwarn", warnsModule.resetWarns))
-	// Add commands to remove latest warn for a user
 	dispatcher.AddHandler(handlers.NewCommand("rmwarn", warnsModule.removeWarn))
 	dispatcher.AddHandler(handlers.NewCommand("unwarn", warnsModule.removeWarn))
 	dispatcher.AddHandler(handlers.NewCommand("warns", warnsModule.warns))


### PR DESCRIPTION
Comment-only split of #830 (whose diff exceeded GitHub's 20k-line API limit for the lint action). No code, string, or test-name changes. Kept: go:build/embed, pedantic nolint/nosec, external-constraint notes, public-API contracts, test concurrency contracts.