### PR TITLE
chore: strip restatement comments in captcha/greetings/abuse modules

### DIFF
--- a/alita/modules/antiflood.go
+++ b/alita/modules/antiflood.go
@@ -26,23 +26,19 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
-// Concurrency limits for flood protection operations
 const (
-	maxConcurrentAdminChecks  = 50 // Maximum concurrent admin permission checks
-	maxConcurrentMsgDeletions = 5  // Maximum concurrent message deletions during flood cleanup
+	maxConcurrentAdminChecks  = 50
+	maxConcurrentMsgDeletions = 5
 )
 
-// floodKey is a type-safe composite key for flood tracking
-// Uses struct instead of string concatenation to avoid collisions
 type floodKey struct {
 	chatId int64
 	userId int64
 }
 
 type antifloodStruct struct {
-	moduleStruct  // inheritance
-	syncHelperMap sync.Map
-	// Add semaphore to limit concurrent admin checks
+	moduleStruct
+	syncHelperMap       sync.Map
 	adminCheckSemaphore chan struct{}
 }
 
@@ -50,10 +46,9 @@ type floodControl struct {
 	userId       int64
 	messageCount int
 	messageIDs   []int64
-	lastActivity int64 // Unix timestamp for cleanup
+	lastActivity int64
 }
 
-// floodMu stores per-key *sync.Mutex values to protect the RMW cycle in updateFlood.
 var floodMu sync.Map
 
 var _normalAntifloodModule = moduleStruct{
@@ -67,7 +62,6 @@ var antifloodModule = antifloodStruct{
 	adminCheckSemaphore: make(chan struct{}, maxConcurrentAdminChecks),
 }
 
-// init starts cleanup goroutine for antiflood cache
 func init() {
 	RegisterLegacyModule("Antiflood", 150, LoadAntiflood)
 	go func() {
@@ -76,31 +70,23 @@ func init() {
 	}()
 }
 
-// cleanupOnce performs a single cleanup pass, removing entries idle for more
-// than 600 seconds (10 minutes) from syncHelperMap and floodMu.
-// It is called by cleanupLoop on each ticker tick and is also directly
-// callable in tests for deterministic verification.
 func (a *antifloodStruct) cleanupOnce(now int64) {
 	a.syncHelperMap.Range(func(key, value any) bool {
 		floodData, ok := value.(floodControl)
 		if !ok || now-floodData.lastActivity <= 600 {
 			return true
 		}
-		// Acquire per-key mutex before deleting to avoid racing with updateFlood's RMW cycle.
-		// If the mutex is busy, skip this key and retry next tick.
 		if muVal, hasMu := floodMu.Load(key); hasMu {
 			if mu, ok := muVal.(*sync.Mutex); ok {
 				if !mu.TryLock() {
 					return true
 				}
-				// Re-validate after acquiring lock - entry may have been refreshed.
 				if cur, ok := a.syncHelperMap.Load(key); ok {
 					if curFC, ok := cur.(floodControl); ok && now-curFC.lastActivity <= 600 {
 						mu.Unlock()
 						return true
 					}
 				} else {
-					// Already deleted by concurrent writer
 					floodMu.Delete(key)
 					mu.Unlock()
 					return true
@@ -110,7 +96,6 @@ func (a *antifloodStruct) cleanupOnce(now int64) {
 				mu.Unlock()
 				return true
 			}
-			// Unexpected type - delete the entry
 			floodMu.Delete(key)
 		}
 		a.syncHelperMap.Delete(key)
@@ -118,9 +103,6 @@ func (a *antifloodStruct) cleanupOnce(now int64) {
 	})
 }
 
-// cleanupLoop periodically removes old flood control entries from memory.
-// Runs every 5 minutes to clean entries older than 10 minutes.
-// Accepts a context for graceful shutdown.
 func (a *antifloodStruct) cleanupLoop(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
@@ -139,8 +121,6 @@ func (a *antifloodStruct) cleanupLoop(ctx context.Context) {
 	}
 }
 
-// cachedAdminStatus reports whether a warm admin cache already knows this user.
-// known=false means the cache missed and the caller must ask Telegram.
 func cachedAdminStatus(chatId, userId int64) (known bool, isAdmin bool) {
 	ok, cached := cache.GetAdminCacheList(chatId)
 	if !ok || !cached.Cached {
@@ -158,11 +138,6 @@ func cachedAdminStatus(chatId, userId int64) (known bool, isAdmin bool) {
 	return true, false
 }
 
-// userIsFloodExempt is true when the sender should skip flood tracking.
-// A warm admin cache (including negative lookups) is trusted so non-admins do
-// not take a semaphore slot or spawn an IsUserAdmin goroutine per message.
-// Cache misses use a bounded Telegram check; timeout and a full semaphore
-// fail open. The semaphore is released before flood tracking or punishment.
 func (a *antifloodStruct) userIsFloodExempt(b *gotgbot.Bot, chatId, userId int64) bool {
 	if known, isAdmin := cachedAdminStatus(chatId, userId); known {
 		return isAdmin
@@ -207,20 +182,14 @@ func (a *antifloodStruct) adminCheckWithTimeout(b *gotgbot.Bot, chatId, userId i
 	}
 }
 
-// updateFlood tracks message counts per user and determines if flood limit exceeded.
-// Returns true if user has exceeded flood limit and should be restricted,
-// along with the flood control data and flood settings from the database.
-// This eliminates redundant database calls by fetching settings once.
 func (a *antifloodStruct) updateFlood(chatId, userId, msgId int64) (shouldPunish bool, floodCrc floodControl, floodSettings *db.AntifloodSettings) {
 	floodSettings = antiflood.GetFlood(chatId)
 
 	if floodSettings.Limit != 0 {
 		currentTime := time.Now().Unix()
 
-		// Use type-safe struct key instead of string concatenation
 		key := floodKey{chatId: chatId, userId: userId}
 
-		// Acquire per-key mutex to protect the Load → mutate → Store RMW cycle
 		muVal, _ := floodMu.LoadOrStore(key, &sync.Mutex{})
 		mu := muVal.(*sync.Mutex)
 		mu.Lock()
@@ -230,31 +199,23 @@ func (a *antifloodStruct) updateFlood(chatId, userId, msgId int64) (shouldPunish
 		if valExists && tmpInterface != nil {
 			floodCrc = tmpInterface.(floodControl)
 
-			// Clean up old entries (older than 1 minute)
 			if currentTime-floodCrc.lastActivity > 60 {
 				floodCrc = floodControl{}
 			}
 		}
 
-		// No need to check userId mismatch since key includes userId
 		if floodCrc.userId == 0 {
 			floodCrc.userId = userId
 			floodCrc.messageCount = 0
-			floodCrc.messageIDs = make([]int64, 0, floodSettings.Limit+5) // Pre-allocate with capacity
+			floodCrc.messageIDs = make([]int64, 0, floodSettings.Limit+5)
 		}
 
 		floodCrc.messageCount++
 		floodCrc.lastActivity = currentTime
 
-		// PERFORMANCE FIX: Append to end instead of prepending
-		// This avoids slice reallocation and copying on every message (O(1) amortized vs O(n))
 		floodCrc.messageIDs = append(floodCrc.messageIDs, msgId)
 
-		// Trim old messages if we exceed the limit
-		// Keep only the most recent messages within the flood window
 		if len(floodCrc.messageIDs) > floodSettings.Limit+5 {
-			// Slice from the end to keep recent messages
-			// This is O(1) operation since it just adjusts the slice header
 			floodCrc.messageIDs = floodCrc.messageIDs[len(floodCrc.messageIDs)-(floodSettings.Limit+5):]
 		}
 
@@ -276,8 +237,6 @@ func (a *antifloodStruct) updateFlood(chatId, userId, msgId int64) (shouldPunish
 	return
 }
 
-// checkFlood monitors incoming messages for flood violations.
-// Applies configured flood actions (mute/kick/ban) when limits are exceeded.
 func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := ctx.EffectiveSender
@@ -305,19 +264,15 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Check if user is approved (immune to anti-spam)
 	if chat_status.IsApproved(b, chatId, userId) {
 		return ext.ContinueGroups
 	}
 
-	// PERFORMANCE FIX: Update flood and get settings in one call to eliminate redundant DB query
-	// Previously this was calling antiflood.GetFlood again after updateFlood, doubling the DB load
 	flooded, floodCrc, flood := antifloodModule.updateFlood(chatId, userId, msg.MessageId)
 	if !flooded {
 		return ext.ContinueGroups
 	}
 
-	// No need to call antiflood.GetFlood again - we already have the settings from updateFlood
 	if flood.Action == "mute" || flood.Action == "kick" || flood.Action == "ban" {
 		if !chat_status.CanBotRestrict(b, ctx, chat) {
 			log.WithFields(log.Fields{
@@ -343,13 +298,11 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 
 		if len(floodCrc.messageIDs) <= 3 {
-			// Sequential deletion - continue on error
 			for _, i := range floodCrc.messageIDs {
 				err := helpers.DeleteMessageWithErrorHandling(b, chatId, i)
 				recordError(err, i)
 			}
 		} else {
-			// Concurrent deletion with rate limiting
 			sem := make(chan struct{}, maxConcurrentMsgDeletions)
 			var wg sync.WaitGroup
 
@@ -379,7 +332,6 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	switch flood.Action {
 	case "mute":
-		// don't work on anonymous channels
 		if user.IsAnonymousChannel() {
 			return ext.ContinueGroups
 		}
@@ -402,7 +354,6 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	case "kick":
-		// don't work on anonymous channels
 		if user.IsAnonymousChannel() {
 			return ext.ContinueGroups
 		}
@@ -456,11 +407,8 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// setFlood handles the /setflood command to configure flood detection limits.
-// Sets the maximum number of messages allowed before triggering flood protection.
 func (m *moduleStruct) setFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -513,17 +461,13 @@ func (m *moduleStruct) setFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// flood handles the /flood command to display current flood protection settings.
-// Shows the flood limit and action (mute/kick/ban) for the chat.
 func (m *moduleStruct) flood(b *gotgbot.Bot, ctx *ext.Context) error {
 	var text string
 	msg := ctx.EffectiveMessage
 
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "flood") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -556,11 +500,8 @@ func (m *moduleStruct) flood(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// setFloodMode handles the /setfloodmode command to configure flood protection actions.
-// Allows setting the punishment type (ban/kick/mute) for flood violations.
 func (m *moduleStruct) setFloodMode(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -602,11 +543,8 @@ func (m *moduleStruct) setFloodMode(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// setFloodDeleter handles the /delflood command to toggle message deletion on flood.
-// Configures whether to delete all flood messages or just the triggering message.
 func (m *moduleStruct) setFloodDeleter(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -655,8 +593,6 @@ func (m *moduleStruct) setFloodDeleter(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadAntiflood registers all antiflood module handlers with the dispatcher.
-// Sets up flood detection commands and message monitoring handlers.
 func LoadAntiflood(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[antifloodModule.moduleName] = true
 

--- a/alita/modules/antiflood_command_test.go
+++ b/alita/modules/antiflood_command_test.go
@@ -404,7 +404,6 @@ func TestAntifloodWatcherSkipsApprovedUsersAndBotRestrictFailures(t *testing.T) 
 	}
 }
 
-// countFloodMuEntries returns the number of entries currently held in floodMu.
 func countFloodMuEntries() int {
 	n := 0
 	floodMu.Range(func(_, _ any) bool {
@@ -414,13 +413,9 @@ func countFloodMuEntries() int {
 	return n
 }
 
-// TestAntifloodCleanupRemovesMutexEntries verifies that cleanupOnce removes both
-// the syncHelperMap entry and the corresponding floodMu entry when the entry has
-// been idle for more than 600 seconds, and that a non-idle entry is left intact.
 func TestAntifloodCleanupRemovesMutexEntries(t *testing.T) {
 	resetAntifloodState(t)
 
-	// Also clear any floodMu entries left over from other tests.
 	floodMu.Range(func(key, _ any) bool {
 		floodMu.Delete(key)
 		return true
@@ -430,14 +425,12 @@ func TestAntifloodCleanupRemovesMutexEntries(t *testing.T) {
 	freshKey := floodKey{chatId: -9001, userId: 1002}
 
 	now := int64(1_000_000)
-	staleActivity := now - 601 // idle > 600 s → must be removed
-	freshActivity := now - 10  // idle 10 s → must survive
+	staleActivity := now - 601
+	freshActivity := now - 10
 
-	// Populate syncHelperMap.
 	antifloodModule.syncHelperMap.Store(staleKey, floodControl{userId: 1001, lastActivity: staleActivity})
 	antifloodModule.syncHelperMap.Store(freshKey, floodControl{userId: 1002, lastActivity: freshActivity})
 
-	// Populate floodMu (mirrors what updateFlood does via LoadOrStore).
 	floodMu.Store(staleKey, &sync.Mutex{})
 	floodMu.Store(freshKey, &sync.Mutex{})
 
@@ -445,10 +438,8 @@ func TestAntifloodCleanupRemovesMutexEntries(t *testing.T) {
 		t.Fatalf("pre-cleanup floodMu entries = %d, want >= 2", got)
 	}
 
-	// Run exactly one cleanup pass at the synthetic "now".
 	antifloodModule.cleanupOnce(now)
 
-	// Stale entry must be gone from both maps.
 	if _, ok := antifloodModule.syncHelperMap.Load(staleKey); ok {
 		t.Error("stale key still present in syncHelperMap after cleanup")
 	}
@@ -456,7 +447,6 @@ func TestAntifloodCleanupRemovesMutexEntries(t *testing.T) {
 		t.Error("stale key still present in floodMu after cleanup")
 	}
 
-	// Fresh entry must still be present in both maps.
 	if _, ok := antifloodModule.syncHelperMap.Load(freshKey); !ok {
 		t.Error("fresh key was incorrectly removed from syncHelperMap")
 	}
@@ -464,7 +454,6 @@ func TestAntifloodCleanupRemovesMutexEntries(t *testing.T) {
 		t.Error("fresh key was incorrectly removed from floodMu")
 	}
 
-	// Cleanup after test.
 	antifloodModule.syncHelperMap.Delete(freshKey)
 	floodMu.Delete(freshKey)
 }

--- a/alita/modules/antiraid.go
+++ b/alita/modules/antiraid.go
@@ -79,14 +79,12 @@ type antiRaidStruct struct {
 	moduleStruct
 }
 
-// raidState stores the serialized raid state in Redis.
 type raidState struct {
 	Active    bool  `json:"active"`
-	StartedAt int64 `json:"started_at"` // unix seconds
-	ExpiresAt int64 `json:"expires_at"` // unix seconds
+	StartedAt int64 `json:"started_at"`
+	ExpiresAt int64 `json:"expires_at"`
 }
 
-// StartAntiRaidExpiryPoller starts the background expiry poller after cache is available.
 func StartAntiRaidExpiryPoller() {
 	if !cache.IsRedisAvailable() {
 		log.Warn("[AntiRaid] Redis not available, skipping expiry poller start")
@@ -95,7 +93,6 @@ func StartAntiRaidExpiryPoller() {
 	antiRaidPollerMu.Lock()
 	defer antiRaidPollerMu.Unlock()
 	if antiRaidCancel != nil {
-		// Already started
 		return
 	}
 	antiRaidCtx, antiRaidCancel = context.WithCancel(context.Background())
@@ -107,7 +104,6 @@ func StartAntiRaidExpiryPoller() {
 	}(antiRaidCtx)
 }
 
-// StopAntiRaidExpiryPoller stops and joins the background expiry poller.
 func StopAntiRaidExpiryPoller() {
 	antiRaidPollerMu.Lock()
 	defer antiRaidPollerMu.Unlock()
@@ -134,7 +130,6 @@ func trackJoin(chatID, userID int64) (count int, err error) {
 	now := time.Now().Unix()
 	ctx := cache.Context
 	rdb := cache.GetRedisClient()
-	// Use unique member to count events, not distinct users (multiple joins from same user in window count separately)
 	member := fmt.Sprintf("%d:%d:%d", userID, now, time.Now().UnixNano())
 	window := antiraidJoinWindowSeconds
 	cutoff := now - int64(antiraidJoinWindowSeconds)
@@ -496,8 +491,6 @@ func (a *antiRaidStruct) onJoin(bot *gotgbot.Bot, ctx *ext.Context) error {
 			}
 			isActive = true
 			if !enabled {
-				// Another update crossed the threshold first. Apply the active
-				// raid without resetting its expiry or sending a duplicate alert.
 				banRaidMember(bot, chat, member.Id, settings.RaidActionTime)
 				continue
 			}
@@ -871,7 +864,6 @@ func parseDuration(input string) (seconds int, ok bool) {
 
 	var duration int64
 	unit := input[len(input)-1]
-	// Bare number without unit is invalid — require explicit s/m/h/d/w
 	if unit >= '0' && unit <= '9' {
 		return 0, false
 	}

--- a/alita/modules/antiraid_test.go
+++ b/alita/modules/antiraid_test.go
@@ -189,18 +189,15 @@ func TestAntiRaidStateMachine(t *testing.T) {
 
 	chatID := time.Now().UnixNano()
 
-	// Initial state
 	if antiRaidModule.isRaidActive(chatID) {
 		t.Fatal("expected raid to be inactive initially")
 	}
 
-	// Enable
 	antiRaidModule.enableRaid(chatID, 3600)
 	if !antiRaidModule.isRaidActive(chatID) {
 		t.Fatal("expected raid to be active after enable")
 	}
 
-	// Disable
 	disabled, err := antiRaidModule.disableRaid(chatID)
 	if err != nil {
 		t.Fatalf("disableRaid() error = %v", err)
@@ -212,7 +209,6 @@ func TestAntiRaidStateMachine(t *testing.T) {
 		t.Fatal("expected raid to be inactive after disable")
 	}
 
-	// Disable when already disabled
 	disabled, err = antiRaidModule.disableRaid(chatID)
 	if err != nil {
 		t.Fatalf("disableRaid(inactive) error = %v", err)
@@ -318,7 +314,7 @@ func TestAntiRaidAutoExpiry(t *testing.T) {
 
 	chatID := time.Now().UnixNano() + 1
 
-	antiRaidModule.enableRaid(chatID, 1) // 1 second
+	antiRaidModule.enableRaid(chatID, 1)
 	if !antiRaidModule.isRaidActive(chatID) {
 		t.Fatal("expected raid active immediately")
 	}
@@ -804,21 +800,16 @@ func TestAntiRaidOnJoinSkipsIneligibleUpdates(t *testing.T) {
 	}
 }
 
-// TestAntiRaidTrackJoinTriggersAtThreshold characterizes the join-counting logic in
-// trackJoin: the count must stay below T for the first T-1 joins and reach T on
-// the T-th join, with no overlap between distinct chat IDs.
 func TestAntiRaidTrackJoinTriggersAtThreshold(t *testing.T) {
 	withMiniredis(t)
 
 	chatID := uniqueModuleChatID()
 	threshold := 3
 
-	// Clean up join tracking state for the chat after the test.
 	t.Cleanup(func() {
 		clearJoinTracking(chatID)
 	})
 
-	// First T-1 joins must not meet the threshold.
 	for i := 0; i < threshold-1; i++ {
 		userID := int64(1000 + i)
 		count, err := trackJoin(chatID, userID)
@@ -830,7 +821,6 @@ func TestAntiRaidTrackJoinTriggersAtThreshold(t *testing.T) {
 		}
 	}
 
-	// T-th join must meet or exceed the threshold.
 	count, err := trackJoin(chatID, int64(1000+threshold-1))
 	if err != nil {
 		t.Fatalf("trackJoin (T-th) error = %v", err)
@@ -846,7 +836,6 @@ func TestAntiRaidTrackJoinTriggersAtThreshold(t *testing.T) {
 		t.Fatalf("join tracking TTL = %v, want within the join window", ttl)
 	}
 
-	// A separate chat ID must have an independent counter.
 	otherChatID := uniqueModuleChatID()
 	t.Cleanup(func() {
 		clearJoinTracking(otherChatID)
@@ -860,9 +849,6 @@ func TestAntiRaidTrackJoinTriggersAtThreshold(t *testing.T) {
 	}
 }
 
-// TestAntiRaidOnJoinAppliesConfiguredAction characterizes two key onJoin branches:
-//  1. No action when raid is inactive and AutoAntiRaidThreshold is 0.
-//  2. Ban + raid activation when the threshold is reached (via miniredis).
 func TestAntiRaidOnJoinAppliesConfiguredAction(t *testing.T) {
 	t.Run("no action when raid inactive and threshold disabled", func(t *testing.T) {
 		client := newModuleBotClient()
@@ -870,7 +856,6 @@ func TestAntiRaidOnJoinAppliesConfiguredAction(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Raid Chat"}
 		raider := gotgbot.User{Id: 5001, FirstName: "Raider"}
 
-		// Ensure threshold is 0 (default) so no auto-raid logic runs.
 		if err := antiraid.SetAutoAntiRaidThreshold(chat.Id, 0); err != nil {
 			t.Fatalf("SetAutoAntiRaidThreshold setup error = %v", err)
 		}
@@ -899,7 +884,6 @@ func TestAntiRaidOnJoinAppliesConfiguredAction(t *testing.T) {
 		chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "Raid Chat"}
 		raider := gotgbot.User{Id: 5002, FirstName: "Raider"}
 
-		// Set threshold to 1: the very first tracked join must trigger auto-raid.
 		if err := antiraid.SetAutoAntiRaidThreshold(chat.Id, 1); err != nil {
 			t.Fatalf("SetAutoAntiRaidThreshold(1) error = %v", err)
 		}
@@ -920,11 +904,9 @@ func TestAntiRaidOnJoinAppliesConfiguredAction(t *testing.T) {
 			t.Fatalf("onJoin(auto-trigger) error = %v, want ContinueGroups", err)
 		}
 
-		// The raid must now be active.
 		if !antiRaidModule.isRaidActive(chat.Id) {
 			t.Fatal("isRaidActive = false after threshold reached, want true")
 		}
-		// The triggering joiner must have been banned.
 		if calls := client.callsFor("banChatMember"); len(calls) != 1 {
 			t.Fatalf("banChatMember calls = %d, want 1 (triggering joiner)", len(calls))
 		}
@@ -970,14 +952,11 @@ func TestAntiRaidOnJoinAppliesConfiguredAction(t *testing.T) {
 	})
 }
 
-// TestAntiRaidCheckExpiredRaidsReleasesAfterWindow verifies that the poller
-// persists expiry while leaving a live raid untouched.
 func TestAntiRaidCheckExpiredRaidsReleasesAfterWindow(t *testing.T) {
 	withMiniredis(t)
 
 	rdb := cache.GetRedisClient()
 
-	// --- Scenario A: expired raid ---
 	expiredChatID := uniqueModuleChatID()
 	t.Cleanup(func() {
 		_, _ = antiRaidModule.disableRaid(expiredChatID)
@@ -990,13 +969,12 @@ func TestAntiRaidCheckExpiredRaidsReleasesAfterWindow(t *testing.T) {
 	expiredState := &raidState{
 		Active:    true,
 		StartedAt: time.Now().Add(-2 * time.Hour).Unix(),
-		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(), // expired 1 hour ago
+		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(),
 	}
 	if err := setRaidState(expiredChatID, expiredState); err != nil {
 		t.Fatalf("setRaidState(expired) setup error = %v", err)
 	}
 
-	// --- Scenario B: still-active raid ---
 	activeChatID := uniqueModuleChatID()
 	t.Cleanup(func() {
 		_, _ = antiRaidModule.disableRaid(activeChatID)
@@ -1009,16 +987,14 @@ func TestAntiRaidCheckExpiredRaidsReleasesAfterWindow(t *testing.T) {
 	activeState := &raidState{
 		Active:    true,
 		StartedAt: time.Now().Unix(),
-		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(), // expires 1 hour from now
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
 	}
 	if err := setRaidState(activeChatID, activeState); err != nil {
 		t.Fatalf("setRaidState(active) setup error = %v", err)
 	}
 
-	// Run the expiry check — must not return an error or panic.
 	antiRaidModule.checkExpiredRaids(context.Background())
 
-	// The expired state is persisted as inactive.
 	expiredSt := getRaidState(expiredChatID)
 	if expiredSt.Active {
 		t.Fatalf("getRaidState(expired).Active = true after checkExpiredRaids, want false")
@@ -1027,7 +1003,6 @@ func TestAntiRaidCheckExpiredRaidsReleasesAfterWindow(t *testing.T) {
 		t.Fatal("isRaidActive(expired) = true after checkExpiredRaids, want false")
 	}
 
-	// A non-expired raid remains active.
 	activeSt := getRaidState(activeChatID)
 	if !activeSt.Active {
 		t.Fatalf("getRaidState(active).Active = false after checkExpiredRaids, want true (non-expired raid must not be released)")

--- a/alita/modules/antispam.go
+++ b/alita/modules/antispam.go
@@ -14,7 +14,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/error_handling"
 )
 
-// spamKey is a composite key for rate limiting per user per chat
 type spamKey struct {
 	chatId int64
 	userId int64
@@ -25,7 +24,6 @@ const (
 	antiSpamWindow = time.Second
 )
 
-// antiSpamInfo tracks a user's current fixed spam window.
 type antiSpamInfo struct {
 	Count       int
 	WindowStart time.Time
@@ -39,7 +37,6 @@ type spamShard struct {
 var antiSpamShards [16]spamShard
 
 func shardFor(key spamKey) *spamShard {
-	// Mix both chat and user to spread users in the same chat across shards.
 	hash := uint64(key.chatId)*31 + uint64(key.userId)
 	return &antiSpamShards[hash%16]
 }
@@ -52,7 +49,6 @@ func init() {
 	go antiSpamCleanupLoop()
 }
 
-// antiSpamCleanupLoop periodically removes expired entries to prevent memory leaks.
 func antiSpamCleanupLoop() {
 	defer error_handling.RecoverFromPanic("antiSpamCleanupLoop", "antispam")
 
@@ -82,8 +78,6 @@ func cleanupExpiredAntiSpam(now time.Time) {
 	}
 }
 
-// spamCheck performs spam detection for a specific user in a chat.
-// The eighteenth message within one second is spam.
 func spamCheck(key spamKey) bool {
 	shard := shardFor(key)
 	shard.mu.Lock()
@@ -106,24 +100,17 @@ func spamCheck(key spamKey) bool {
 	return info.Count >= antiSpamLimit
 }
 
-// LoadAntispam registers the antispam message handler with the dispatcher.
-// Sets up spam detection monitoring for all incoming messages.
 func LoadAntispam(dispatcher *ext.Dispatcher) {
 	dispatcher.AddHandlerToGroup(
 		handlers.NewMessage(
 			message.All,
 			func(bot *gotgbot.Bot, ctx *ext.Context) error {
-				// Skip if no user (channel posts, etc.)
 				if ctx.EffectiveUser == nil {
 					return ext.ContinueGroups
 				}
-				// Skip approved users (immune to anti-spam)
 				if chat_status.IsApproved(bot, ctx.EffectiveChat.Id, ctx.EffectiveUser.Id) {
 					return ext.ContinueGroups
 				}
-				// Skip admins: every other anti-abuse module exempts admins, and
-				// silently dropping an admin's messages (including legitimate
-				// command bursts) is worse than letting them through.
 				if chat_status.IsUserAdmin(bot, ctx.EffectiveChat.Id, ctx.EffectiveUser.Id) {
 					return ext.ContinueGroups
 				}

--- a/alita/modules/blacklists.go
+++ b/alita/modules/blacklists.go
@@ -26,19 +26,8 @@ var blacklistsModule = moduleStruct{
 	handlerGroup: 7,
 }
 
-// Use the shared global regex cache from filters module
-
-/*
-	Used to add a blacklist to group!
-
-Connection - true, true
-Admin can add a blacklist to the chat
-*/
-// addBlacklist handles the /addblacklist command to add blacklisted words to a group.
-// Admins can add words that will trigger automatic moderation actions.
 func (m moduleStruct) addBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -56,7 +45,6 @@ func (m moduleStruct) addBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 		text                             string
 	)
 
-	// Permission Checks
 	if !chat_status.IsUserAdmin(b, chat.Id, user.Id) {
 		return ext.EndGroups
 	}
@@ -83,13 +71,11 @@ func (m moduleStruct) addBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 	} else if len(args) >= 1 {
 		allBlWords := blacklists.GetBlacklistSettings(chat.Id).Triggers()
 
-		// OPTIMIZATION: Convert blacklist slice to map for O(1) lookups
 		blWordSet := make(map[string]struct{}, len(allBlWords))
 		for _, w := range allBlWords {
 			blWordSet[w] = struct{}{}
 		}
 
-		// Validate word lengths - reject words over 100 characters
 		var tooLong []string
 		validArgs := make([]string, 0, len(args))
 		for _, word := range args {
@@ -159,17 +145,8 @@ func (m moduleStruct) addBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to remove a blacklist from group!
-
-Connection - true, true
-Admin can add a blacklist to the chat
-*/
-// removeBlacklist handles the /rmblacklist command to remove blacklisted words.
-// Allows admins to remove previously blacklisted words from the group.
 func (m moduleStruct) removeBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -184,7 +161,6 @@ func (m moduleStruct) removeBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	var removedBlacklists []string
 
-	// Permission Checks
 	if !chat_status.IsUserAdmin(b, chat.Id, user.Id) {
 		return ext.EndGroups
 	}
@@ -243,22 +219,12 @@ func (m moduleStruct) removeBlacklist(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to list all blacklists of a group!
-
-Connection - false, true
-Anyone can view blacklists in group
-*/
-// listBlacklists handles the /blacklists command to display all blacklisted words.
-// Shows a sorted list of all currently blacklisted words in the group.
 func (m moduleStruct) listBlacklists(b *gotgbot.Bot, ctx *ext.Context) error {
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "blacklists") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -310,18 +276,8 @@ func (m moduleStruct) listBlacklists(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to set mode for blacklists in chat
-
-# Connection - true, true
-
-Admin with restriction permission can set blacklist action in group out of - ick, ban, mute
-*/
-// setBlacklistAction handles the /blaction command to configure blacklist punishment.
-// Sets the action (mute/kick/warn/ban/none) taken when blacklisted words are detected.
 func (m moduleStruct) setBlacklistAction(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -336,7 +292,6 @@ func (m moduleStruct) setBlacklistAction(b *gotgbot.Bot, ctx *ext.Context) error
 
 	var rMsg string
 
-	// Permission Checks
 	if !chat_status.CanUserRestrict(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_restrict_cmd_error", "chat_status_restrict_button_error")
 		return ext.EndGroups
@@ -378,13 +333,6 @@ func (m moduleStruct) setBlacklistAction(b *gotgbot.Bot, ctx *ext.Context) error
 	return ext.EndGroups
 }
 
-/*
-	Used to remove all blacklists from a group
-
-Only chat creator can use this command to remove all blacklists aat once from the current chat
-*/
-// rmAllBlacklists handles the /rmallbl command to remove all blacklisted words.
-// Only chat owners can use this command with confirmation via inline keyboard.
 func (m moduleStruct) rmAllBlacklists(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := chat_status.RequireUser(b, ctx)
@@ -394,7 +342,6 @@ func (m moduleStruct) rmAllBlacklists(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// permission checks
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -433,9 +380,6 @@ func (m moduleStruct) rmAllBlacklists(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// Callback Handler for rmallblacklist
-// buttonHandler processes confirmation callbacks for removing all blacklists.
-// Handles the yes/no confirmation when owners attempt to clear all blacklisted words.
 func (m moduleStruct) buttonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -449,7 +393,6 @@ func (m moduleStruct) buttonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// permission checks
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 		return ext.EndGroups
@@ -502,13 +445,6 @@ func (m moduleStruct) buttonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Blacklist watcher
-
-Watcher for blacklisted words, if any of the sentence contains the word, it will remove and use the appropriate action
-*/
-// blacklistWatcher monitors all messages for blacklisted words.
-// Automatically applies configured punishment when blacklisted content is detected.
 func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	user := ctx.EffectiveSender
@@ -519,15 +455,12 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Fast path: if no triggers are configured, bail out before any API call.
 	blSettings := blacklists.GetBlacklistSettings(chat.Id)
 	triggers := blSettings.Triggers()
 	if len(triggers) == 0 {
 		return ext.ContinueGroups
 	}
 
-	// skip admins and creator + approved users and anonymous channel
-	// Only check admin status for actual users, not anonymous channels
 	if !user.IsAnonymousChannel() && user.IsUser() && user.Id() > 0 && chat_status.IsUserAdmin(b, chat.Id, user.Id()) {
 		return ext.ContinueGroups
 	}
@@ -535,8 +468,6 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Check if bot has admin permissions to take action
-	// This prevents wasted API calls when bot can't delete/restrict
 	if !chat_status.IsBotAdmin(b, ctx, chat) {
 		return ext.ContinueGroups
 	}
@@ -548,11 +479,9 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Use Aho-Corasick for efficient multi-pattern matching
 	cache := keyword_matcher.GetNamedCache("blacklists")
 	matcher := cache.GetOrCreateMatcher(chat.Id, triggers)
 
-	// Find first matching blacklist trigger using optimized path
 	firstPattern, found := matcher.FirstMatch(matchText)
 	if !found {
 		return ext.ContinueGroups
@@ -571,7 +500,6 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	var err error
 	switch matched.Action {
 	case "mute":
-		// don't work on anonymous channels
 		if user.IsAnonymousChannel() {
 			return ext.ContinueGroups
 		}
@@ -593,7 +521,6 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	case "ban":
-		// ban anonymous channels as well
 		if user.IsAnonymousChannel() {
 			_, err = b.BanChatSenderChat(chat.Id, user.Id(), nil)
 		} else {
@@ -615,7 +542,6 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	case "kick":
-		// don't work on anonymous channels
 		if user.IsAnonymousChannel() {
 			return ext.ContinueGroups
 		}
@@ -636,7 +562,6 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	case "warn":
-		// don't work on anonymous channels
 		if user.IsAnonymousChannel() {
 			return ext.ContinueGroups
 		}
@@ -647,15 +572,12 @@ func (m moduleStruct) blacklistWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	case "none":
-		// Message already deleted, no further action needed
 		return ext.ContinueGroups
 	}
 
 	return ext.ContinueGroups
 }
 
-// LoadBlacklists registers all blacklist module handlers with the dispatcher.
-// Sets up commands for managing blacklists and the message watcher for enforcement.
 func LoadBlacklists(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[blacklistsModule.moduleName] = true
 

--- a/alita/modules/blacklists_command_test.go
+++ b/alita/modules/blacklists_command_test.go
@@ -368,13 +368,9 @@ func slicesContains(values []string, target string) bool {
 	return false
 }
 
-// TestBlacklistWatcherSkipsBotAdminCallWhenNoTriggers asserts that when a chat
-// has no blacklist triggers the watcher returns before issuing any getChatMember
-// API call — verifying the reorder from Step 1 of plan 007.
 func TestBlacklistWatcherSkipsBotAdminCallWhenNoTriggers(t *testing.T) {
 	client := newModuleBotClient()
 	bot := newModuleTestBot(client)
-	// Use a fresh chat ID with no blacklist triggers configured.
 	chat := gotgbot.Chat{Id: uniqueModuleChatID(), Type: "supergroup", Title: "No Triggers Chat"}
 	member := gotgbot.User{Id: 42, FirstName: "Member"}
 
@@ -383,8 +379,6 @@ func TestBlacklistWatcherSkipsBotAdminCallWhenNoTriggers(t *testing.T) {
 		t.Fatalf("blacklistWatcher(no triggers) error = %v, want ContinueGroups", err)
 	}
 
-	// getChatMember must NOT have been called — the fast-path returns before any
-	// admin-status lookup when no triggers are configured.
 	if calls := client.callsFor("getChatMember"); len(calls) != 0 {
 		t.Fatalf("getChatMember calls = %d, want 0 when no triggers are set", len(calls))
 	}

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -48,8 +48,6 @@ func isTransientMemberError(err error) bool {
 
 var captchaModule = moduleStruct{moduleName: "Captcha"}
 
-// fixedStringCaptchaDriver wraps DriverString so captcha.Generate renders
-// the exact provided content instead of randomly sampling from Source.
 type fixedStringCaptchaDriver struct {
 	*base64Captcha.DriverString
 	content string
@@ -60,7 +58,6 @@ func (d *fixedStringCaptchaDriver) GenerateIdQuestionAnswer() (id, q, a string) 
 	return id, d.content, d.content
 }
 
-// noopCaptchaStore avoids persisting unused answers for image-only generation paths.
 type noopCaptchaStore struct{}
 
 func (noopCaptchaStore) Set(id string, value string) error {
@@ -78,21 +75,20 @@ func (noopCaptchaStore) Verify(id, answer string, clear bool) bool {
 func newMathImageCaptchaDriver(question string) *fixedStringCaptchaDriver {
 	return &fixedStringCaptchaDriver{
 		DriverString: base64Captcha.NewDriverString(
-			80,            // height
-			240,           // width (wider for math expression)
-			0,             // noiseCount
-			0,             // showLineOptions - keep math operators readable
-			len(question), // source length
-			question,      // source string (the question itself)
-			nil,           // bgColor
-			nil,           // fonts
-			[]string{},    // fontsArray
+			80,
+			240,
+			0,
+			0,
+			len(question),
+			question,
+			nil,
+			nil,
+			[]string{},
 		),
 		content: question,
 	}
 }
 
-// messageTypeToString converts message type constants to human-readable strings
 func messageTypeToString(tr *i18n.Translator, messageType int) string {
 	var key string
 	switch messageType {
@@ -119,13 +115,11 @@ func messageTypeToString(tr *i18n.Translator, messageType int) string {
 	return text
 }
 
-// Refresh controls
 const (
 	captchaMaxRefreshes     = 3
-	captchaRefreshCooldownS = 5 // seconds
+	captchaRefreshCooldownS = 5
 )
 
-// Process-wide captcha worker lifecycle.
 var (
 	captchaLifecycleOnce sync.Once
 	captchaLifecycleErr  error
@@ -139,7 +133,6 @@ var (
 )
 
 // StartCaptchaLifecycle restores persisted attempts and starts the cleanup workers.
-// It must run during process startup, before updates are accepted.
 func StartCaptchaLifecycle(bot *gotgbot.Bot) error {
 	if bot == nil {
 		return errors.New("captcha lifecycle requires a bot")
@@ -176,7 +169,6 @@ func StartCaptchaLifecycle(bot *gotgbot.Bot) error {
 	return nil
 }
 
-// StopCaptchaLifecycle stops and joins periodic workers and challenge timers.
 func StopCaptchaLifecycle() {
 	captchaLifecycleMu.Lock()
 	captchaLifecycleDone = true
@@ -205,7 +197,6 @@ func startCaptchaLifecycleTask(task func(context.Context)) bool {
 	return true
 }
 
-// isPermanentTelegramError checks if an error is permanent and shouldn't be retried
 func isPermanentTelegramError(err error) bool {
 	if err == nil {
 		return false
@@ -229,8 +220,6 @@ func isPermanentTelegramError(err error) bool {
 	return false
 }
 
-// isPermanentUnmuteError reports errors where permission restoration is no
-// longer needed. Access and permission failures remain queued for retry.
 func isPermanentUnmuteError(err error) bool {
 	if err == nil {
 		return false
@@ -250,7 +239,6 @@ func isPermanentUnmuteError(err error) bool {
 	return false
 }
 
-// runOrphanedCaptchaRecovery resumes valid attempts and finalizes expired ones.
 func runOrphanedCaptchaRecovery(bot *gotgbot.Bot) error {
 	log.Info("[CaptchaRecovery] Starting orphaned captcha recovery...")
 
@@ -291,8 +279,6 @@ func runOrphanedCaptchaRecovery(bot *gotgbot.Bot) error {
 
 		handled, err := expireCaptchaAttempt(bot, attempt)
 		if err != nil {
-			// Keep the attempt so the periodic worker can retry it. A single
-			// inaccessible chat must not prevent the bot from starting.
 			log.Warnf("[CaptchaRecovery] Failed to expire attempt %d; will retry: %v", attempt.ID, err)
 		} else if handled {
 			expiredCount++
@@ -322,8 +308,6 @@ func secureIntn(max int) (int, error) {
 	if max <= 0 {
 		return 0, nil
 	}
-	// Use crypto/rand.Int for unbiased secure random selection
-	// Bounded retry to avoid CPU starvation if entropy source fails persistently.
 	const maxRetries = 10
 	for i := 0; i < maxRetries; i++ {
 		n, err := crand.Int(crand.Reader, big.NewInt(int64(max)))
@@ -334,7 +318,6 @@ func secureIntn(max int) (int, error) {
 	return 0, fmt.Errorf("secureIntn: exhausted retries for crypto/rand.Int (max=%d)", max)
 }
 
-// secureShuffleStrings shuffles a slice of strings using Fisher-Yates with crypto-grade randomness.
 func secureShuffleStrings(values []string) error {
 	for i := len(values) - 1; i > 0; i-- {
 		j, err := secureIntn(i + 1)
@@ -346,8 +329,6 @@ func secureShuffleStrings(values []string) error {
 	return nil
 }
 
-// viewPendingMessages handles the /captchapending command to view stored messages for a user.
-// Admins can use this to see what messages a user tried to send before verification.
 func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -356,13 +337,11 @@ func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) erro
 		return ext.EndGroups
 	}
 
-	// Check admin permissions
 	if !chat_status.RequireUserAdmin(bot, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
 	}
 
-	// Parse target user from command
 	if len(ctx.Args()) < 2 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("captcha_pending_usage")
@@ -370,7 +349,6 @@ func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) erro
 		return err
 	}
 
-	// Get user ID from mention or ID
 	targetUserID := extraction.ExtractUser(bot, ctx)
 	if targetUserID == 0 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -379,7 +357,6 @@ func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) erro
 		return err
 	}
 
-	// Get stored messages for user
 	messages, err := captcha.GetStoredMessagesForUser(targetUserID, chat.Id)
 	if err != nil || len(messages) == 0 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -388,7 +365,6 @@ func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) erro
 		return err
 	}
 
-	// Build response
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	var response strings.Builder
 	headerText, _ := tr.GetString("captcha_pending_messages_header")
@@ -417,8 +393,6 @@ func (moduleStruct) viewPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) erro
 	return err
 }
 
-// clearPendingMessages handles the /captchaclear command to clear stored messages for a user.
-// Admins can use this to manually clear pending messages if needed.
 func (moduleStruct) clearPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -427,13 +401,11 @@ func (moduleStruct) clearPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) err
 		return ext.EndGroups
 	}
 
-	// Check admin permissions
 	if !chat_status.RequireUserAdmin(bot, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
 	}
 
-	// Parse target user
 	args := ctx.Args()[1:]
 	if len(args) < 1 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -450,7 +422,6 @@ func (moduleStruct) clearPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) err
 		return err
 	}
 
-	// Delete messages
 	err := captcha.DeleteStoredMessagesForUser(targetUserID, chat.Id)
 	if err != nil {
 		log.Errorf("Failed to delete stored messages for user %d in chat %d: %v", targetUserID, chat.Id, err)
@@ -467,10 +438,6 @@ func (moduleStruct) clearPendingMessages(bot *gotgbot.Bot, ctx *ext.Context) err
 	return err
 }
 
-// captchaAdminGate runs the shared permission preamble for captcha setting
-// commands: RequireUser → RequireGroup → RequireUserAdmin (and RequireBotAdmin
-// when requireBotAdmin is set). Each gate sends its own responder message on
-// failure; ok is false the instant any gate fails.
 func captchaAdminGate(bot *gotgbot.Bot, ctx *ext.Context, requireBotAdmin bool) (*gotgbot.User, bool) {
 	user := chat_status.RequireUser(bot, ctx)
 	if user == nil {
@@ -491,8 +458,6 @@ func captchaAdminGate(bot *gotgbot.Bot, ctx *ext.Context, requireBotAdmin bool) 
 	return user, true
 }
 
-// captchaCommand handles the /captcha command to enable/disable captcha verification.
-// Admins can use this to toggle captcha protection for their group.
 func (moduleStruct) captchaCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -502,7 +467,6 @@ func (moduleStruct) captchaCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	args := ctx.Args()[1:]
 
 	if len(args) == 0 {
-		// Show current status
 		settings, err := captcha.GetCaptchaSettings(chat.Id)
 		if err != nil {
 			log.Errorf("[Captcha] Failed to get settings for chat %d: %v", chat.Id, err)
@@ -616,8 +580,6 @@ func disableCaptchaForChat(bot *gotgbot.Bot, chatID int64) error {
 	return cleanupErr
 }
 
-// captchaModeCommand handles the /captchamode command to set captcha type.
-// Admins can choose between math and text captcha modes.
 func (moduleStruct) captchaModeCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -668,8 +630,6 @@ func (moduleStruct) captchaModeCommand(bot *gotgbot.Bot, ctx *ext.Context) error
 	return err
 }
 
-// captchaTimeCommand handles the /captchatime command to set verification timeout.
-// Admins can set how long users have to complete the captcha (1-10 minutes).
 func (moduleStruct) captchaTimeCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -715,8 +675,6 @@ func (moduleStruct) captchaTimeCommand(bot *gotgbot.Bot, ctx *ext.Context) error
 	return err
 }
 
-// captchaActionCommand handles the /captchaaction command to set failure action.
-// Admins can choose what happens when users fail the captcha: kick, ban, or mute.
 func (moduleStruct) captchaActionCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -761,8 +719,6 @@ func (moduleStruct) captchaActionCommand(bot *gotgbot.Bot, ctx *ext.Context) err
 	return err
 }
 
-// captchaMaxAttemptsCommand handles the /captchamaxattempts command to set max verification attempts.
-// Admins can set how many wrong answers are allowed before taking action (1-10 attempts).
 func (moduleStruct) captchaMaxAttemptsCommand(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -808,7 +764,6 @@ func (moduleStruct) captchaMaxAttemptsCommand(bot *gotgbot.Bot, ctx *ext.Context
 	return err
 }
 
-// generateMathCaptcha generates a random math problem and returns the question and answer.
 func generateMathCaptcha() (string, string, []string, error) {
 	opIdx, err := secureIntn(3)
 	if err != nil {
@@ -862,10 +817,8 @@ func generateMathCaptcha() (string, string, []string, error) {
 		question = formatMathQuestion(a, b, operation)
 	}
 
-	// Generate wrong answers
 	options := []string{strconv.Itoa(answer)}
 	for len(options) < 4 {
-		// Generate a wrong answer within reasonable range
 		off, err := secureIntn(20)
 		if err != nil {
 			return "", "", nil, err
@@ -873,14 +826,12 @@ func generateMathCaptcha() (string, string, []string, error) {
 		wrongAnswer := answer + off - 10
 		if wrongAnswer != answer && wrongAnswer > 0 {
 			wrongStr := strconv.Itoa(wrongAnswer)
-			// Check if this option already exists
 			if !slices.Contains(options, wrongStr) {
 				options = append(options, wrongStr)
 			}
 		}
 	}
 
-	// Shuffle options
 	if err := secureShuffleStrings(options); err != nil {
 		return "", "", nil, err
 	}
@@ -898,36 +849,29 @@ func formatMathQuestion(a, b int, operation string) string {
 	return fmt.Sprintf("%d %s %d", a, operator, b)
 }
 
-// generateTextCaptcha generates a captcha image with random text.
 func generateTextCaptcha() (string, []byte, []string, error) {
-	// Create captcha store (using memory store)
 	store := base64Captcha.DefaultMemStore
 
-	// Create a string driver for text captcha
 	driver := base64Captcha.NewDriverString(
-		80,                                 // height
-		160,                                // width
-		0,                                  // noiseCount
-		2,                                  // showLineOptions
-		4,                                  // length
-		"234567890abcdefghjkmnpqrstuvwxyz", // source characters
-		nil,                                // bgColor
-		nil,                                // fonts
+		80,
+		160,
+		0,
+		2,
+		4,
+		"234567890abcdefghjkmnpqrstuvwxyz",
+		nil,
+		nil,
 		[]string{},
 	)
 
-	// Create captcha
 	captcha := base64Captcha.NewCaptcha(driver, store)
 
-	// Generate the captcha
 	id, b64s, answer, err := captcha.Generate()
 	if err != nil {
 		return "", nil, nil, err
 	}
-	_ = id // We don't use the ID
+	_ = id
 
-	// Decode base64 image
-	// Remove data:image/png;base64, prefix if present
 	if strings.HasPrefix(b64s, "data:image/") {
 		parts := strings.Split(b64s, ",")
 		if len(parts) > 1 {
@@ -940,11 +884,9 @@ func generateTextCaptcha() (string, []byte, []string, error) {
 		return "", nil, nil, err
 	}
 
-	// Generate decoy answers
 	options := []string{answer}
 	characters := "234567890abcdefghjkmnpqrstuvwxyz"
 	for len(options) < 4 {
-		// Generate a random string of same length as answer
 		decoy := ""
 		for range len(answer) {
 			idx, err := secureIntn(len(characters))
@@ -953,30 +895,24 @@ func generateTextCaptcha() (string, []byte, []string, error) {
 			}
 			decoy += string(characters[idx])
 		}
-		// Check if this option already exists
 		if !slices.Contains(options, decoy) {
 			options = append(options, decoy)
 		}
 	}
 
-	// Shuffle options
 	if err := secureShuffleStrings(options); err != nil {
 		return "", nil, nil, err
 	}
 
-	// Verify answer is in options (defensive check)
 	if !slices.Contains(options, answer) {
 		log.Error("[Captcha] Generated text answer was missing from its options, regenerating")
-		return generateTextCaptcha() // Retry
+		return generateTextCaptcha()
 	}
 
 	return answer, imageBytes, options, nil
 }
 
-// generateMathImageCaptcha generates a math captcha image using custom math generation
-// for reliable answer matching. Uses the existing generateMathCaptcha logic.
 func generateMathImageCaptcha() (string, []byte, []string, error) {
-	// Use our reliable math generation
 	question, answer, options, err := generateMathCaptcha()
 	if err != nil {
 		return "", nil, nil, err
@@ -992,7 +928,6 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 		return "", nil, nil, err
 	}
 
-	// Decode base64 image
 	if strings.HasPrefix(b64s, "data:image/") {
 		parts := strings.Split(b64s, ",")
 		if len(parts) > 1 {
@@ -1004,18 +939,14 @@ func generateMathImageCaptcha() (string, []byte, []string, error) {
 		return "", nil, nil, err
 	}
 
-	// Verify answer is in options (defensive check)
 	if !slices.Contains(options, answer) {
 		log.Error("[Captcha] Generated math answer was missing from its options, regenerating")
-		return generateMathImageCaptcha() // Retry
+		return generateMathImageCaptcha()
 	}
 
 	return answer, imageBytes, options, nil
 }
 
-// buildCaptchaKeyboard builds the inline keyboard for a captcha challenge:
-// one button per answer option (captcha_verify) and, when includeRefresh is
-// set, a trailing refresh button (captcha_refresh) labelled refreshBtnText.
 func buildCaptchaKeyboard(attemptID uint, userID int64, refreshCount int, options []string, includeRefresh bool, refreshBtnText string) gotgbot.InlineKeyboardMarkup {
 	var buttons [][]gotgbot.InlineKeyboardButton
 	for _, option := range options {
@@ -1062,7 +993,6 @@ func buildCaptchaKeyboard(attemptID uint, userID int64, refreshCount int, option
 }
 
 // SendCaptcha sends a captcha challenge to a new member.
-// Called when a new member joins a group with captcha enabled.
 //
 //nolint:gocyclo // The ordered mute/send/persist rollback state machine is intentionally cohesive.
 func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName string) (err error) {
@@ -1098,12 +1028,10 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 	isImage := false
 
 	if settings.CaptchaMode == "math" {
-		// Prefer image captcha for math mode
 		var err error
 		answer, imageBytes, options, err = generateMathImageCaptcha()
 		if err != nil || imageBytes == nil {
 			log.Errorf("Failed to generate math image captcha: %v", err)
-			// Fallback to text-based math question (fail-closed on entropy error)
 			var fbErr error
 			question, answer, options, fbErr = generateMathCaptcha()
 			if fbErr != nil {
@@ -1115,12 +1043,10 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 			isImage = true
 		}
 	} else {
-		// Text mode: image captcha with text content
 		var err error
 		answer, imageBytes, options, err = generateTextCaptcha()
 		if err != nil {
 			log.Errorf("Failed to generate text captcha: %v", err)
-			// Fallback to text-based math question (fail-closed on entropy error)
 			var fbErr error
 			question, answer, options, fbErr = generateMathCaptcha()
 			if fbErr != nil {
@@ -1133,10 +1059,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		}
 	}
 
-	// Validate user and chat exist in Telegram before creating DB records
-	// This prevents FK constraint violations for non-existent entities
-
-	// Validate user exists via Telegram API (retry once on transient membership lag)
 	userMember, err := bot.GetChatMember(chat.Id, userID, nil)
 	if err != nil {
 		if isTransientMemberError(err) {
@@ -1149,7 +1071,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		}
 	}
 
-	// Extract validated user info from API response
 	validatedUser := userMember.GetUser()
 	validatedUserName := userName
 	if validatedUser.FirstName != "" {
@@ -1157,13 +1078,11 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 	}
 	validatedUsername := validatedUser.Username
 
-	// Validate chat exists (already have chat object from context, but verify it's valid)
 	if chat.Id == 0 || chat.Title == "" {
 		log.Errorf("Invalid chat data: ID=%d, Title=%s", chat.Id, chat.Title)
 		return fmt.Errorf("invalid chat data")
 	}
 
-	// Now that we've validated via Telegram API, ensure records exist in database
 	if err := user.EnsureUserInDb(userID, validatedUsername, validatedUserName); err != nil {
 		log.Errorf("Failed to ensure user in database: %v", err)
 		return err
@@ -1191,8 +1110,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 	}
 	muted = true
 
-	// Create inline keyboard with options including attempt ID.
-	// Add refresh button for image-based captcha (text or math) with attempt ID.
 	includeRefresh := isImage && imageBytes != nil
 	refreshBtnText := ""
 	if includeRefresh {
@@ -1200,7 +1117,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		refreshBtnText, _ = tr.GetString("captcha_refresh_button")
 	}
 	keyboard := buildCaptchaKeyboard(preAttempt.ID, userID, preAttempt.RefreshCount, options, includeRefresh, refreshBtnText)
-	// If no verify options could be encoded, fail before sending — rollback mute
 	verifyCount := len(keyboard.InlineKeyboard)
 	if includeRefresh && verifyCount > 0 {
 		verifyCount--
@@ -1210,7 +1126,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		return errors.Join(errors.New("captcha keyboard empty: no encodable options"), rollbackCaptchaAttempt(bot, preAttempt))
 	}
 
-	// Prepare message text/caption
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	var msgText string
 	if isImage {
@@ -1228,7 +1143,6 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 			msgText = text
 		}
 	} else {
-		// Text-based fallback for math
 		text, _ := tr.GetString("captcha_welcome_math_text", i18n.TranslationParams{
 			"first":    formatting.MentionHtml(userID, userName),
 			"question": question,
@@ -1237,18 +1151,15 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		msgText = text
 	}
 
-	// Send the captcha message
 	var sent *gotgbot.Message
 
 	if isImage && imageBytes != nil {
-		// Send photo with text captcha
 		sent, err = bot.SendPhoto(chat.Id, gotgbot.InputFileByReader("captcha.png", bytes.NewReader(imageBytes)), &gotgbot.SendPhotoOpts{
 			Caption:     msgText,
 			ParseMode:   formatting.HTML,
 			ReplyMarkup: keyboard,
 		})
 	} else {
-		// Send text message for math captcha
 		sent, err = helpers.SendMessageWithErrorHandling(bot, chat.Id, msgText, &gotgbot.SendMessageOpts{
 			ParseMode:   formatting.HTML,
 			ReplyMarkup: keyboard,
@@ -1263,11 +1174,9 @@ func SendCaptcha(bot *gotgbot.Bot, ctx *ext.Context, userID int64, userName stri
 		return errors.Join(err, rollbackCaptchaAttempt(bot, preAttempt))
 	}
 
-	// Update the attempt with the sent message ID
 	err = captcha.UpdateCaptchaAttemptMessageID(preAttempt.ID, sent.MessageId)
 	if err != nil {
 		log.Errorf("Failed to set captcha attempt message ID: %v", err)
-		// Delete the message if we can't track it
 		_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, sent.MessageId)
 		return errors.Join(err, rollbackCaptchaAttempt(bot, preAttempt))
 	}
@@ -1345,9 +1254,7 @@ func expireCaptchaAttempt(bot *gotgbot.Bot, attempt *db.CaptchaAttempts) (bool, 
 	return claimed, nil
 }
 
-// handleCaptchaTimeout handles when a user fails to complete captcha in time.
 func handleCaptchaTimeout(bot *gotgbot.Bot, chatID, userID int64, attemptID uint, fallbackMessageID int64, action string) (bool, bool) {
-	// Fetch and validate the specific attempt targeted by this timeout event.
 	attempt, err := captcha.GetCaptchaAttemptByID(attemptID)
 	if err != nil || attempt == nil {
 		log.Debugf("[Captcha] Timeout handler skipped - attempt not found for attempt_id=%d", attemptID)
@@ -1366,16 +1273,12 @@ func handleCaptchaTimeout(bot *gotgbot.Bot, chatID, userID int64, attemptID uint
 
 	storedMsgCount, _ := captcha.CountStoredMessagesForAttempt(attemptID)
 
-	// Claim the attempt and persist an immediate unmute fallback in one
-	// transaction. If the process dies before applying the failure action, the
-	// unmute worker will not leave the user captcha-muted forever.
 	deleted, err := captcha.ReleaseCaptchaAttemptAtomic(attemptID, userID, chatID)
 	if err != nil || !deleted {
 		log.Debugf("[Captcha] Timeout handler skipped - attempt already handled for attempt_id=%d", attemptID)
 		return false, false
 	}
 
-	// Delete the captcha message
 	messageID := attempt.MessageID
 	if messageID == 0 {
 		messageID = fallbackMessageID
@@ -1384,7 +1287,6 @@ func handleCaptchaTimeout(bot *gotgbot.Bot, chatID, userID int64, attemptID uint
 		_ = helpers.DeleteMessageWithErrorHandling(bot, chatID, messageID)
 	}
 
-	// Get user info for the failure message
 	member, err := bot.GetChatMember(chatID, userID, nil)
 	var userName string
 	if err == nil {
@@ -1421,7 +1323,6 @@ func handleCaptchaTimeout(bot *gotgbot.Bot, chatID, userID int64, attemptID uint
 		log.Errorf("Failed to send captcha failure message: %v", err)
 	}
 
-	// Delete the failure message after 30 seconds
 	if sent != nil {
 		time.AfterFunc(30*time.Second, func() {
 			defer error_handling.RecoverFromPanic("captchaFailureMsgDelete", "captcha")
@@ -1432,9 +1333,6 @@ func handleCaptchaTimeout(bot *gotgbot.Bot, chatID, userID int64, attemptID uint
 	return true, true
 }
 
-// buildCaptchaFailureMessage builds the user-facing captcha failure message,
-// including stored pending-message counts when present. Extracted from
-// handleCaptchaTimeout to keep its cyclomatic complexity under the gocyclo limit.
 func buildCaptchaFailureMessage(tr *i18n.Translator, action string, userID int64, userName string, storedMsgCount int64) string {
 	if storedMsgCount > 0 {
 		var actionKey string
@@ -1465,8 +1363,6 @@ func buildCaptchaFailureMessage(tr *i18n.Translator, action string, userID int64
 	return fmt.Sprintf(template, formatting.MentionHtml(userID, userName))
 }
 
-// executeCaptchaFailureAction applies the configured captcha failure action
-// (kick/ban/mute) to a user. Extracted from handleCaptchaTimeout.
 func executeCaptchaFailureAction(bot *gotgbot.Bot, chatID, userID int64, action string) error {
 	switch action {
 	case "kick":
@@ -1508,8 +1404,6 @@ func restoreCaptchaPermissions(bot *gotgbot.Bot, chatID, userID int64) error {
 	return captcha.DeleteMutedUser(userID, chatID)
 }
 
-// captchaVerifyCallback handles captcha answer button clicks.
-// Verifies if the selected answer is correct and takes appropriate action.
 func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -1560,7 +1454,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		return err
 	}
 
-	// Check if this is the correct user
 	if user.Id != targetUserID {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("captcha_not_for_you")
@@ -1568,7 +1461,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		return err
 	}
 
-	// Get the captcha attempt and ensure IDs match
 	attempt, err := captcha.GetCaptchaAttempt(targetUserID, chat.Id)
 	if err != nil || attempt == nil {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -1598,16 +1490,12 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		return err
 	}
 
-	// Check if answer is correct
 	if selectedAnswer == attempt.Answer {
-		// Read the summary before the atomic delete; PostgreSQL cascades stored
-		// messages as soon as the attempt is claimed.
 		storedMessages, storedErr := captcha.GetStoredMessagesForAttempt(attempt.ID)
 		if storedErr != nil {
 			log.Warnf("[Captcha] Failed to read stored messages for attempt %d: %v", attempt.ID, storedErr)
 		}
 
-		// Claim the attempt first to prevent timeout workers from acting after success.
 		claimed, claimErr := captcha.CompleteCaptchaAttemptAtomic(
 			attempt.ID,
 			targetUserID,
@@ -1624,9 +1512,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		}
 
 		if err = restoreCaptchaPermissions(bot, chat.Id, targetUserID); err != nil {
-			// The attempt is already claimed (single-winner), so the timeout
-			// worker will not act. The user answered correctly, so do NOT apply
-			// the failure action. restoreCaptchaPermissions persists a retry.
 			log.Errorf("Failed to unmute user %d on verify: %v", targetUserID, err)
 			_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, attempt.MessageID)
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -1637,7 +1522,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 
 		if storedErr == nil && len(storedMessages) > 0 {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-			// Create a summary of what the user tried to send
 			var messageTypes []string
 			for _, msg := range storedMessages {
 				msgTypeStr := messageTypeToString(tr, msg.MessageType)
@@ -1652,12 +1536,10 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 					"types": strings.Join(messageTypes, ", "),
 				})
 
-			// Send summary message that auto-deletes after 30 seconds
 			summaryMsg, _ := helpers.SendMessageWithErrorHandling(bot, chat.Id, summaryText, &gotgbot.SendMessageOpts{
 				ParseMode: formatting.HTML,
 			})
 
-			// Auto-delete the summary after 30 seconds
 			if summaryMsg != nil {
 				time.AfterFunc(30*time.Second, func() {
 					defer error_handling.RecoverFromPanic("captchaSummaryMsgDelete", "captcha")
@@ -1666,16 +1548,13 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 			}
 		}
 
-		// Delete the captcha message
 		_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, attempt.MessageID)
 
-		// Send success message
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		msgTemplate, _ := tr.GetString("greetings_captcha_verified_success")
 		successMsg := fmt.Sprintf(msgTemplate, formatting.MentionHtml(targetUserID, user.FirstName))
 		sent, _ := helpers.SendMessageWithErrorHandling(bot, chat.Id, successMsg, &gotgbot.SendMessageOpts{ParseMode: formatting.HTML})
 
-		// Delete success message after 5 seconds
 		if sent != nil {
 			time.AfterFunc(5*time.Second, func() {
 				defer error_handling.RecoverFromPanic("captchaSuccessMsgDelete", "captcha")
@@ -1683,7 +1562,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 			})
 		}
 
-		// Send welcome message after successful verification
 		if err = SendWelcomeMessage(bot, ctx, targetUserID, user.FirstName); err != nil {
 			log.Errorf("Failed to send welcome message after captcha verification: %v", err)
 		}
@@ -1693,7 +1571,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		return err
 
 	} else {
-		// Wrong answer - increment attempts
 		attempt, err = captcha.IncrementCaptchaAttempts(
 			attempt.ID,
 			targetUserID,
@@ -1714,11 +1591,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 		}
 
 		if attempt.Attempts >= settings.MaxAttempts {
-			// Max attempts reached - execute failure action. handleCaptchaTimeout
-			// claims the attempt atomically; only this call wins it (another wrong
-			// answer or the timeout goroutine may have already claimed it). Send the
-			// final alert only when this call won, to avoid duplicate/contradictory
-			// "you were kicked/banned" popups.
 			claimed, applied := handleCaptchaTimeout(bot, chat.Id, targetUserID, attempt.ID, attempt.MessageID, settings.FailureAction)
 			if applied {
 				tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -1743,7 +1615,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 				_, err = query.Answer(bot, &gotgbot.AnswerCallbackQueryOpts{Text: text})
 				return err
 			}
-			// Another actor already claimed this attempt; answer quietly.
 			return ext.EndGroups
 		}
 
@@ -1758,9 +1629,6 @@ func (moduleStruct) captchaVerifyCallback(bot *gotgbot.Bot, ctx *ext.Context) er
 	}
 }
 
-// captchaRefreshCallback handles the refresh button for text captchas.
-// Generates a new captcha image when users can't read the current one.
-// Uses send-first pattern for atomic refresh to prevent stuck states.
 func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -1809,7 +1677,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Check if this is the correct user
 	if user.Id != targetUserID {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("captcha_not_for_you")
@@ -1817,7 +1684,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Cooldown: block rapid refreshes per user+chat
 	cooldownKey := fmt.Sprintf("alita:captcha:refresh:cooldown:%d:%d", chat.Id, targetUserID)
 	if m := cache.GetMarshal(); m != nil {
 		if exists, _ := m.Get(cache.Context, cooldownKey, new(bool)); exists != nil {
@@ -1828,7 +1694,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		}
 	}
 
-	// Get the existing attempt and verify attempt ID
 	attempt, err := captcha.GetCaptchaAttempt(targetUserID, chat.Id)
 	if err != nil || attempt == nil {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -1849,7 +1714,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Enforce per-attempt refresh cap
 	if attempt.RefreshCount >= captchaMaxRefreshes {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("captcha_refresh_limit_reached")
@@ -1857,17 +1721,13 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Store old message ID for cleanup later (send-first pattern)
 	oldMessageID := attempt.MessageID
 
-	// Determine current mode and whether image flow applies
 	settings, err := captcha.GetCaptchaSettings(chat.Id)
 	if err != nil {
 		log.Errorf("[Captcha] Failed to get settings for chat %d: %v", chat.Id, err)
-		// Fall through with nil settings — the nil guard below handles it safely
 	}
 
-	// Generate a new image/options based on current mode
 	var newAnswer string
 	var imageBytes []byte
 	var options []string
@@ -1884,12 +1744,10 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Build keyboard with new options and refresh button
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	refreshBtnText, _ := tr.GetString("captcha_refresh_button")
 	keyboard := buildCaptchaKeyboard(attempt.ID, targetUserID, attempt.RefreshCount+1, options, true, refreshBtnText)
 
-	// Build caption for the new message
 	remainingMinutes := int(time.Until(attempt.ExpiresAt).Minutes())
 	if remainingMinutes < 0 {
 		remainingMinutes = 0
@@ -1909,7 +1767,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		)
 	}
 
-	// Step 1: Send new message FIRST (before any deletion) - atomic refresh pattern
 	sent, sendErr := bot.SendPhoto(chat.Id, gotgbot.InputFileByReader("captcha.png", bytes.NewReader(imageBytes)), &gotgbot.SendPhotoOpts{
 		Caption:     caption,
 		ParseMode:   formatting.HTML,
@@ -1927,7 +1784,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return sendErr
 	}
 
-	// Step 2: Update DB with new answer and message ID
 	updated, err := captcha.UpdateCaptchaAttemptOnRefreshByID(
 		attempt.ID,
 		attempt.Answer,
@@ -1940,7 +1796,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		if err != nil {
 			log.Errorf("Failed to update captcha attempt on refresh: %v", err)
 		}
-		// Rollback: delete the new message since DB update failed
 		_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, sent.MessageId)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		key := "captcha_internal_update_error"
@@ -1952,14 +1807,12 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 		return err
 	}
 
-	// Step 3: Delete old message LAST (best effort).
 	if oldMessageID > 0 {
 		if err := helpers.DeleteMessageWithErrorHandling(bot, chat.Id, oldMessageID); err != nil {
 			log.Warnf("[CaptchaRefresh] Failed to delete old message %d in chat %d: %v", oldMessageID, chat.Id, err)
 		}
 	}
 
-	// Set cooldown
 	if m := cache.GetMarshal(); m != nil {
 		if err := m.Set(cache.Context, cooldownKey, true, store.WithExpiration(time.Duration(captchaRefreshCooldownS)*time.Second)); err != nil {
 			log.Errorf("[CaptchaRefresh] Failed to set refresh cooldown for chat %d user %d: %v", chat.Id, targetUserID, err)
@@ -1972,8 +1825,6 @@ func (moduleStruct) captchaRefreshCallback(bot *gotgbot.Bot, ctx *ext.Context) e
 	return err
 }
 
-// handlePendingCaptchaMessage intercepts messages from users with pending captcha verification.
-// Stores their messages and deletes them to prevent spam while they complete verification.
 func (moduleStruct) handlePendingCaptchaMessage(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -1982,12 +1833,10 @@ func (moduleStruct) handlePendingCaptchaMessage(bot *gotgbot.Bot, ctx *ext.Conte
 		return ext.ContinueGroups
 	}
 
-	// Skip if this is not a group chat
 	if chat.Type != "group" && chat.Type != "supergroup" {
 		return ext.ContinueGroups
 	}
 
-	// Skip if user is an admin
 	if chat_status.IsUserAdmin(bot, chat.Id, user.Id) {
 		return ext.ContinueGroups
 	}
@@ -1995,19 +1844,16 @@ func (moduleStruct) handlePendingCaptchaMessage(bot *gotgbot.Bot, ctx *ext.Conte
 		return ext.ContinueGroups
 	}
 
-	// Check if user has a pending captcha attempt
 	attempt, err := captcha.GetCaptchaAttempt(user.Id, chat.Id)
 	if err != nil {
 		log.Errorf("Failed to check captcha attempt for user %d: %v", user.Id, err)
 		return ext.ContinueGroups
 	}
 
-	// If no pending captcha, continue normal processing
 	if attempt == nil {
 		return ext.ContinueGroups
 	}
 
-	// Store the message content based on type
 	var messageType int
 	var content, fileID, caption string
 
@@ -2025,7 +1871,7 @@ func (moduleStruct) handlePendingCaptchaMessage(bot *gotgbot.Bot, ctx *ext.Conte
 	case msg.Photo != nil:
 		messageType = db.PHOTO
 		if len(msg.Photo) > 0 {
-			fileID = msg.Photo[len(msg.Photo)-1].FileId // Get highest resolution
+			fileID = msg.Photo[len(msg.Photo)-1].FileId
 		}
 		caption = msg.Caption
 	case msg.Audio != nil:
@@ -2044,21 +1890,17 @@ func (moduleStruct) handlePendingCaptchaMessage(bot *gotgbot.Bot, ctx *ext.Conte
 		messageType = db.VIDEO_NOTE
 		fileID = msg.VideoNote.FileId
 	default:
-		// Unknown message type, skip storing but still delete
 		messageType = db.TEXT
 		content = "[Unsupported message type]"
 	}
 
-	// Store the message
 	err = captcha.StoreMessageForCaptcha(user.Id, chat.Id, attempt.ID, messageType, content, fileID, caption)
 	if err != nil {
 		log.Errorf("Failed to store message for user %d with pending captcha: %v", user.Id, err)
 	}
 
-	// Delete the message to prevent spam
 	_ = helpers.DeleteMessageWithErrorHandling(bot, chat.Id, msg.MessageId)
 
-	// End processing - don't let this message continue through other handlers
 	return ext.EndGroups
 }
 
@@ -2071,7 +1913,6 @@ func cleanupExpiredCaptchaAttempts(ctx context.Context, bot *gotgbot.Bot) error 
 	default:
 	}
 
-	// Get expired attempts with message IDs before cleanup
 	attempts, err := captcha.GetExpiredCaptchaAttempts()
 	if err != nil {
 		return err
@@ -2139,14 +1980,12 @@ func unmuteExpiredCaptchaUsers(bot *gotgbot.Bot) {
 		err := unmuteCaptchaUser(bot, user.ChatID, user.UserID)
 		if err != nil {
 			if isPermanentUnmuteError(err) {
-				// Permanent error - user left, chat deleted, etc. - remove from DB
 				log.Infof("[CaptchaUnmute] User %d no longer in chat %d, removing from muted list: %v",
 					user.UserID, user.ChatID, err)
 				if _, deleteErr := captcha.DeleteMutedUserIfUnchanged(user.ID, user.UnmuteAt); deleteErr != nil {
 					log.Errorf("[CaptchaUnmute] Failed to delete permanent schedule %d: %v", user.ID, deleteErr)
 				}
 			} else {
-				// Transient error - will retry on next tick
 				log.Warnf("[CaptchaUnmute] Failed to unmute user %d in chat %d (will retry): %v",
 					user.UserID, user.ChatID, err)
 			}
@@ -2163,8 +2002,6 @@ func unmuteExpiredCaptchaUsers(bot *gotgbot.Bot) {
 			continue
 		}
 
-		// A concurrent captcha mute replaced the schedule while Telegram was
-		// unmuting. Re-apply the mute so the newer schedule remains effective.
 		current, currentErr := captcha.GetMutedUser(user.UserID, user.ChatID)
 		if currentErr != nil {
 			log.Errorf("[CaptchaUnmute] Failed to reload schedule for user %d: %v", user.UserID, currentErr)
@@ -2207,25 +2044,20 @@ func startCaptchaWorkers(bot *gotgbot.Bot) {
 	})
 }
 
-// LoadCaptcha registers all captcha module handlers with the dispatcher.
 func LoadCaptcha(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[captchaModule.moduleName] = true
 
-	// Message handler for users with pending captcha (high priority to intercept early)
 	dispatcher.AddHandlerToGroup(handlers.NewMessage(nil, captchaModule.handlePendingCaptchaMessage), -10)
 
-	// Commands
 	dispatcher.AddHandler(handlers.NewCommand("captcha", captchaModule.captchaCommand))
 	dispatcher.AddHandler(handlers.NewCommand("captchamode", captchaModule.captchaModeCommand))
 	dispatcher.AddHandler(handlers.NewCommand("captchatime", captchaModule.captchaTimeCommand))
 	dispatcher.AddHandler(handlers.NewCommand("captchaaction", captchaModule.captchaActionCommand))
 	dispatcher.AddHandler(handlers.NewCommand("captchamaxattempts", captchaModule.captchaMaxAttemptsCommand))
 
-	// Admin commands for managing stored messages
 	dispatcher.AddHandler(handlers.NewCommand("captchapending", captchaModule.viewPendingMessages))
 	dispatcher.AddHandler(handlers.NewCommand("captchaclear", captchaModule.clearPendingMessages))
 
-	// Callbacks
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("captcha_verify"), captchaModule.captchaVerifyCallback))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("captcha_refresh"), captchaModule.captchaRefreshCallback))
 }

--- a/alita/modules/captcha_math_image_test.go
+++ b/alita/modules/captcha_math_image_test.go
@@ -25,8 +25,6 @@ message_type_video_note: "video note"
 message_type_unknown: "unknown"
 `
 
-// ---- isPermanentTelegramError ----
-
 func TestIsPermanentTelegramError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -56,8 +54,6 @@ func TestIsPermanentTelegramError(t *testing.T) {
 		})
 	}
 }
-
-// ---- isPermanentUnmuteError ----
 
 func TestIsPermanentUnmuteError(t *testing.T) {
 	tests := []struct {
@@ -91,8 +87,6 @@ func TestIsPermanentUnmuteError(t *testing.T) {
 	}
 }
 
-// ---- messageTypeToString ----
-
 func TestMessageTypeToString(t *testing.T) {
 	tr, err := i18n.NewTestTranslator(mockMessageTypesYAML)
 	if err != nil {
@@ -125,8 +119,6 @@ func TestMessageTypeToString(t *testing.T) {
 		})
 	}
 }
-
-// ---- secureIntn ----
 
 func TestSecureIntn(t *testing.T) {
 	t.Run("max zero returns zero", func(t *testing.T) {
@@ -175,8 +167,6 @@ func TestSecureIntn(t *testing.T) {
 	})
 }
 
-// ---- secureShuffleStrings ----
-
 func TestSecureShuffleStrings(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
 		empty := []string{}
@@ -216,8 +206,6 @@ func TestSecureShuffleStrings(t *testing.T) {
 		}
 	})
 }
-
-// ---- generateMathCaptcha ----
 
 func TestGenerateMathCaptcha(t *testing.T) {
 	for i := 0; i < 20; i++ {
@@ -306,8 +294,6 @@ func assertCaptchaChallenge(t *testing.T, answer string, imageBytes []byte, opti
 	}
 }
 
-// ---- noopCaptchaStore ----
-
 func TestNoopCaptchaStore(t *testing.T) {
 	store := noopCaptchaStore{}
 
@@ -336,8 +322,6 @@ func TestNoopCaptchaStore(t *testing.T) {
 	})
 }
 
-// ---- newMathImageCaptchaDriver ----
-
 func TestNewMathImageCaptchaDriver(t *testing.T) {
 	const question = "12 + 34"
 
@@ -359,8 +343,6 @@ func TestNewMathImageCaptchaDriver(t *testing.T) {
 		t.Fatalf("expected Width=240, got %d", driver.Width)
 	}
 }
-
-// ---- formatMathQuestion ----
 
 func TestFormatMathQuestion(t *testing.T) {
 	tests := []struct {
@@ -384,8 +366,6 @@ func TestFormatMathQuestion(t *testing.T) {
 		})
 	}
 }
-
-// ---- fixedStringCaptchaDriver.GenerateIdQuestionAnswer ----
 
 func TestFixedStringCaptchaDriverGenerateIdQuestionAnswer(t *testing.T) {
 	const question = "12 + 34"
@@ -458,12 +438,12 @@ func TestParseInt64ForLargeUserIDs(t *testing.T) {
 		},
 		{
 			name:    "large user ID exceeding 32-bit max",
-			userID:  "2147483648", // 2^31
+			userID:  "2147483648",
 			wantErr: false,
 		},
 		{
 			name:    "very large user ID near 64-bit range",
-			userID:  "9223372036854775807", // math.MaxInt64
+			userID:  "9223372036854775807",
 			wantErr: false,
 		},
 		{
@@ -487,7 +467,6 @@ func TestParseInt64ForLargeUserIDs(t *testing.T) {
 				t.Fatalf("failed to parse userID %s: %v", tc.userID, err)
 			}
 
-			// Verify the parsed value matches the original
 			if strconv.FormatInt(parsedID, 10) != tc.userID {
 				t.Fatalf("round-trip failed: got %d, want %s", parsedID, tc.userID)
 			}

--- a/alita/modules/filters.go
+++ b/alita/modules/filters.go
@@ -34,12 +34,10 @@ var filtersModule = moduleStruct{
 	handlerGroup: 9,
 }
 
-// filterOverwriteCacheKey generates a cache key for filter overwrite confirmations.
 func filterOverwriteCacheKey(token string) string {
 	return overwriteCacheKey("filter", token)
 }
 
-// setFilterOverwriteCache stores filter overwrite data in cache with TTL.
 func setFilterOverwriteCache(token string, data overwriteFilter) error {
 	return setOverwriteCache(filterOverwriteCacheKey(token), data)
 }
@@ -48,20 +46,10 @@ func consumeFilterOverwriteCache(token string) (*overwriteFilter, error) {
 	return consumeOverwriteCache[overwriteFilter](filterOverwriteCacheKey(token))
 }
 
-// deleteFilterOverwriteCache removes filter overwrite data from cache.
 func deleteFilterOverwriteCache(token string) {
 	deleteOverwriteCache(filterOverwriteCacheKey(token))
 }
 
-/*
-	Used to add a filter to a specific keyword in chat!
-
-# Connection - true, true
-
-Only admin can add new filters in the chat
-*/
-// addFilter creates a new filter with a keyword trigger and response content.
-// Only admins can add filters. Supports text, media, and buttons with a limit of 150 filters per chat.
 //nolint:dupl // addFilter shares validation logic with notes module by design
 func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
@@ -70,7 +58,6 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}()
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -83,7 +70,6 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	args := ctx.Args()
 
-	// check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -133,9 +119,8 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	filterWord = strings.ToLower(filterWord) // convert string to it's lower form
+	filterWord = strings.ToLower(filterWord)
 
-	// Validate keyword length - max 100 characters
 	if len([]rune(filterWord)) > 100 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("filters_keyword_too_long")
@@ -157,7 +142,6 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 			return ext.EndGroups
 		}
 
-		// Store in cache instead of in-memory map
 		err := setFilterOverwriteCache(token, overwriteFilter{
 			overwriteBase: overwriteBase{
 				ChatID:   chat.Id,
@@ -215,7 +199,6 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Perform DB operation synchronously to ensure completion before confirmation
 	if err := db_filters.AddFilter(chat.Id, filterWord, text, fileid, buttons, dataType); err != nil {
 		log.Errorf("[Filters] AddFilter failed for chat %d: %v", chat.Id, err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -235,17 +218,7 @@ func (m moduleStruct) addFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to remove a filter to a specific keyword in chat!
-
-# Connection - true, true
-
-Only admin can remove filters in the chat
-*/
-// rmFilter removes an existing filter by its keyword trigger.
-// Only admins can remove filters. Requires the exact filter keyword as argument.
 func (moduleStruct) rmFilter(b *gotgbot.Bot, ctx *ext.Context) error {
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -259,7 +232,6 @@ func (moduleStruct) rmFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	args := ctx.Args()[1:]
 
-	// check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -286,7 +258,6 @@ func (moduleStruct) rmFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 				return err
 			}
 		} else {
-			// Perform DB operation synchronously to ensure completion before confirmation
 			if err := db_filters.RemoveFilter(chat.Id, strings.ToLower(filterWord)); err != nil {
 				log.Errorf("[Filters] RemoveFilter failed for chat %d: %v", chat.Id, err)
 				errText, _ := tr.GetString("common_settings_save_failed")
@@ -304,22 +275,11 @@ func (moduleStruct) rmFilter(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to view all filters in the chat!
-
-# Connection - false, true
-
-Any user can view users in a chat
-*/
-// filtersList displays all active filter keywords in the current chat.
-// Any user can view the list of available filters with their trigger keywords.
 func (moduleStruct) filtersList(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "filters") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -367,13 +327,6 @@ func (moduleStruct) filtersList(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to remove all filters from the current chat
-
-Only owner can remove all filters from the chat
-*/
-// rmAllFilters removes all filters from the current chat with confirmation.
-// Only chat owners can use this command. Shows confirmation buttons before deletion.
 //nolint:dupl // rmAllFilters shares confirmation pattern with notes module by design
 func (moduleStruct) rmAllFilters(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
@@ -428,9 +381,6 @@ func (moduleStruct) rmAllFilters(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// CallbackQuery handler for rmAllFilters
-// filtersButtonHandler handles callback queries for filter-related button interactions.
-// Processes confirmation dialogs for removing all filters from a chat.
 func (moduleStruct) filtersButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -442,7 +392,6 @@ func (moduleStruct) filtersButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error
 		return ext.EndGroups
 	}
 
-	// permission checks
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 		return ext.EndGroups
@@ -499,9 +448,6 @@ func (moduleStruct) filtersButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	return ext.EndGroups
 }
 
-// CallbackQuery handler for filters_overwite. query
-// filterOverWriteHandler handles callback queries for filter overwrite confirmations.
-// Processes admin decisions when attempting to overwrite existing filter keywords.
 func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -513,7 +459,6 @@ func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) e
 		return ext.EndGroups
 	}
 
-	// permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -531,18 +476,15 @@ func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) e
 	}
 	var helpText string
 
-	// Handle cancel — atomically consume and validate
 	if action == "cancel" {
 		if token != "" {
 			if data, err := consumeFilterOverwriteCache(token); err == nil {
 				if data.UserID != 0 && data.UserID != user.Id {
-					// Wrong user consumed another user's token — already deleted atomically
 					helpText, _ = tr.GetString("filters_overwrite_expired")
 					if query.Message != nil {
 						_, _, _ = query.Message.EditText(b, &gotgbot.EditMessageTextOpts{Text: helpText})
 					}
 					_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{Text: helpText})
-					// Re-store is not attempted; token is already consumed (one-time)
 					return ext.EndGroups
 				}
 				if data.ChatID != 0 && data.ChatID != chat.Id {
@@ -569,7 +511,6 @@ func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) e
 		return ext.EndGroups
 	}
 
-	// Atomically consume — no prior get check (TOCTOU fix)
 	filterData, err := consumeFilterOverwriteCache(token)
 	if err != nil || filterData == nil {
 		log.Debugf("[Filters] Failed to retrieve overwrite data from cache: %v", err)
@@ -636,15 +577,7 @@ func (m moduleStruct) filterOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) e
 	return ext.EndGroups
 }
 
-/*
-	Watchers for filter
-
-Replies with appropriate data to the filter.
-*/
-// filtersWatcher monitors incoming messages for filter keyword matches.
-// Automatically responds with filter content when keywords are detected in messages.
 func (moduleStruct) filtersWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
-	// Defensive nil check for EffectiveSender to prevent panics on channel messages
 	if ctx == nil || ctx.EffectiveSender == nil {
 		return ext.ContinueGroups
 	}
@@ -660,7 +593,6 @@ func (moduleStruct) filtersWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Use optimized cached query to fetch all filters at once (no N+1 query)
 	allFilters, err := db_filters.GetChatFiltersCached(chat.Id)
 	if err != nil {
 		log.WithField("chatId", chat.Id).WithError(err).Error("Failed to get chat filters")
@@ -671,7 +603,6 @@ func (moduleStruct) filtersWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Build keyword list for Aho-Corasick matching
 	filterKeys := make([]string, len(allFilters))
 	filterMap := make(map[string]*db.ChatFilters, len(allFilters))
 	for i, filter := range allFilters {
@@ -679,41 +610,33 @@ func (moduleStruct) filtersWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		filterMap[filter.KeyWord] = filter
 	}
 
-	// Use Aho-Corasick for efficient multi-pattern matching
 	cache := keyword_matcher.GetNamedCache("filters")
 	matcher := cache.GetOrCreateMatcher(chat.Id, filterKeys)
 
-	// Find first matching filter using optimized path
 	firstPattern, found := matcher.FirstMatch(matchText)
 	if !found {
 		return ext.ContinueGroups
 	}
 	i := firstPattern
 
-	// Check for noformat pattern using simpler string matching
 	noformatPattern := i + " noformat"
 	noformatMatch := strings.Contains(strings.ToLower(matchText), strings.ToLower(noformatPattern))
 
-	// Get filter data from pre-loaded map (no additional DB query)
 	filtData, exists := filterMap[i]
 	if !exists {
 		return ext.ContinueGroups
 	}
 
 	if noformatMatch {
-		// check if user is admin or not
 		if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 			chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 			return ext.EndGroups
 		}
 
-		// Reverse notedata
 		filtData.FilterReply = formatting.ReverseHTML2MD(filtData.FilterReply)
 
-		// show the buttons back as text
 		filtData.FilterReply += content.RevertButtons(filtData.Buttons)
 
-		// using true as last argument to prevent the message from being formatted
 		var err error
 		_, err = media.Send(b, media.Content{
 			Text:    filtData.FilterReply,
@@ -746,8 +669,6 @@ func (moduleStruct) filtersWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// LoadFilters registers all filter-related handlers with the dispatcher.
-// Sets up commands for managing filters and the message watcher for automatic responses.
 func LoadFilters(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[filtersModule.moduleName] = true
 
@@ -762,7 +683,7 @@ func LoadFilters(dispatcher *ext.Dispatcher) {
 				CallbackData: encodeCallbackData("helpq", map[string]string{"m": "Formatting"}),
 			},
 		},
-	} // Adds Formatting kb button to Filters Menu
+	}
 	dispatcher.AddHandler(handlers.NewCommand("filter", filtersModule.addFilter))
 	dispatcher.AddHandler(handlers.NewCommand("addfilter", filtersModule.addFilter))
 	dispatcher.AddHandler(handlers.NewCommand("stop", filtersModule.rmFilter))

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -32,8 +32,7 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/media"
 )
 
-// Concurrency limit for processing multiple new members
-const maxConcurrentMemberProcessing = 5 // Maximum concurrent member welcome/captcha processing
+const maxConcurrentMemberProcessing = 5
 
 var recentJoinProcessTTL = 5 * time.Second
 
@@ -92,11 +91,9 @@ func claimRecentJoinProcessing(chatID, userID int64) bool {
 			TTL:  recentJoinProcessTTL,
 		}).Result()
 		if err == nil {
-			// Key did not exist; we set it — claim is ours.
 			return true
 		}
 		if errors.Is(err, redis.Nil) {
-			// Key already existed; another instance/goroutine claimed this join.
 			return false
 		}
 		// Genuine Redis error — fail closed to avoid double welcome/captcha in multi-instance.
@@ -115,13 +112,11 @@ func claimRecentJoinProcessing(chatID, userID int64) bool {
 		if c, ok := actual.(joinClaim); ok && now.Before(c.exp) {
 			return false
 		}
-		// expired — try to take over atomically so only one caller wins
 		newClaim = joinClaim{exp: time.Now().Add(recentJoinProcessTTL)}
 		if recentJoinProcessing.CompareAndSwap(key, actual, newClaim) {
 			expireRecentJoinClaim(key, newClaim)
 			return true
 		}
-		// CAS lost to a concurrent takeover — re-evaluate fresh state
 		now = time.Now()
 	}
 }
@@ -144,13 +139,9 @@ func clearRecentJoinProcessing(chatID, userID int64) {
 	recentJoinProcessing.Delete(key)
 }
 
-// displayGreeting is a shared helper function that handles both welcome and goodbye greeting display/toggling.
-// It consolidates common logic between welcome() and goodbye() commands.
-//
 //nolint:dupl // displayGreeting has symmetric welcome/goodbye logic by design
 func (moduleStruct) displayGreeting(bot *gotgbot.Bot, ctx *ext.Context, config greetingConfig) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -169,7 +160,6 @@ func (moduleStruct) displayGreeting(bot *gotgbot.Bot, ctx *ext.Context, config g
 		noformat := len(args) > 0 && strings.ToLower(args[0]) == "noformat"
 		greetPrefs := greetings.GetGreetingSettings(chat.Id)
 
-		// Get the appropriate settings based on greeting type
 		var buttons []db.Button
 		var fileID string
 		var greetingDataType int
@@ -302,21 +292,14 @@ func (moduleStruct) displayGreeting(bot *gotgbot.Bot, ctx *ext.Context, config g
 	return ext.EndGroups
 }
 
-// welcome manages welcome message settings and displays current welcome configuration.
-// Admins can toggle welcome messages on/off or view current settings with 'noformat' option.
-//
 //nolint:dupl // welcome delegates to displayGreeting with different config
 func (m moduleStruct) welcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.displayGreeting(bot, ctx, welcomeConfig)
 }
 
-// setWelcome allows admins to set a custom welcome message for new chat members.
-// Supports text, media, and inline buttons with formatting and placeholder variables.
-//
 //nolint:dupl // setWelcome is similar to setGoodbye but uses different DB calls and translation keys
 func (moduleStruct) setWelcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -328,7 +311,6 @@ func (moduleStruct) setWelcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// check permission
 	if !chat_status.CanUserChangeInfo(bot, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -362,13 +344,9 @@ func (moduleStruct) setWelcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetGreeting is a shared helper for resetting welcome or goodbye messages to defaults.
-// It consolidates the common logic between resetWelcome and resetGoodbye.
-//
 //nolint:dupl // resetGreeting has symmetric welcome/goodbye logic by design
 func (moduleStruct) resetGreeting(bot *gotgbot.Bot, ctx *ext.Context, isWelcome bool) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -379,13 +357,11 @@ func (moduleStruct) resetGreeting(bot *gotgbot.Bot, ctx *ext.Context, isWelcome 
 	if user == nil {
 		return ext.EndGroups
 	}
-	// check permission
 	if !chat_status.CanUserChangeInfo(bot, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
 	}
 
-	// Reset greeting text synchronously to ensure DB write completes before sending success
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if isWelcome {
 		if dbErr := greetings.SetWelcomeText(chat.Id, db.DefaultWelcome, "", nil, db.TEXT); dbErr != nil {
@@ -416,27 +392,18 @@ func (moduleStruct) resetGreeting(bot *gotgbot.Bot, ctx *ext.Context, isWelcome 
 	return ext.EndGroups
 }
 
-// resetWelcome resets the welcome message back to the default bot welcome message.
-// Only admins can use this command to restore the original welcome text.
 func (m moduleStruct) resetWelcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.resetGreeting(bot, ctx, true)
 }
 
-// goodbye manages goodbye message settings and displays current goodbye configuration.
-// Admins can toggle goodbye messages on/off or view current settings with 'noformat' option.
-//
 //nolint:dupl // goodbye delegates to displayGreeting with different config
 func (m moduleStruct) goodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.displayGreeting(bot, ctx, goodbyeConfig)
 }
 
-// setGoodbye allows admins to set a custom goodbye message for members leaving the chat.
-// Supports text, media, and inline buttons with formatting and placeholder variables.
-//
 //nolint:dupl // setGoodbye is similar to setWelcome but uses different DB calls and translation keys
 func (moduleStruct) setGoodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -447,7 +414,6 @@ func (moduleStruct) setGoodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	if user == nil {
 		return ext.EndGroups
 	}
-	// check permission
 	if !chat_status.CanUserChangeInfo(bot, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -480,34 +446,20 @@ func (moduleStruct) setGoodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetGoodbye resets the goodbye message back to the default bot goodbye message.
-// Only admins can use this command to restore the original goodbye text.
 func (m moduleStruct) resetGoodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.resetGreeting(bot, ctx, false)
 }
 
-// greetingToggleConfig captures the per-command differences between the four
-// near-identical on/off/show greeting toggle handlers (cleanWelcome, cleanGoodbye,
-// delJoined, autoApprove), so they can share a single skeleton in greetingToggle.
 type greetingToggleConfig struct {
-	// getPref returns the current setting; for clean* it also emits the
-	// "settings nil" warn log and returns false in that case.
-	getPref func(chatID int64) bool
-	// setPref persists the new setting.
-	setPref func(chatID int64, val bool) error
-	// saveErrLog is the setter name used in the DB-error log line.
-	saveErrLog string
-	// connectBotAdmin is the botAdmin arg passed to IsUserConnected.
-	connectBotAdmin bool
-	// Message keys for each branch.
-	showEnabled  string
-	showDisabled string
-	setEnabled   string
-	setDisabled  string
-	invalid      string
-	// useMarkdownOnEnabled renders the enabled "show" branch with Smarkdown
-	// instead of Shtml (delJoined/autoApprove quirk); disabled show + all other
-	// branches always use Shtml.
+	getPref              func(chatID int64) bool
+	setPref              func(chatID int64, val bool) error
+	saveErrLog           string
+	connectBotAdmin      bool
+	showEnabled          string
+	showDisabled         string
+	setEnabled           string
+	setDisabled          string
+	invalid              string
 	useMarkdownOnEnabled bool
 }
 
@@ -581,11 +533,8 @@ var autoApproveToggleConfig = greetingToggleConfig{
 	useMarkdownOnEnabled: true,
 }
 
-// greetingToggle is the shared skeleton for the on/off/show greeting toggle
-// commands. Per-command differences are supplied via cfg.
 func (moduleStruct) greetingToggle(bot *gotgbot.Bot, ctx *ext.Context, cfg greetingToggleConfig) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, cfg.connectBotAdmin)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -598,7 +547,6 @@ func (moduleStruct) greetingToggle(bot *gotgbot.Bot, ctx *ext.Context, cfg greet
 	if user == nil {
 		return ext.EndGroups
 	}
-	// check permission
 	if !chat_status.CanUserChangeInfo(bot, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(bot).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -656,26 +604,19 @@ func (moduleStruct) greetingToggle(bot *gotgbot.Bot, ctx *ext.Context, cfg greet
 	return ext.EndGroups
 }
 
-// cleanWelcome toggles automatic deletion of old welcome messages.
-// Admins can enable/disable cleanup or check current setting. Helps keep chats tidy.
 func (m moduleStruct) cleanWelcome(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.greetingToggle(bot, ctx, cleanWelcomeToggleConfig)
 }
 
-// cleanGoodbye toggles automatic deletion of old goodbye messages.
-// Admins can enable/disable cleanup or check current setting. Helps keep chats tidy.
 func (m moduleStruct) cleanGoodbye(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.greetingToggle(bot, ctx, cleanGoodbyeToggleConfig)
 }
 
-// delJoined toggles automatic deletion of service messages when users join the chat.
-// Admins can enable/disable cleanup of 'user joined' messages or check current setting.
 func (m moduleStruct) delJoined(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.greetingToggle(bot, ctx, delJoinedToggleConfig)
 }
 
 // SendWelcomeMessage sends the configured welcome message for a user in a chat.
-// This is extracted as a separate function to be reusable after captcha verification.
 func SendWelcomeMessage(bot *gotgbot.Bot, ctx *ext.Context, userID int64, firstName string) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -685,14 +626,12 @@ func SendWelcomeMessage(bot *gotgbot.Bot, ctx *ext.Context, userID int64, firstN
 	chat := ctx.EffectiveChat
 	greetPrefs := greetings.GetGreetingSettings(chat.Id)
 
-	// Nil check for WelcomeSettings
 	if greetPrefs.WelcomeSettings == nil {
 		log.Warnf("[Greetings][SendWelcomeMessage] WelcomeSettings is nil for chat %d, skipping welcome message", chat.Id)
 		return nil
 	}
 
 	if greetPrefs.WelcomeSettings.ShouldWelcome {
-		// Create a user object for formatting
 		user := &gotgbot.User{
 			Id:        userID,
 			FirstName: firstName,
@@ -725,8 +664,6 @@ func SendWelcomeMessage(bot *gotgbot.Bot, ctx *ext.Context, userID int64, firstN
 	return nil
 }
 
-// newMember handles welcome messages when new members join the chat.
-// Automatically sends welcome message and manages cleanup based on chat settings.
 func (moduleStruct) newMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	newMember := ctx.ChatMember.NewChatMember.MergeChatMember().User
@@ -746,26 +683,21 @@ func (moduleStruct) newMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// leftMember handles goodbye messages when members leave the chat.
-// Automatically sends goodbye message and manages cleanup based on chat settings.
 func (moduleStruct) leftMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	leftMember := ctx.ChatMember.OldChatMember.MergeChatMember().User
 	greetPrefs := greetings.GetGreetingSettings(chat.Id)
 
-	// when bot leaves stop all updates of the groups
 	if leftMember.Id == bot.Id {
 		return ext.EndGroups
 	}
 
 	clearRecentJoinProcessing(chat.Id, leftMember.Id)
 
-	// Clean up any pending captcha for the leaving user
 	captchaAttempt, err := captcha.GetCaptchaAttemptIncludingExpired(leftMember.Id, chat.Id)
 	if err != nil {
 		log.Errorf("Failed to get captcha attempt for leaving user %d: %v", leftMember.Id, err)
 	} else if captchaAttempt != nil {
-		// Delete the captcha message if it exists
 		if captchaAttempt.MessageID > 0 {
 			if delErr := helpers.DeleteMessageWithErrorHandling(bot, chat.Id, captchaAttempt.MessageID); delErr != nil {
 				log.Debugf("Failed to delete captcha message for leaving user %d: %v", leftMember.Id, delErr)
@@ -779,7 +711,6 @@ func (moduleStruct) leftMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 		log.Errorf("Failed to delete scheduled captcha unmute for leaving user %d: %v", leftMember.Id, err)
 	}
 
-	// Nil check for GoodbyeSettings
 	if greetPrefs.GoodbyeSettings == nil {
 		log.Warnf("[Greetings][leftMember] GoodbyeSettings is nil for chat %d, skipping goodbye message", chat.Id)
 		return ext.EndGroups
@@ -809,7 +740,6 @@ func (moduleStruct) leftMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// processSingleNewMember handles a single new member joining (mute, captcha, welcome).
 func processSingleNewMember(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64, newMember gotgbot.User, captchaEnabled bool) error {
 	if newMember.Id == bot.Id {
 		return nil
@@ -827,7 +757,6 @@ func processSingleNewMember(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64
 		}
 		if err := SendCaptcha(bot, &ctxCopy, newMember.Id, newMember.FirstName); err != nil {
 			if errors.Is(err, errCaptchaDisabled) {
-				// captcha turned off mid-flight — welcome normally
 			} else {
 				log.Errorf("Failed to send captcha to user %d: %v", newMember.Id, err)
 				return err
@@ -843,9 +772,6 @@ func processSingleNewMember(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64
 	return SendWelcomeMessage(bot, &ctxCopy, newMember.Id, newMember.FirstName)
 }
 
-// cleanService automatically deletes service messages about members joining/leaving.
-// Runs when service messages are posted and deletes them if cleanup is enabled.
-// Also handles captcha for users joining via invite links or being added.
 func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -858,29 +784,23 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Handle new members joining via invite links or being added
 	if msg.NewChatMembers != nil {
 		captchaSettings, err := captcha.GetCaptchaSettings(chat.Id)
 		if err != nil {
 			log.Errorf("[Greetings][cleanService] Failed to get captcha settings for chat %d: %v", chat.Id, err)
-			// Default to disabled captcha on error
 			captchaSettings = &db.CaptchaSettings{Enabled: false}
 		}
 		captchaEnabled := captchaSettings != nil && captchaSettings.Enabled
 
-		// Capture chat identity and thread before fanning out
 		var threadID int64
 		if msg != nil {
 			threadID = msg.MessageThreadId
 		}
 		chatCopyBase := *chat
 
-		// Process multiple members concurrently for better performance
 		numMembers := len(msg.NewChatMembers)
 		if numMembers > 1 {
-			// Use goroutines for multiple members
 			var wg sync.WaitGroup
-			// Limit concurrent processing to prevent overwhelming the API
 			sem := make(chan struct{}, maxConcurrentMemberProcessing)
 
 			for _, newMember := range msg.NewChatMembers {
@@ -889,14 +809,13 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 				}
 
 				wg.Add(1)
-				sem <- struct{}{} // Acquire semaphore
+				sem <- struct{}{}
 
 				go func(member gotgbot.User) {
 					defer wg.Done()
 					defer func() { <-sem }()
-					defer error_handling.RecoverFromPanic("processNewMember", "Greetings") // Release semaphore
+					defer error_handling.RecoverFromPanic("processNewMember", "Greetings")
 
-					// Local chat copy per goroutine so we don't share pointer
 					chatCopy := chatCopyBase
 					if err := processSingleNewMember(bot, &chatCopy, threadID, member, captchaEnabled); err != nil {
 						log.Error(err)
@@ -906,7 +825,6 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 
 			wg.Wait()
 		} else if numMembers == 1 {
-			// For single member, process directly without goroutine (copy for consistency)
 			chatCopy := chatCopyBase
 			if err := processSingleNewMember(bot, &chatCopy, threadID, msg.NewChatMembers[0], captchaEnabled); err != nil {
 				log.Error(err)
@@ -926,8 +844,6 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// pendingJoins handles chat join requests and creates approval buttons for admins.
-// Auto-approves if enabled, otherwise presents approve/decline/ban options to admins.
 func (m moduleStruct) pendingJoins(bot *gotgbot.Bot, ctx *ext.Context) error {
 	defer error_handling.RecoverFromPanic("Greetings", "pendingJoins")
 
@@ -937,7 +853,6 @@ func (m moduleStruct) pendingJoins(bot *gotgbot.Bot, ctx *ext.Context) error {
 
 	if !m.loadPendingJoins(chat.Id, user.Id) {
 
-		// auto approve join requests
 		if greetings.GetGreetingSettings(chat.Id).ShouldAutoApprove {
 			if _, err := bot.ApproveChatJoinRequest(chat.Id, user.Id, nil); err != nil {
 				if helpers.IsExpectedTelegramError(err) {
@@ -1000,9 +915,6 @@ func (m moduleStruct) pendingJoins(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// joinRequestHandler processes admin responses to join request approval buttons.
-// Handles accept, decline, and ban actions for pending chat join requests.
-//
 //nolint:gocyclo // Validation and one-shot action handling stay together to prevent partial flows.
 func (m moduleStruct) joinRequestHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer error_handling.RecoverFromPanic("Greetings", "joinRequestHandler")
@@ -1018,7 +930,6 @@ func (m moduleStruct) joinRequestHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	chat := ctx.EffectiveChat
 	msg := query.Message
 
-	// permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -1134,8 +1045,6 @@ func (m moduleStruct) joinRequestHandler(b *gotgbot.Bot, ctx *ext.Context) error
 	return ext.EndGroups
 }
 
-// autoApprove toggles automatic approval of chat join requests.
-// Admins can enable/disable auto-approval or check current setting for new join requests.
 func (m moduleStruct) autoApprove(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return m.greetingToggle(bot, ctx, autoApproveToggleConfig)
 }
@@ -1144,8 +1053,6 @@ func pendingJoinsKey(chatId, userId int64) string {
 	return fmt.Sprintf("alita:pendingJoins:%d:%d", chatId, userId)
 }
 
-// loadPendingJoins checks if a join request notification has already been sent for a user.
-// Prevents duplicate join request messages by checking cache for recent requests.
 func (moduleStruct) loadPendingJoins(chatId, userId int64) bool {
 	m := cache.GetMarshal()
 	if m == nil {
@@ -1155,15 +1062,12 @@ func (moduleStruct) loadPendingJoins(chatId, userId int64) bool {
 	if err != nil || alreadyAsked == nil {
 		return false
 	}
-	// Safe type assertion
 	if boolVal, ok := alreadyAsked.(*bool); ok && boolVal != nil {
 		return *boolVal
 	}
 	return false
 }
 
-// setPendingJoins marks a join request as processed in cache with expiration.
-// Stores request info for 5 minutes to prevent duplicate approval notifications.
 func (moduleStruct) setPendingJoins(chatId, userId int64) {
 	m := cache.GetMarshal()
 	if m == nil {
@@ -1178,12 +1082,9 @@ func (moduleStruct) clearPendingJoins(chatId, userId int64) {
 	}
 }
 
-// LoadGreetings registers all greeting-related handlers with the dispatcher.
-// Sets up welcome/goodbye messages, join requests, and service message cleanup.
 func LoadGreetings(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[greetingsModule.moduleName] = true
 
-	// Adds Formatting kb button to Greetings Menu
 	DefaultHelpRegistry().helpableKb[greetingsModule.moduleName] = [][]gotgbot.InlineKeyboardButton{
 		{
 			{
@@ -1193,14 +1094,12 @@ func LoadGreetings(dispatcher *ext.Dispatcher) {
 		},
 	}
 
-	// this is used when user join, and creates a join request
 	dispatcher.AddHandler(
 		handlers.NewChatJoinRequest(
 			chatjoinrequest.All, greetingsModule.pendingJoins,
 		),
 	)
 
-	// this is for chat member joined the chat
 	dispatcher.AddHandler(
 		handlers.NewChatMember(
 			func(u *gotgbot.ChatMemberUpdated) bool {
@@ -1211,7 +1110,6 @@ func LoadGreetings(dispatcher *ext.Dispatcher) {
 		),
 	)
 
-	// this is for chat member left the chat
 	dispatcher.AddHandler(
 		handlers.NewChatMember(
 			func(u *gotgbot.ChatMemberUpdated) bool {
@@ -1222,7 +1120,6 @@ func LoadGreetings(dispatcher *ext.Dispatcher) {
 		),
 	)
 
-	// for cleaning service messages
 	dispatcher.AddHandler(
 		handlers.NewMessage(
 			func(msg *gotgbot.Message) bool {

--- a/alita/modules/greetings_dedupe_test.go
+++ b/alita/modules/greetings_dedupe_test.go
@@ -38,7 +38,6 @@ func TestRecentJoinProcessingNoCacheFallback(t *testing.T) {
 // join-dedup claim for a given (chat, user) pair — both in the sequential case
 // and when N goroutines race concurrently.
 func TestClaimRecentJoinProcessingIsAtomic(t *testing.T) {
-	// Use unique IDs so this test doesn't collide with others.
 	chatID := -time.Now().UnixNano() / 1e6 // negative to avoid valid Telegram chat IDs
 	userID := time.Now().UnixNano()/1e6 + 1
 
@@ -46,7 +45,6 @@ func TestClaimRecentJoinProcessingIsAtomic(t *testing.T) {
 		clearRecentJoinProcessing(chatID, userID)
 	})
 
-	// Sequential: first call must win, second must lose.
 	if !claimRecentJoinProcessing(chatID, userID) {
 		t.Fatal("first claimRecentJoinProcessing() = false, want true")
 	}
@@ -54,10 +52,8 @@ func TestClaimRecentJoinProcessingIsAtomic(t *testing.T) {
 		t.Fatal("second claimRecentJoinProcessing() = true, want false (duplicate)")
 	}
 
-	// Reset for the concurrent sub-test.
 	clearRecentJoinProcessing(chatID, userID)
 
-	// Concurrent: N goroutines race; exactly one must win.
 	const N = 20
 	var wg sync.WaitGroup
 	var wins atomic.Int64

--- a/alita/modules/locks.go
+++ b/alita/modules/locks.go
@@ -30,7 +30,7 @@ var (
 		permHandlerGroup:  5,
 		restrHandlerGroup: 6,
 	}
-	arabmatch, _                 = regexp.Compile("[\u0600-\u06FF]") // the regex detects the arabic language
+	arabmatch, _                 = regexp.Compile("[\u0600-\u06FF]")
 	OTHER        filters.Message = func(msg *gotgbot.Message) bool {
 		return msg.Game != nil || msg.Sticker != nil || message.Animation(msg)
 	}
@@ -77,7 +77,6 @@ var (
 		},
 		"anonchannel": func(msg *gotgbot.Message) bool {
 			sender := msg.GetSender()
-			// Block messages from anonymous channels OR linked channels (channel posts forwarded to discussion)
 			return sender.IsAnonymousChannel() || sender.IsLinkedChannel()
 		},
 	}
@@ -91,14 +90,10 @@ var (
 		"all":      message.All,
 	}
 
-	// Cached lock types - computed once and reused
 	cachedLockTypes     []string
 	cachedLockTypesOnce sync.Once
 )
 
-// getLockMapAsArray returns a sorted array of all available lock types
-// by combining restriction types and permission lock types.
-// Uses sync.Once to cache the result since lock types never change.
 func (moduleStruct) getLockMapAsArray() []string {
 	cachedLockTypesOnce.Do(func() {
 		tmpMap := make(map[string]filters.Message, len(lockMap)+len(restrMap))
@@ -121,8 +116,6 @@ func (moduleStruct) getLockMapAsArray() []string {
 	return cachedLockTypes
 }
 
-// buildLockTypesMessage constructs a formatted string showing all locks
-// currently enabled in the specified chat.
 func (moduleStruct) buildLockTypesMessage(chatID int64) (res string) {
 	chatLocks := locks.GetChatLocks(chatID)
 
@@ -144,15 +137,11 @@ func (moduleStruct) buildLockTypesMessage(chatID int64) (res string) {
 	return
 }
 
-// locktypes handles the /locktypes command by displaying all available
-// lock types that can be used in the chat.
 func (m moduleStruct) locktypes(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "locktypes") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -171,15 +160,11 @@ func (m moduleStruct) locktypes(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// locks handles the /locks command by showing all currently enabled
-// locks in the chat with their status.
 func (m moduleStruct) locks(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "locks") {
 		return ext.EndGroups
 	}
-	// connection status
 	chat := chat_status.IsUserConnected(b, ctx, true, true)
 	if chat == nil {
 		return ext.EndGroups
@@ -195,13 +180,9 @@ func (m moduleStruct) locks(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// lockPerm handles the /lock command to enable specific lock types
-// in the chat, requiring admin permissions.
-//
 //nolint:dupl // lockPerm has symmetric logic with unlockPerm
 func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -210,7 +191,6 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	args := ctx.Args()[1:]
 
-	// Get sender for admin check
 	sender := ctx.EffectiveSender
 	if sender == nil {
 		return ext.EndGroups
@@ -236,7 +216,6 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Validate all lock types first
 	toLock := make([]string, 0, len(args))
 	for _, perm := range args {
 		if !slices.Contains(m.getLockMapAsArray(), perm) {
@@ -253,7 +232,6 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		toLock = append(toLock, perm)
 	}
 
-	// Update locks synchronously to ensure success before sending confirmation
 	failedLocks := make([]string, 0, len(toLock))
 	for _, perm := range toLock {
 		if err := locks.UpdateLock(chat.Id, perm, true); err != nil {
@@ -262,10 +240,8 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	// Send appropriate response based on success/failure
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if len(failedLocks) > 0 {
-		// Some locks failed
 		text, _ := tr.GetString("locks_lock_failed")
 		_, err := msg.Reply(b, fmt.Sprintf(text, strings.Join(failedLocks, ", ")), formatting.Shtml())
 		if err != nil {
@@ -273,7 +249,6 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	} else {
-		// All locks succeeded
 		temp, _ := tr.GetString("locks_locked_successfully")
 		text := fmt.Sprintf(temp, strings.Join(toLock, "\n - "))
 		_, err := msg.Reply(b, text, formatting.Shtml())
@@ -286,13 +261,9 @@ func (m moduleStruct) lockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// unlockPerm handles the /unlock command to disable specific lock types
-// in the chat, requiring admin permissions.
-//
 //nolint:dupl // unlockPerm has symmetric logic with lockPerm
 func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -301,7 +272,6 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	args := ctx.Args()[1:]
 
-	// Get sender for admin check
 	sender := ctx.EffectiveSender
 	if sender == nil {
 		return ext.EndGroups
@@ -327,7 +297,6 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Validate all lock types first
 	toUnlock := make([]string, 0, len(args))
 	for _, perm := range args {
 		if !slices.Contains(m.getLockMapAsArray(), perm) {
@@ -344,7 +313,6 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		toUnlock = append(toUnlock, perm)
 	}
 
-	// Update locks synchronously to ensure success before sending confirmation
 	failedLocks := make([]string, 0, len(toUnlock))
 	for _, perm := range toUnlock {
 		if err := locks.UpdateLock(chat.Id, perm, false); err != nil {
@@ -353,10 +321,8 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	// Send appropriate response based on success/failure
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	if len(failedLocks) > 0 {
-		// Some unlocks failed
 		text, _ := tr.GetString("locks_unlock_failed")
 		_, err := msg.Reply(b, fmt.Sprintf(text, strings.Join(failedLocks, ", ")), formatting.Shtml())
 		if err != nil {
@@ -364,7 +330,6 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 			return err
 		}
 	} else {
-		// All unlocks succeeded
 		temp, _ := tr.GetString("locks_unlocked_successfully")
 		text := fmt.Sprintf(temp, strings.Join(toUnlock, "\n - "))
 		_, err := msg.Reply(b, text, formatting.Shtml())
@@ -377,19 +342,15 @@ func (m moduleStruct) unlockPerm(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// restHandler monitors messages and deletes them if they match
-// restricted content types that are locked in the chat.
 func (moduleStruct) restHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
 	sender := ctx.EffectiveSender
 
-	// Skip if sender is nil (shouldn't happen but be safe)
 	if sender == nil {
 		return ext.ContinueGroups
 	}
 
-	// Early exit: skip API call if no restriction-type locks are active for this chat.
 	chatLocks := locks.GetChatLocks(chat.Id)
 	hasActiveLock := false
 	for restrKey := range restrMap {
@@ -402,10 +363,8 @@ func (moduleStruct) restHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Get sender ID - works for both users and channels
 	senderID := sender.Id()
 
-	// Skip for admins and approved users (IsUserAdmin handles channel IDs safely)
 	if chat_status.IsUserAdmin(b, chat.Id, senderID) {
 		return ext.ContinueGroups
 	}
@@ -413,7 +372,6 @@ func (moduleStruct) restHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Check bot delete permission once before scanning restrictions
 	if !chat_status.CanBotDelete(b, ctx, nil) {
 		return ext.ContinueGroups
 	}
@@ -423,41 +381,32 @@ func (moduleStruct) restHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 			continue
 		}
 
-		// Special handling for comments lock:
-		// Delete messages from users who aren't members of the chat (discussion comments)
 		// but skip Telegram's system account (777000) which forwards channel posts
 		if restr == "comments" {
-			// Skip if from Telegram's system account
 			if msg.From != nil && msg.From.Id == 777000 {
 				continue
 			}
-			// Only delete if sender is not a member of the chat
 			if chat_status.IsUserInChat(b, chat, senderID) {
 				continue
 			}
 		}
 
 		_ = helpers.DeleteMessageWithErrorHandling(b, chat.Id, msg.MessageId)
-		// Message deleted, no need to check other restrictions
 		break
 	}
 
 	return ext.ContinueGroups
 }
 
-// permHandler monitors messages and deletes them if they match
-// specific permission locks that are enabled in the chat.
 func (moduleStruct) permHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
 	sender := ctx.EffectiveSender
 
-	// Skip if sender is nil (shouldn't happen but be safe)
 	if sender == nil {
 		return ext.ContinueGroups
 	}
 
-	// Early exit: skip API call if no permission-type locks are active for this chat.
 	chatLocks := locks.GetChatLocks(chat.Id)
 	hasActiveLock := false
 	for permKey := range lockMap {
@@ -470,10 +419,8 @@ func (moduleStruct) permHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Get sender ID - works for both users and channels
 	senderID := sender.Id()
 
-	// Skip for admins and approved users (IsUserAdmin handles channel IDs safely)
 	if chat_status.IsUserAdmin(b, chat.Id, senderID) {
 		return ext.ContinueGroups
 	}
@@ -481,7 +428,6 @@ func (moduleStruct) permHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Check bot delete permission once before scanning locks
 	if !chat_status.CanBotDelete(b, ctx, nil) {
 		return ext.ContinueGroups
 	}
@@ -491,38 +437,31 @@ func (moduleStruct) permHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 			continue
 		}
 
-		// Skip "bots" lock - handled separately by botLockHandler for new member joins
 		if perm == "bots" {
 			continue
 		}
 
 		_ = helpers.DeleteMessageWithErrorHandling(b, chat.Id, msg.MessageId)
-		// Message deleted, no need to check other locks
 		break
 	}
 
 	return ext.ContinueGroups
 }
 
-// botLockHandler handles the bots lock by automatically banning
-// bots that are added to the chat when bots lock is enabled.
 func (moduleStruct) botLockHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	sender := ctx.EffectiveSender
 	mem := ctx.ChatMember.NewChatMember.MergeChatMember().User
 
-	// Check if bots lock is enabled first (most common case: it's not)
 	if !locks.IsPermLocked(chat.Id, "bots") {
 		return ext.ContinueGroups
 	}
 
-	// Get sender ID for admin check - the person who added the bot
 	var senderID int64
 	if sender != nil {
 		senderID = sender.Id()
 	}
 
-	// Allow admins to add bots even when bots lock is enabled
 	if senderID > 0 && chat_status.IsUserAdmin(b, chat.Id, senderID) {
 		return ext.ContinueGroups
 	}
@@ -530,7 +469,6 @@ func (moduleStruct) botLockHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Check if bot has necessary permissions
 	if !chat_status.IsBotAdmin(b, ctx, nil) {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(&ext.Context{EffectiveChat: chat}))
 		text, _ := tr.GetString("locks_bot_lock_no_permission")
@@ -546,7 +484,6 @@ func (moduleStruct) botLockHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Ban the bot that was added
 	_, err := chat.BanMember(b, mem.Id, nil)
 	if err != nil {
 		log.Error(err)
@@ -564,8 +501,6 @@ func (moduleStruct) botLockHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// LoadLocks registers all locks module handlers with the dispatcher,
-// including commands and message filters for lock enforcement.
 func LoadLocks(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[locksModule.moduleName] = true
 
@@ -582,7 +517,7 @@ func LoadLocks(dispatcher *ext.Dispatcher) {
 			func(u *gotgbot.ChatMemberUpdated) bool {
 				mem := u.NewChatMember.MergeChatMember()
 				oldMem := u.OldChatMember.MergeChatMember()
-				return mem.User.IsBot && mem.Status == "member" && oldMem.Status == "left" // new bot being added to group
+				return mem.User.IsBot && mem.Status == "member" && oldMem.Status == "left"
 			},
 			locksModule.botLockHandler,
 		),

--- a/alita/modules/locks_test.go
+++ b/alita/modules/locks_test.go
@@ -11,7 +11,6 @@ func TestGetLockMapAsArray(t *testing.T) {
 	var m moduleStruct
 	got := m.getLockMapAsArray()
 
-	// Compute expected keys from lockMap + restrMap
 	expected := make(map[string]struct{}, len(lockMap)+len(restrMap))
 	for k := range lockMap {
 		expected[k] = struct{}{}
@@ -24,12 +23,10 @@ func TestGetLockMapAsArray(t *testing.T) {
 		t.Fatalf("expected %d lock types, got %d", len(expected), len(got))
 	}
 
-	// Ensure sorted
 	if !slices.IsSorted(got) {
 		t.Fatalf("expected sorted slice, got %v", got)
 	}
 
-	// Ensure every expected key is present
 	for k := range expected {
 		if !slices.Contains(got, k) {
 			t.Fatalf("expected lock type %q missing from %v", k, got)


### PR DESCRIPTION
Comment-only split of #830 (whose diff exceeded GitHub's 20k-line API limit for the lint action). No code, string, or test-name changes. Kept: go:build/embed, pedantic nolint/nosec, external-constraint notes, public-API contracts, test concurrency contracts.