### PR TITLE
chore: strip restatement comments in content/misc modules

### DIFF
--- a/alita/modules/approvals.go
+++ b/alita/modules/approvals.go
@@ -32,17 +32,8 @@ var approvalsModule = moduleStruct{
 
 const approvedUsersInlineLimit = 50
 
-/*
-	Used to approve a user in the group!
-
-Connection - true, true
-Admin can approve a user in the chat
-*/
-// approveUser handles the /approve command to add a user to the approved list.
-// Approved users are immune to anti-spam measures (antiflood, blacklists, locks, captcha, antispam).
 func (m moduleStruct) approveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -54,7 +45,6 @@ func (m moduleStruct) approveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -74,7 +64,6 @@ func (m moduleStruct) approveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if already approved
 	if approvals.IsUserApproved(chat.Id, targetUserID) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_already_approved")
 		_, err := msg.Reply(b, fmt.Sprintf(text, formatting.MentionHtml(targetUserID, "")), formatting.Shtml())
@@ -85,13 +74,11 @@ func (m moduleStruct) approveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Resolve approved_by user name for display
 	_, approverName, found := extraction.GetUserInfo(user.Id)
 	if !found {
 		approverName = user.FirstName
 	}
 
-	// Reason is optional; default to empty string
 	if err := approvals.AddApprovedUser(chat.Id, targetUserID, user.Id, reason); err != nil {
 		log.Errorf("[Approvals] Failed to approve user %d in chat %d: %v", targetUserID, chat.Id, err)
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_approve_error")
@@ -127,16 +114,8 @@ func (m moduleStruct) approveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to remove a user from the approved list!
-
-Connection - true, true
-Admin can unapprove a user in the chat
-*/
-// unapproveUser handles the /unapprove command to remove a user from the approved list.
 func (m moduleStruct) unapproveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -148,7 +127,6 @@ func (m moduleStruct) unapproveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -168,7 +146,6 @@ func (m moduleStruct) unapproveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if actually approved
 	if !approvals.IsUserApproved(chat.Id, targetUserID) {
 		text, _ := tr.GetString(strings.ToLower(m.moduleName) + "_not_approved")
 		_, err := msg.Reply(b, fmt.Sprintf(text, formatting.MentionHtml(targetUserID, "")), formatting.Shtml())
@@ -197,16 +174,8 @@ func (m moduleStruct) unapproveUser(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	Used to check a user's approval status!
-
-Connection - true, true
-Admin can check a user's approval status in the chat
-*/
-// checkApprovalStatus handles the /approval command to check if a user is approved.
 func (m moduleStruct) checkApprovalStatus(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -218,7 +187,6 @@ func (m moduleStruct) checkApprovalStatus(b *gotgbot.Bot, ctx *ext.Context) erro
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -259,7 +227,6 @@ func (m moduleStruct) checkApprovalStatus(b *gotgbot.Bot, ctx *ext.Context) erro
 		return ext.EndGroups
 	}
 
-	// Resolve names for display
 	_, approverName, approverFound := extraction.GetUserInfo(foundUser.ApprovedBy)
 	if !approverFound {
 		approverName = strconv.FormatInt(foundUser.ApprovedBy, 10)
@@ -289,17 +256,8 @@ func (m moduleStruct) checkApprovalStatus(b *gotgbot.Bot, ctx *ext.Context) erro
 	return ext.EndGroups
 }
 
-/*
-	Used to list all approved users in the chat!
-
-Connection - true, true
-Admin can list all approved users in the chat
-*/
-// listApprovedUsers handles the /approved command to list all approved users.
-// If the list exceeds 50 users, sends a .txt file instead of an inline message.
 func (m moduleStruct) listApprovedUsers(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -311,7 +269,6 @@ func (m moduleStruct) listApprovedUsers(b *gotgbot.Bot, ctx *ext.Context) error 
 	}
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -328,7 +285,6 @@ func (m moduleStruct) listApprovedUsers(b *gotgbot.Bot, ctx *ext.Context) error 
 		return ext.EndGroups
 	}
 
-	// If the list is small, send it inline
 	if len(approvedUsers) <= approvedUsersInlineLimit {
 		listHeader, _ := tr.GetString(strings.ToLower(m.moduleName) + "_list_header")
 		listItem, _ := tr.GetString(strings.ToLower(m.moduleName) + "_list_item")
@@ -354,7 +310,6 @@ func (m moduleStruct) listApprovedUsers(b *gotgbot.Bot, ctx *ext.Context) error 
 		return ext.EndGroups
 	}
 
-	// Large list: send as .txt file
 	tmpFile, err := os.CreateTemp("", "approved-*.txt")
 	if err != nil {
 		log.Errorf("[Approvals] Failed to create temp file: %v", err)
@@ -416,13 +371,6 @@ func (m moduleStruct) listApprovedUsers(b *gotgbot.Bot, ctx *ext.Context) error 
 	return ext.EndGroups
 }
 
-/*
-	Used to remove all approved users from the chat!
-
-Only chat creator can use this command with a confirmation button.
-*/
-// unapproveAllHandler handles the /unapproveall command.
-// Sends an inline keyboard for confirmation before bulk removal.
 //nolint:dupl // Similar to other rmAll handlers with distinct callback data and messages
 func (m moduleStruct) unapproveAllHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
@@ -433,7 +381,6 @@ func (m moduleStruct) unapproveAllHandler(b *gotgbot.Bot, ctx *ext.Context) erro
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -472,7 +419,6 @@ func (m moduleStruct) unapproveAllHandler(b *gotgbot.Bot, ctx *ext.Context) erro
 	return ext.EndGroups
 }
 
-// unapproveAllCallback processes the confirmation callback for /unapproveall.
 func (m moduleStruct) unapproveAllCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -481,7 +427,6 @@ func (m moduleStruct) unapproveAllCallback(b *gotgbot.Bot, ctx *ext.Context) err
 	user := query.From
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Permission checks
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 		return ext.EndGroups
@@ -552,8 +497,6 @@ func (m moduleStruct) unapproveAllCallback(b *gotgbot.Bot, ctx *ext.Context) err
 	return ext.EndGroups
 }
 
-// extractDisplayName returns a display name for a user ID by looking up in DB.
-// Falls back to the raw numeric ID if not found in database.
 func extractDisplayName(userID int64) string {
 	_, name, found := extraction.GetUserInfo(userID)
 	if found && name != "" {
@@ -562,8 +505,6 @@ func extractDisplayName(userID int64) string {
 	return strconv.FormatInt(userID, 10)
 }
 
-// LoadApprovals registers all approvals module handlers with the dispatcher.
-//
 //nolint:dupl // Pattern matches other LoadXxx functions
 func LoadApprovals(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[approvalsModule.moduleName] = true

--- a/alita/modules/approvals_command_test.go
+++ b/alita/modules/approvals_command_test.go
@@ -172,7 +172,6 @@ func TestUnapproveAllCallbackCancelInvalidAndUnavailableMessage(t *testing.T) {
 		t.Fatal("cancel callback removed approved user")
 	}
 
-	// Invalid (non-codec) data hits the "missing action" path.
 	invalidCtx := newModuleCallbackContext(bot, chat, owner, "not-a-valid-callback")
 	if err := approvalsModule.unapproveAllCallback(bot, invalidCtx); err != ext.EndGroups {
 		t.Fatalf("unapproveAllCallback invalid error = %v, want EndGroups", err)

--- a/alita/modules/approvals_test.go
+++ b/alita/modules/approvals_test.go
@@ -13,7 +13,6 @@ func TestApprovalsModuleName(t *testing.T) {
 }
 
 func TestExtractDisplayName(t *testing.T) {
-	// Pure function: should not panic with unknown IDs.
 	// Known users may or may not be in the test DB depending on test ordering.
 	name := extractDisplayName(99999999999)
 	assert.NotEmpty(t, name)

--- a/alita/modules/backup.go
+++ b/alita/modules/backup.go
@@ -28,7 +28,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/ratelimit"
 )
 
-// Module instance
 var backupModule = moduleStruct{
 	moduleName: "Backup",
 }
@@ -46,10 +45,6 @@ type pendingResetState struct {
 	expiresAt time.Time
 }
 
-// Pending backup operations are stored in memory per chat. The callback token
-// prevents an older confirmation button from acting on newer pending state.
-// NOTE: single-instance requirement — pending maps are in-memory and lost on
-// restart; not suitable for multi-instance deployments without shared storage.
 var (
 	pendingMu        sync.Mutex
 	pendingImports   = make(map[int64]pendingImportState)
@@ -188,7 +183,6 @@ func startPendingCleanupTicker() {
 	}()
 }
 
-// exportHandler handles the /export command
 func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -198,19 +192,16 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if in a group
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
 	}
 
-	// Check if user is admin
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
 	}
 
-	// Check if bot is admin
 	if !chat_status.RequireBotAdmin(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_bot_not_admin", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -218,7 +209,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Parse module arguments
 	var modules []string
 	if msg.Text != "" {
 		args := strings.Fields(msg.Text)
@@ -233,8 +223,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	// Reserve before starting work. The cooldown remains after a failure so an
-	// expired operation cannot delete a newer caller's reservation.
 	limiter := ratelimit.GetBackupRateLimiter()
 	if allowed, cooldown := limiter.AcquireExport(chat.Id); !allowed {
 		cooldownStr := ratelimit.FormatCooldown(cooldown)
@@ -245,7 +233,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Export data
 	bkp, err := backup.ExportChatData(chat.Id, chat.Title, user.Id, modules)
 	if err != nil {
 		log.Errorf("[Backup] Export failed for chat %d: %v", chat.Id, err)
@@ -254,14 +241,12 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if any data was exported
 	if len(bkp.Data) == 0 {
 		text, _ := tr.GetString("backup_export_no_modules")
 		_, _ = msg.Reply(b, text, formatting.Shtml())
 		return ext.EndGroups
 	}
 
-	// Convert to JSON
 	jsonData, err := bkp.ToJSON()
 	if err != nil {
 		log.Errorf("[Backup] Failed to marshal backup: %v", err)
@@ -270,7 +255,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Send as document
 	fileName := fmt.Sprintf("alita_backup_%d_%s.json", chat.Id, time.Now().Format("20060102_150405"))
 	caption := buildExportCaption(tr, bkp)
 
@@ -285,7 +269,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	)
 	if err != nil {
 		log.Errorf("[Backup] Failed to send document: %v", err)
-		// Fallback: send as text
 		text, _ := tr.GetString("backup_export_success_text", i18n.TranslationParams{
 			"modules": fmt.Sprintf("%d", len(bkp.Data)),
 		})
@@ -297,7 +280,6 @@ func (m moduleStruct) exportHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// validateImportRequest checks all permissions and prerequisites for import
 func validateImportRequest(b *gotgbot.Bot, ctx *ext.Context) (*gotgbot.Message, *gotgbot.Chat, *gotgbot.User, *i18n.Translator, bool) {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -307,13 +289,11 @@ func validateImportRequest(b *gotgbot.Bot, ctx *ext.Context) (*gotgbot.Message, 
 		return nil, nil, nil, nil, false
 	}
 
-	// Check if in a group
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return nil, nil, nil, nil, false
 	}
 
-	// Check if bot is admin
 	if !chat_status.RequireBotAdmin(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_bot_not_admin", "", chat_status.WithReply())
 		return nil, nil, nil, nil, false
@@ -321,7 +301,6 @@ func validateImportRequest(b *gotgbot.Bot, ctx *ext.Context) (*gotgbot.Message, 
 
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check if user is the group creator
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		text, _ := tr.GetString("backup_import_creator_only")
 		_, _ = msg.Reply(b, text, formatting.Shtml())
@@ -331,9 +310,7 @@ func validateImportRequest(b *gotgbot.Bot, ctx *ext.Context) (*gotgbot.Message, 
 	return msg, chat, user, tr, true
 }
 
-// downloadBackupFile downloads the backup file from Telegram
 func downloadBackupFile(b *gotgbot.Bot, doc *gotgbot.Document, tr *i18n.Translator) ([]byte, string) {
-	// Check file type
 	if !strings.HasSuffix(strings.ToLower(doc.FileName), ".json") {
 		text, _ := tr.GetString("backup_import_invalid_file")
 		return nil, text
@@ -358,7 +335,6 @@ func downloadBackupFile(b *gotgbot.Bot, doc *gotgbot.Document, tr *i18n.Translat
 	return fileData, ""
 }
 
-// parseImportModules parses module arguments from command text.
 func parseImportModules(text string, backupData map[string]interface{}) ([]string, error) {
 	if text != "" {
 		args := strings.Fields(text)
@@ -395,14 +371,12 @@ func parseModuleArgs(args []string, valid func(string) bool) ([]string, error) {
 	return modules, nil
 }
 
-// importHandler handles the /import command
 func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg, chat, _, tr, ok := validateImportRequest(b, ctx)
 	if !ok {
 		return ext.EndGroups
 	}
 
-	// Check if this is a reply to a document (validate before burning cooldown)
 	if msg.ReplyToMessage == nil || msg.ReplyToMessage.Document == nil {
 		text, _ := tr.GetString("backup_import_no_reply")
 		_, _ = msg.Reply(b, text, formatting.Shtml())
@@ -411,14 +385,12 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	doc := msg.ReplyToMessage.Document
 
-	// Download the backup file
 	fileData, errText := downloadBackupFile(b, doc, tr)
 	if fileData == nil {
 		_, _ = msg.Reply(b, errText, formatting.Shtml())
 		return ext.EndGroups
 	}
 
-	// Parse backup file
 	bkp, err := backup.BackupFormatFromJSON(fileData)
 	if err != nil {
 		log.Errorf("[Backup] Failed to parse backup: %v", err)
@@ -427,7 +399,6 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Validate backup
 	if err := bkp.Validate(); err != nil {
 		log.Errorf("[Backup] Invalid backup: %v", err)
 		text, _ := tr.GetString("backup_import_invalid_file")
@@ -441,7 +412,6 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Parse module arguments
 	importModules, parseErr := parseImportModules(msg.Text, bkp.Data)
 	if parseErr != nil {
 		text, _ := tr.GetString("backup_import_invalid_file")
@@ -449,12 +419,10 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// If no modules specified, use all from backup
 	if len(importModules) == 0 {
 		importModules = bkp.Modules
 	}
 
-	// Reserve cooldown after validation to avoid burning on malformed input.
 	limiter := ratelimit.GetBackupRateLimiter()
 	if allowed, cooldown := limiter.AcquireImport(chat.Id); !allowed {
 		text, _ := tr.GetString("backup_import_rate_limited", i18n.TranslationParams{
@@ -464,7 +432,6 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Store pending import
 	token, err := storePendingImport(chat.Id, bkp, importModules)
 	if err != nil {
 		log.Errorf("[Backup] Failed to store pending import: %v", err)
@@ -473,7 +440,6 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Show confirmation with keyboard
 	confirmText, _ := tr.GetString("backup_import_confirm", i18n.TranslationParams{
 		"modules": fmt.Sprintf("%d", len(importModules)),
 		"list":    buildModuleList(importModules),
@@ -493,7 +459,6 @@ func (m moduleStruct) importHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetHandler handles the /reset command
 func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -503,13 +468,11 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check if in a group
 	if !chat_status.RequireGroup(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_group_only_error", "", chat_status.WithReply())
 		return ext.EndGroups
 	}
 
-	// Check if bot is admin
 	if !chat_status.RequireBotAdmin(b, ctx, nil) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_bot_not_admin", "", chat_status.WithReply())
 		return ext.EndGroups
@@ -517,13 +480,11 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check if user is the group creator
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 		return ext.EndGroups
 	}
 
-	// Parse module arguments (validate before burning cooldown)
 	var resetModules []string
 	if msg.Text != "" {
 		args := strings.Fields(msg.Text)
@@ -538,12 +499,10 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	}
 
-	// If no modules specified, reset all
 	if len(resetModules) == 0 {
 		resetModules = backup.AllExportableModules()
 	}
 
-	// Reserve after validation to avoid burning cooldown on malformed input.
 	limiter := ratelimit.GetBackupRateLimiter()
 	if allowed, cooldown := limiter.AcquireReset(chat.Id); !allowed {
 		text, _ := tr.GetString("backup_reset_rate_limited", i18n.TranslationParams{
@@ -553,7 +512,6 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Store pending reset
 	token, err := storePendingReset(chat.Id, resetModules)
 	if err != nil {
 		log.Errorf("[Backup] Failed to store pending reset: %v", err)
@@ -562,7 +520,6 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Show confirmation with keyboard
 	confirmText, _ := tr.GetString("backup_reset_confirm", i18n.TranslationParams{
 		"modules": fmt.Sprintf("%d", len(resetModules)),
 		"list":    buildModuleList(resetModules),
@@ -582,7 +539,6 @@ func (m moduleStruct) resetHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// backupCallbackHandler handles callback queries for backup operations
 func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -595,7 +551,6 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 		return answerInvalidCallback(b, ctx, query)
 	}
 
-	// Only creator can confirm import/reset
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		text, _ := tr.GetString("backup_import_creator_only")
 		_, _ = query.Answer(b, &gotgbot.AnswerCallbackQueryOpts{
@@ -605,7 +560,6 @@ func (m moduleStruct) backupCallbackHandler(b *gotgbot.Bot, ctx *ext.Context) er
 		return ext.EndGroups
 	}
 
-	// Decode callback data
 	decoded, ok := decodeCallbackData(query.Data, "backup")
 	if !ok {
 		return answerInvalidCallback(b, ctx, query)
@@ -647,9 +601,6 @@ func (m moduleStruct) handleConfirmImport(b *gotgbot.Bot, ctx *ext.Context, tr *
 		return ext.EndGroups
 	}
 
-	// Rate limit already acquired at importHandler entry; no second Acquire here
-	// to keep operation atomic (handler entry reserves the cooldown).
-	// Perform import
 	if err := backup.ImportChatData(chat.Id, bkp, modules); err != nil {
 		log.Errorf("[Backup] Import failed for chat %d: %v", chat.Id, err)
 		text, _ := tr.GetString("backup_import_failed", i18n.TranslationParams{
@@ -659,7 +610,6 @@ func (m moduleStruct) handleConfirmImport(b *gotgbot.Bot, ctx *ext.Context, tr *
 		return ext.EndGroups
 	}
 
-	// Success message
 	text, _ := tr.GetString("backup_import_success", i18n.TranslationParams{
 		"modules": fmt.Sprintf("%d", len(modules)),
 		"list":    buildModuleList(modules),
@@ -673,8 +623,6 @@ func (m moduleStruct) handleConfirmImport(b *gotgbot.Bot, ctx *ext.Context, tr *
 	return ext.EndGroups
 }
 
-// handleCancelPending atomically discards matching pending state and
-// acknowledges the cancelled backup callback.
 func (m moduleStruct) handleCancelPending(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery, token string, discard func(int64, string) bool, cancelKey, expiredKey string) error {
 	chat := ctx.EffectiveChat
 
@@ -709,8 +657,6 @@ func (m moduleStruct) handleConfirmReset(b *gotgbot.Bot, ctx *ext.Context, tr *i
 		return ext.EndGroups
 	}
 
-	// Rate limit already acquired at resetHandler entry.
-	// Perform reset
 	if err := backup.ClearChatData(chat.Id, modules); err != nil {
 		log.Errorf("[Backup] Reset failed for chat %d: %v", chat.Id, err)
 		text, _ := tr.GetString("backup_reset_failed", i18n.TranslationParams{
@@ -720,7 +666,6 @@ func (m moduleStruct) handleConfirmReset(b *gotgbot.Bot, ctx *ext.Context, tr *i
 		return ext.EndGroups
 	}
 
-	// Success message
 	text, _ := tr.GetString("backup_reset_success", i18n.TranslationParams{
 		"modules": fmt.Sprintf("%d", len(modules)),
 		"list":    buildModuleList(modules),
@@ -737,8 +682,6 @@ func (m moduleStruct) handleConfirmReset(b *gotgbot.Bot, ctx *ext.Context, tr *i
 func (m moduleStruct) handleCancelReset(b *gotgbot.Bot, ctx *ext.Context, tr *i18n.Translator, query *gotgbot.CallbackQuery, token string) error {
 	return m.handleCancelPending(b, ctx, tr, query, token, discardPendingReset, "backup_reset_cancelled", "backup_reset_expired")
 }
-
-// Helper functions
 
 func buildExportCaption(tr *i18n.Translator, backup *backup.BackupFormat) string {
 	modulesList := buildModuleList(backup.Modules)
@@ -810,23 +753,18 @@ func buildResetKeyboard(tr *i18n.Translator, chatID int64, token string) gotgbot
 	}
 }
 
-// LoadBackup registers all backup module handlers with the dispatcher.
 func LoadBackup(dispatcher *ext.Dispatcher) {
-	// Register module in enabled map
 	DefaultHelpRegistry().AbleMap[backupModule.moduleName] = true
 
-	// Register command handlers
 	dispatcher.AddHandler(handlers.NewCommand("export", backupModule.exportHandler))
 	dispatcher.AddHandler(handlers.NewCommand("import", backupModule.importHandler))
 	dispatcher.AddHandler(handlers.NewCommand("reset", backupModule.resetHandler))
 
-	// Register callback query handlers
 	dispatcher.AddHandler(handlers.NewCallback(
 		callbackquery.Prefix("backup"),
 		backupModule.backupCallbackHandler,
 	))
 
-	// Add disableable commands
 	helpers.AddCmdToDisableable("export")
 	helpers.AddCmdToDisableable("import")
 

--- a/alita/modules/backup_test.go
+++ b/alita/modules/backup_test.go
@@ -451,7 +451,6 @@ func TestBuildImportKeyboard(t *testing.T) {
 	assert.Equal(t, "Cancel Import", cancelBtn.Text)
 	assert.NotEmpty(t, cancelBtn.CallbackData)
 
-	// Verify callback data decodes correctly
 	decodedConfirm, ok := decodeCallbackData(confirmBtn.CallbackData, "backup")
 	require.True(t, ok)
 	action, _ := decodedConfirm.Field("a")
@@ -491,7 +490,6 @@ func TestBuildResetKeyboard(t *testing.T) {
 	assert.Equal(t, "Cancel Reset", cancelBtn.Text)
 	assert.NotEmpty(t, cancelBtn.CallbackData)
 
-	// Verify callback data decodes correctly
 	decodedConfirm, ok := decodeCallbackData(confirmBtn.CallbackData, "backup")
 	require.True(t, ok)
 	action, _ := decodedConfirm.Field("a")
@@ -551,7 +549,6 @@ func dropPendingReset(chatID int64) {
 
 func TestPendingImportsMaps(t *testing.T) {
 	t.Run("pending imports maps exist", func(t *testing.T) {
-		// Just verify the maps are initialized
 		assert.NotNil(t, pendingImports)
 		assert.NotNil(t, pendingResets)
 	})
@@ -949,7 +946,7 @@ func TestModuleNames(t *testing.T) {
 		}
 
 		for _, module := range modules {
-			assert.Equal(t, module, module) // Just checking they exist
+			assert.Equal(t, module, module)
 		}
 	})
 }

--- a/alita/modules/callback_codec.go
+++ b/alita/modules/callback_codec.go
@@ -48,8 +48,6 @@ func decodeCallbackData(data string, expectedNamespaces ...string) (*callbackcod
 	return nil, false
 }
 
-// answerInvalidCallback answers a malformed callback with the shared
-// "invalid request" string and ends group dispatch.
 func answerInvalidCallback(b *gotgbot.Bot, ctx *ext.Context, query *gotgbot.CallbackQuery) error {
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	text, _ := tr.GetString("common_callback_invalid_request")

--- a/alita/modules/callback_codec_test.go
+++ b/alita/modules/callback_codec_test.go
@@ -11,7 +11,6 @@ func TestEncodeCallbackData(t *testing.T) {
 		t.Parallel()
 
 		result := encodeCallbackData("test_ns", map[string]string{"k": "v"})
-		// Result must not be empty and must contain the namespace.
 		if result == "" {
 			t.Fatal("expected non-empty encoded data")
 		}
@@ -20,7 +19,6 @@ func TestEncodeCallbackData(t *testing.T) {
 	t.Run("encode error with empty namespace returns empty string", func(t *testing.T) {
 		t.Parallel()
 
-		// Empty namespace triggers ErrInvalidNamespace in the codec.
 		result := encodeCallbackData("", map[string]string{"k": "v"})
 		if result != "" {
 			t.Fatalf("expected empty string on encode error, got %q", result)
@@ -30,7 +28,6 @@ func TestEncodeCallbackData(t *testing.T) {
 	t.Run("nil fields map", func(t *testing.T) {
 		t.Parallel()
 
-		// Nil map should produce a valid encoded string (empty payload becomes "_").
 		result := encodeCallbackData("test_ns", nil)
 		if result == "" {
 			t.Fatal("nil fields map should encode successfully")

--- a/alita/modules/core.go
+++ b/alita/modules/core.go
@@ -6,11 +6,8 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
-// ableMapMu protects AbleMap/helpableKb/AltHelpOptions on the singleton help registry.
-// All writes happen during init-only LoadModules; readers in help.go use RLock.
 var ableMapMu sync.RWMutex
 
-// module struct for all modules
 type moduleStruct struct {
 	moduleName        string
 	handlerGroup      int
@@ -22,7 +19,6 @@ type moduleStruct struct {
 	helpableKb        map[string][][]gotgbot.InlineKeyboardButton
 }
 
-// GetAbleMap returns a snapshot copy of AbleMap under RLock.
 func GetAbleMap() map[string]bool {
 	ableMapMu.RLock()
 	defer ableMapMu.RUnlock()
@@ -33,8 +29,6 @@ func GetAbleMap() map[string]bool {
 	return out
 }
 
-// ResetHelpRegistry clears AbleMap, helpableKb and AltHelpOptions under lock.
-// Call only during single-threaded startup (LoadModules).
 func ResetHelpRegistry() {
 	ableMapMu.Lock()
 	defer ableMapMu.Unlock()
@@ -52,7 +46,6 @@ func newHelpRegistry() *moduleStruct {
 	}
 }
 
-// DefaultHelpRegistry returns the default help registry.
 func DefaultHelpRegistry() *moduleStruct {
 	return defaultHelpRegistry
 }

--- a/alita/modules/deeplink_router.go
+++ b/alita/modules/deeplink_router.go
@@ -49,7 +49,6 @@ func HandleDeepLink(b *gotgbot.Bot, ctx *ext.Context, user *gotgbot.User, arg st
 	return sendDefaultHelp(b, ctx, user)
 }
 
-// sendDefaultHelp sends the default start/help message.
 func sendDefaultHelp(b *gotgbot.Bot, ctx *ext.Context, user *gotgbot.User) error {
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	startHelpText := getStartHelp(tr)

--- a/alita/modules/disabling.go
+++ b/alita/modules/disabling.go
@@ -21,30 +21,18 @@ import (
 
 var disablingModule = moduleStruct{moduleName: "Disabling"}
 
-/*
-	To disable or enable commands
-
-# Connection - true, true
-
-Only Admin can use this command to disable/enable usage of a command in the chat
-*/
-
-// toggleCmdConfig holds configuration for disable/enable command operations.
 type toggleCmdConfig struct {
 	emptyArgsMsgKey  string
 	noCmdMsgKey      string
 	successMsgKey    string
 	unknownCmdMsgKey string
 	dbOp             func(int64, string) error
-	actionName       string // for logging: "disable" or "enable"
+	actionName       string
 }
 
-// toggleCommands handles both disabling and enabling commands.
-// Only admins can use this command. Accepts multiple command names as arguments.
 func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context) error {
 	return func(b *gotgbot.Bot, ctx *ext.Context) error {
 		msg := ctx.EffectiveMessage
-		// connection status
 		connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 		if connectedChat == nil {
 			return ext.EndGroups
@@ -85,7 +73,6 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 			return ext.EndGroups
 		}
 
-		// Collect valid and invalid commands
 		toToggle := make([]string, 0, len(args))
 		unknownCmds := make([]string, 0, len(args))
 
@@ -98,7 +85,6 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 			}
 		}
 
-		// First, toggle all valid commands in the database
 		failedCmds := make([]string, 0, len(toToggle))
 		for _, cmd := range toToggle {
 			if err := cfg.dbOp(chat.Id, cmd); err != nil {
@@ -107,7 +93,6 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 			}
 		}
 
-		// Remove failed commands from success list
 		successCmds := make([]string, 0, len(toToggle))
 		for _, cmd := range toToggle {
 			if !slices.Contains(failedCmds, cmd) {
@@ -115,7 +100,6 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 			}
 		}
 
-		// Send success message for successfully toggled commands
 		if len(successCmds) > 0 {
 			temp, _ := tr.GetString(cfg.successMsgKey)
 			text := fmt.Sprintf(temp, "\n - "+strings.Join(successCmds, "\n - "))
@@ -126,7 +110,6 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 			}
 		}
 
-		// Send error message for unknown commands
 		for _, cmd := range unknownCmds {
 			temp, _ := tr.GetString(cfg.unknownCmdMsgKey)
 			text := fmt.Sprintf(temp, cmd)
@@ -141,25 +124,14 @@ func (moduleStruct) toggleCommands(enable bool) func(*gotgbot.Bot, *ext.Context)
 	}
 }
 
-// disable disables one or more bot commands in the current chat.
-// Only admins can use this command. Accepts multiple command names as arguments.
 func (m moduleStruct) disable(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.toggleCommands(false)(b, ctx)
 }
 
-// enable re-enables one or more previously disabled bot commands in the chat.
-// Only admins can use this command. Accepts multiple command names as arguments.
 func (m moduleStruct) enable(b *gotgbot.Bot, ctx *ext.Context) error {
 	return m.toggleCommands(true)(b, ctx)
 }
 
-/*
-	To check the disableable commands
-
-Anyone can use this command to check the disableable commands
-*/
-// disableable shows a list of all commands that can be disabled in the chat.
-// Any user can view this list to see which commands support disabling functionality.
 func (moduleStruct) disableable(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 
@@ -180,22 +152,11 @@ func (moduleStruct) disableable(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	To list all disabled commands in chat
-
-# Connection - false, true
-
-Any user in can use this command to check the disabled commands in the current chat.
-*/
-// disabled displays all currently disabled commands in the chat.
-// Any user can view the list of disabled commands for the current chat.
 func (moduleStruct) disabled(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "disabled") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -247,19 +208,8 @@ func (moduleStruct) disabled(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-/*
-	To either delete or not to delete the disabled command in the chat
-
-# Connection - true, true
-
-Only admins can use this command to either choose to delete the disabled command
-or not to. If no argument is given, the current chat setting is returned
-*/
-// disabledel toggles whether disabled commands should be automatically deleted.
-// Only admins can use this. With no args, shows current setting; with args, changes it.
 func (moduleStruct) disabledel(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -275,7 +225,6 @@ func (moduleStruct) disabledel(b *gotgbot.Bot, ctx *ext.Context) error {
 		param := strings.ToLower(args[0])
 		switch param {
 		case "on", "true", "yes":
-			// Execute DB operation synchronously before sending confirmation
 			if err := disabling.ToggleDel(chat.Id, true); err != nil {
 				log.Errorf("[Disabling] Failed to enable delete mode for chat %d: %v", chat.Id, err)
 				text = "Failed to update setting. Please try again."
@@ -283,7 +232,6 @@ func (moduleStruct) disabledel(b *gotgbot.Bot, ctx *ext.Context) error {
 				text, _ = tr.GetString("disabling_delete_enabled")
 			}
 		case "off", "false", "no":
-			// Execute DB operation synchronously before sending confirmation
 			if err := disabling.ToggleDel(chat.Id, false); err != nil {
 				log.Errorf("[Disabling] Failed to disable delete mode for chat %d: %v", chat.Id, err)
 				text = "Failed to update setting. Please try again."
@@ -311,8 +259,6 @@ func (moduleStruct) disabledel(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadDisabling registers all disabling-related command handlers with the dispatcher.
-// Sets up commands for managing which bot commands are enabled or disabled in chats.
 func LoadDisabling(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[disablingModule.moduleName] = true
 

--- a/alita/modules/federations.go
+++ b/alita/modules/federations.go
@@ -1236,7 +1236,6 @@ func (moduleStruct) enforceFedBan(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.ContinueGroups
 }
 
-// LoadFederations registers federation commands and the passive fban watcher.
 func LoadFederations(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[federationsModule.moduleName] = true
 

--- a/alita/modules/federations_io.go
+++ b/alita/modules/federations_io.go
@@ -58,7 +58,6 @@ func parseFedBanCSV(data []byte) ([]models.FederationBan, error) {
 	}
 	start := 1
 	if idIdx < 0 {
-		// Treat the first row as data if there is no header.
 		idIdx = 0
 		start = 0
 	}

--- a/alita/modules/formatting.go
+++ b/alita/modules/formatting.go
@@ -18,13 +18,10 @@ import (
 
 var formattingModule = moduleStruct{moduleName: "Formatting"}
 
-// markdownHelp provides markdown formatting help and examples to users.
-// Shows formatting options in private messages or sends a button to open help in PM.
 func (m moduleStruct) markdownHelp(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	// Check of group or pm
 	if !chat_status.RequirePrivate(b, ctx, nil) {
 		reply := msg.Reply
 		if msg.ReplyToMessage != nil {
@@ -57,7 +54,6 @@ func (m moduleStruct) markdownHelp(b *gotgbot.Bot, ctx *ext.Context) error {
 	} else {
 		backText, _ := tr.GetString("common_back")
 
-		// Keyboard for markdown help menu
 		Mkdkb := append(m.genFormattingKb(lang.GetLanguage(ctx)),
 			[]gotgbot.InlineKeyboardButton{
 				{
@@ -69,7 +65,6 @@ func (m moduleStruct) markdownHelp(b *gotgbot.Bot, ctx *ext.Context) error {
 
 		largeOptionsText, _ := tr.GetString("formatting_large_options")
 		_, err := msg.Reply(b,
-			// Uses localized largeOptionsText for the formatting help message.
 			largeOptionsText,
 			&gotgbot.SendMessageOpts{
 				ParseMode: formatting.HTML,
@@ -87,9 +82,6 @@ func (m moduleStruct) markdownHelp(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// genFormattingKb generates the inline keyboard layout for formatting help options.
-// Creates buttons for different formatting categories like markdown, fillings, and random content.
-// If lang is empty, defaults to "en".
 func (moduleStruct) genFormattingKb(lang string) [][]gotgbot.InlineKeyboardButton {
 	if lang == "" {
 		lang = "en"
@@ -106,7 +98,6 @@ func (moduleStruct) genFormattingKb(lang string) [][]gotgbot.InlineKeyboardButto
 	fillingsText, _ := tr.GetString("help_fillings_button")
 	randomContentText, _ := tr.GetString("help_random_content_button")
 
-	// First row
 	keyboard[0][0] = gotgbot.InlineKeyboardButton{
 		Text:         markdownFormattingText,
 		CallbackData: encodeCallbackData("formatting", map[string]string{"m": "md_formatting"}),
@@ -116,7 +107,6 @@ func (moduleStruct) genFormattingKb(lang string) [][]gotgbot.InlineKeyboardButto
 		CallbackData: encodeCallbackData("formatting", map[string]string{"m": "fillings"}),
 	}
 
-	// Second Row
 	keyboard[1][0] = gotgbot.InlineKeyboardButton{
 		Text:         randomContentText,
 		CallbackData: encodeCallbackData("formatting", map[string]string{"m": "random"}),
@@ -125,8 +115,6 @@ func (moduleStruct) genFormattingKb(lang string) [][]gotgbot.InlineKeyboardButto
 	return keyboard
 }
 
-// getMarkdownHelp retrieves the appropriate help text for a specific formatting module.
-// Returns localized help content based on the requested formatting category.
 func (moduleStruct) getMarkdownHelp(tr *i18n.Translator, module string) string {
 	var helpTxt string
 	switch module {
@@ -140,8 +128,6 @@ func (moduleStruct) getMarkdownHelp(tr *i18n.Translator, module string) string {
 	return helpTxt
 }
 
-// formattingHandler processes callback queries for formatting help navigation.
-// Updates help messages based on user selections from the formatting keyboard.
 func (m moduleStruct) formattingHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -169,7 +155,6 @@ func (m moduleStruct) formattingHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 
 	backText, _ := tr.GetString("common_back")
 
-	// Edit the help as per sub-module selected in markdownhelp
 	opts := &gotgbot.EditMessageTextOpts{
 		MessageId: msg.GetMessageId(),
 		ReplyMarkup: gotgbot.InlineKeyboardMarkup{
@@ -199,8 +184,6 @@ func (m moduleStruct) formattingHandler(b *gotgbot.Bot, ctx *ext.Context) error 
 	return ext.EndGroups
 }
 
-// LoadMkdCmd registers markdown and formatting command handlers with the dispatcher.
-// Sets up help commands and callback handlers for formatting assistance.
 func LoadMkdCmd(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[formattingModule.moduleName] = true
 	DefaultHelpRegistry().helpableKb[formattingModule.moduleName] = formattingModule.genFormattingKb("en")

--- a/alita/modules/help.go
+++ b/alita/modules/help.go
@@ -20,7 +20,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/i18n"
 )
 
-// cachedBotUsernameMu protects cachedBotUsername against concurrent reads/writes.
 var (
 	cachedBotUsername   string
 	cachedBotUsernameMu sync.RWMutex
@@ -33,7 +32,6 @@ func getBotUsername(b *gotgbot.Bot) string {
 	if cached != "" {
 		return cached
 	}
-	// Fetch outside lock to avoid holding lock over network RTT
 	if b != nil && b.Username != "" {
 		cachedBotUsernameMu.Lock()
 		if cachedBotUsername == "" {
@@ -54,13 +52,11 @@ func getBotUsername(b *gotgbot.Bot) string {
 			return cached
 		}
 	}
-	// Re-check under RLock in case another goroutine populated it
 	cachedBotUsernameMu.RLock()
 	defer cachedBotUsernameMu.RUnlock()
 	return cachedBotUsername
 }
 
-// Dynamic strings that will be loaded using i18n
 func getAboutText(tr *i18n.Translator) string {
 	text, _ := tr.GetString("help_info_about_header")
 	return text
@@ -78,7 +74,6 @@ func getMainHelp(tr *i18n.Translator, firstName string) string {
 	return text1 + text2
 }
 
-// Dynamic keyboard generation functions
 func getAboutKb(tr *i18n.Translator) gotgbot.InlineKeyboardMarkup {
 	aboutMeText, _ := tr.GetString("help_button_about_me")
 	newsChannelText, _ := tr.GetString("help_button_news_channel")
@@ -127,7 +122,6 @@ func getStartMarkup(tr *i18n.Translator, botUsername string) gotgbot.InlineKeybo
 	commandsHelpText, _ := tr.GetString("help_button_commands_help")
 	languageText, _ := tr.GetString("help_button_language")
 
-	// Build the add to chat URL dynamically using the bot's username
 	addToChatUrl := fmt.Sprintf("https://t.me/%s?startgroup=botstart", botUsername)
 
 	return gotgbot.InlineKeyboardMarkup{
@@ -164,8 +158,6 @@ func getStartMarkup(tr *i18n.Translator, botUsername string) gotgbot.InlineKeybo
 	}
 }
 
-// about displays information about the bot including version and features.
-// Shows bot details, links to support channels, and configuration options.
 func (moduleStruct) about(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 
@@ -279,8 +271,6 @@ func (moduleStruct) about(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// helpButtonHandler processes callback queries from help menu button interactions.
-// Navigates between help sections and displays appropriate help content for modules.
 func (moduleStruct) helpButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -307,26 +297,21 @@ func (moduleStruct) helpButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		replyKb             gotgbot.InlineKeyboardMarkup
 	)
 
-	// Sort the module names
 	if slices.Contains([]string{"BackStart", "Help"}, module) {
 		parsemode = formatting.HTML
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		switch module {
 		case "Help":
-			// This shows the main start menu
 			helpText = getMainHelp(tr, html.EscapeString(query.From.FirstName))
 			replyKb = markup
 		case "BackStart":
-			// This shows the modules menu
 			helpText = getStartHelp(tr)
 			replyKb = getStartMarkup(tr, getBotUsername(b))
 		}
 	} else {
-		// For all remaining modules
 		helpText, replyKb, parsemode = getHelpTextAndMarkup(ctx, strings.ToLower(module), DefaultHelpRegistry())
 	}
 
-	// Edit the main message, the main querymessage
 	_, _, err := query.Message.EditText(b, &gotgbot.EditMessageTextOpts{Text: helpText, ParseMode: parsemode,
 		ReplyMarkup: replyKb,
 		LinkPreviewOptions: &gotgbot.LinkPreviewOptions{
@@ -346,9 +331,6 @@ func (moduleStruct) helpButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// start introduces the bot
-// start handles the /start command and displays welcome message with navigation options.
-// Shows different content in private vs group chats and handles start parameters.
 func (moduleStruct) start(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -397,8 +379,6 @@ func (moduleStruct) start(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// donate displays information about supporting the bot and its development.
-// Shows donation links and ways users can contribute to bot maintenance.
 func (moduleStruct) donate(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -427,8 +407,6 @@ func (moduleStruct) donate(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// botConfig provides step-by-step configuration guidance for new users.
-// Walks users through adding the bot to chats and basic setup procedures.
 func (moduleStruct) botConfig(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -442,7 +420,6 @@ func (moduleStruct) botConfig(b *gotgbot.Bot, ctx *ext.Context) error {
 		return answerInvalidCallback(b, ctx, query)
 	}
 
-	// just in case
 	if msg.GetChat().Type != "private" {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("help_config_private_only")
@@ -538,8 +515,6 @@ func (moduleStruct) botConfig(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// help displays the main help menu or specific module help information.
-// Shows module list in private messages or provides links to PM help in groups.
 func (moduleStruct) help(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	msg := ctx.EffectiveMessage
@@ -628,8 +603,6 @@ func (moduleStruct) help(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadHelp registers all help-related command and callback handlers.
-// Sets up the help system including start, about, donate, and configuration commands.
 func LoadHelp(dispatcher *ext.Dispatcher) {
 	dispatcher.AddHandler(handlers.NewCommand("start", DefaultHelpRegistry().start))
 	dispatcher.AddHandler(handlers.NewCommand("help", DefaultHelpRegistry().help))

--- a/alita/modules/help_system.go
+++ b/alita/modules/help_system.go
@@ -13,7 +13,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
 )
 
-// markup is the global help menu keyboard.
 var markup gotgbot.InlineKeyboardMarkup
 
 func listModulesFrom(registry *moduleStruct) []string {
@@ -27,12 +26,10 @@ func listModulesFrom(registry *moduleStruct) []string {
 	return modules
 }
 
-// initHelpButtons initializes the help menu keyboard with all enabled modules.
 func initHelpButtons() {
 	markup = initHelpButtonsFrom(DefaultHelpRegistry())
 }
 
-// initHelpButtonsFrom builds a help menu keyboard from the given registry.
 func initHelpButtonsFrom(registry *moduleStruct) gotgbot.InlineKeyboardMarkup {
 	var kb []gotgbot.InlineKeyboardButton
 
@@ -52,7 +49,6 @@ func initHelpButtonsFrom(registry *moduleStruct) gotgbot.InlineKeyboardMarkup {
 	return gotgbot.InlineKeyboardMarkup{InlineKeyboard: zb}
 }
 
-// getModuleHelpAndKb retrieves help text and keyboard for a specific module.
 func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText string, replyMarkup gotgbot.InlineKeyboardMarkup) {
 	ModName := module
 	if ModName != "" {
@@ -61,9 +57,6 @@ func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText s
 	tr := i18n.MustNewTranslator(lang)
 	helpMsg, _ := tr.GetString(fmt.Sprintf("%s_help_msg", strings.ToLower(ModName)))
 	headerTemplate, _ := tr.GetString("helpers_module_help_header")
-	// Convert the markdown header and the body independently. Concatenating
-	// first then running MD2HTMLV2 escapes already-HTML _help_msg strings
-	// (reactions/backup/approvals/antispam) into visible <b> tags.
 	helpText = renderModuleHelp(headerTemplate, ModName, helpMsg)
 
 	backText, _ := tr.GetString("common_back_arrow")
@@ -86,15 +79,11 @@ func getModuleHelpAndKb(module, lang string, registry *moduleStruct) (helpText s
 	return
 }
 
-// renderModuleHelp converts the markdown help header and the module body to
-// Telegram HTML independently so HTML-authored _help_msg strings keep their
-// tags instead of being escaped into visible <b> text.
 func renderModuleHelp(headerTemplate, modName, helpMsg string) string {
 	return formatting.ToTelegramHTML(fmt.Sprintf(headerTemplate, modName)) +
 		formatting.ToTelegramHTML(helpMsg)
 }
 
-// sendHelpkb sends help information for a specific module with navigation keyboard.
 func sendHelpkb(b *gotgbot.Bot, ctx *ext.Context, module string, registry *moduleStruct) (msg *gotgbot.Message, err error) {
 	module = strings.ToLower(module)
 	if module == "help" {
@@ -123,7 +112,6 @@ func sendHelpkb(b *gotgbot.Bot, ctx *ext.Context, module string, registry *modul
 	return
 }
 
-// getModuleNameFromAltName resolves alternative module names to their canonical form.
 func getModuleNameFromAltName(altName string, registry *moduleStruct) string {
 	for _, modName := range listModulesFrom(registry) {
 		altNames := getAltNamesOfModule(modName)
@@ -136,14 +124,12 @@ func getModuleNameFromAltName(altName string, registry *moduleStruct) string {
 	return ""
 }
 
-// getAltNamesOfModule returns all alternative names for a given module.
 func getAltNamesOfModule(moduleName string) []string {
 	tr := i18n.MustNewTranslator("config")
 	altNamesFromConfig, _ := tr.GetStringSlice(fmt.Sprintf("alt_names.%s", moduleName))
 	return append(altNamesFromConfig, strings.ToLower(moduleName))
 }
 
-// getHelpTextAndMarkup generates help content and keyboard for a module or main help.
 func getHelpTextAndMarkup(ctx *ext.Context, module string, registry *moduleStruct) (helpText string, kbmarkup gotgbot.InlineKeyboardMarkup, _parsemode string) {
 	var moduleName string
 	userOrGroupLanguage := lang.GetLanguage(ctx)

--- a/alita/modules/helpers_test.go
+++ b/alita/modules/helpers_test.go
@@ -50,7 +50,6 @@ func TestListModules(t *testing.T) {
 		t.Fatalf("listModules() = %v (len %d), want 3 elements", result, len(result))
 	}
 
-	// Result must be sorted alphabetically.
 	expected := []string{"admin", "filters", "help"}
 	for i, name := range expected {
 		if result[i] != name {
@@ -368,8 +367,6 @@ func TestHandleDeepLinkSendsAboutAndDefaultHelp(t *testing.T) {
 	}
 }
 
-// TestGetModuleHelpAndKb_UsesPassedRegistry proves that getModuleHelpAndKb honors
-// the passed *moduleStruct registry instead of reaching for the global HelpModule.
 func TestGetModuleHelpAndKb_UsesPassedRegistry(t *testing.T) {
 	localRegistry := newHelpRegistry()
 	localRegistry.AbleMap["Admin"] = true
@@ -384,7 +381,6 @@ func TestGetModuleHelpAndKb_UsesPassedRegistry(t *testing.T) {
 		t.Fatalf("inline keyboard rows = %d, want at least module row + navigation", len(kb.InlineKeyboard))
 	}
 
-	// Verify the first row comes from the local registry.
 	firstRow := kb.InlineKeyboard[0]
 	if len(firstRow) != 1 {
 		t.Fatalf("first module row len = %d, want 1", len(firstRow))
@@ -396,7 +392,6 @@ func TestGetModuleHelpAndKb_UsesPassedRegistry(t *testing.T) {
 		t.Fatalf("button[0].CallbackData = %q, want test-admin", firstRow[0].CallbackData)
 	}
 
-	// Verify the second module row.
 	secondRow := kb.InlineKeyboard[1]
 	if len(secondRow) != 1 {
 		t.Fatalf("second module row len = %d, want 1", len(secondRow))
@@ -405,15 +400,12 @@ func TestGetModuleHelpAndKb_UsesPassedRegistry(t *testing.T) {
 		t.Fatalf("button[1].Text = %q, want FakeAdminBtn2", secondRow[0].Text)
 	}
 
-	// Verify that back + home navigation buttons are present in last row.
 	lastRow := kb.InlineKeyboard[len(kb.InlineKeyboard)-1]
 	if len(lastRow) != 2 {
 		t.Fatalf("last row len = %d, want 2 (back + home)", len(lastRow))
 	}
 }
 
-// TestGetModuleNameFromAltName_UsesPassedRegistry proves getModuleNameFromAltName
-// resolves against the registry passed as parameter rather than the global HelpModule.
 func TestGetModuleNameFromAltName_UsesPassedRegistry(t *testing.T) {
 	localRegistry := newHelpRegistry()
 	localRegistry.AbleMap["Filters"] = true
@@ -440,13 +432,10 @@ func TestGetModuleNameFromAltName_UsesPassedRegistry(t *testing.T) {
 	}
 }
 
-// TestGetHelpTextAndMarkup_UsesPassedRegistry proves getHelpTextAndMarkup resolves
-// the module list and keyboard from the passed registry, not from the global.
 func TestGetHelpTextAndMarkup_UsesPassedRegistry(t *testing.T) {
 	localRegistry := newHelpRegistry()
 	localRegistry.AbleMap["Admin"] = true
 	localRegistry.AbleMap["Filters"] = true
-	// Do NOT store "Warns" — querying "warns" should miss in local registry.
 	localRegistry.helpableKb["Admin"] = [][]gotgbot.InlineKeyboardButton{
 		{{Text: "CustomAdmin", CallbackData: "custom-admin"}},
 	}
@@ -525,8 +514,6 @@ func TestHandleDeepLinkPropagatesAboutAndDefaultSendErrors(t *testing.T) {
 // The test harness maps user ID 13 to {"status":"left"} and user ID 14 to
 // {"status":"kicked"}, so both IDs represent non-members.
 func TestDeepLinkNonMemberDenied(t *testing.T) {
-	// Override the global i18n manager so MustNewTranslator returns real strings.
-	// This lets us assert that the rejection text IS sent and content is NOT.
 	restore, err := i18n.OverrideManagerForTest(deepLinkTestYAML)
 	if err != nil {
 		t.Fatalf("OverrideManagerForTest() error = %v", err)
@@ -535,7 +522,6 @@ func TestDeepLinkNonMemberDenied(t *testing.T) {
 
 	chatID := uniqueModuleChatID()
 
-	// Seed the target chat and some content.
 	if err := chats.EnsureChatInDb(chatID, "Secure Chat"); err != nil {
 		t.Fatalf("EnsureChatInDb() error = %v", err)
 	}
@@ -548,7 +534,6 @@ func TestDeepLinkNonMemberDenied(t *testing.T) {
 		_ = notes.RemoveNote(chatID, "secret")
 	})
 
-	// Non-member: user ID 13 (status:"left" in test harness).
 	nonMemberUser := gotgbot.User{Id: 13, FirstName: "Left User"}
 	privateChat := gotgbot.Chat{Id: nonMemberUser.Id, Type: "private", FirstName: "Left User"}
 
@@ -580,18 +565,13 @@ func TestDeepLinkNonMemberDenied(t *testing.T) {
 				t.Fatalf("sendMessage calls = %d, want 1 (rejection notice)", len(calls))
 			}
 
-			// The sent text MUST be the rejection message (not the served content).
 			text, _ := calls[0].Params["text"].(string)
 			if !strings.Contains(text, "Could not find the chat") {
 				t.Fatalf("non-member received unexpected message (not the rejection): %q", text)
 			}
-			// The sent text MUST NOT contain any seeded content that would indicate
-			// the security gate was bypassed and content was leaked.
 			if strings.Contains(text, "No spam.") || strings.Contains(text, "Secret content") || strings.Contains(text, "secret") {
 				t.Fatalf("non-member leaked content via deep link: %q", text)
 			}
-			// For the note subtest: verify no alternative content-delivery call fired
-			// (e.g. sendDocument or sendPhoto that media.SendNote might use for media notes).
 			for _, call := range client.calls {
 				if call.Method == "sendDocument" || call.Method == "sendPhoto" || call.Method == "sendAudio" || call.Method == "sendVideo" {
 					t.Fatalf("non-member triggered content-delivery call %q — gate was bypassed", call.Method)
@@ -606,8 +586,6 @@ func TestDeepLinkNonMemberDenied(t *testing.T) {
 //
 // The test harness maps user ID 42 to {"status":"member"} — a legitimate member.
 func TestDeepLinkMemberAllowed(t *testing.T) {
-	// Override the global i18n manager so MustNewTranslator returns real strings.
-	// This lets us assert that actual content (not a rejection) is delivered.
 	restore, err := i18n.OverrideManagerForTest(deepLinkTestYAML)
 	if err != nil {
 		t.Fatalf("OverrideManagerForTest() error = %v", err)
@@ -634,8 +612,8 @@ func TestDeepLinkMemberAllowed(t *testing.T) {
 	cases := []struct {
 		name       string
 		arg        string
-		wantText   string // substring that must appear in the sent text
-		forbidText string // substring that must NOT appear (the rejection)
+		wantText   string
+		forbidText string
 	}{
 		{
 			name:       "rules allowed for member",
@@ -676,7 +654,6 @@ func TestDeepLinkMemberAllowed(t *testing.T) {
 				t.Fatalf("sendMessage calls = %d, want 1 (content reply)", len(calls))
 			}
 
-			// The sent text MUST contain actual content, not the rejection message.
 			text, _ := calls[0].Params["text"].(string)
 			if strings.Contains(text, tc.forbidText) {
 				t.Fatalf("member was wrongly denied — got rejection text in response: %q", text)

--- a/alita/modules/language.go
+++ b/alita/modules/language.go
@@ -19,8 +19,6 @@ import (
 
 var languagesModule = moduleStruct{moduleName: "Languages"}
 
-// genFullLanguageKb generates the complete language selection keyboard.
-// Creates inline buttons for all available languages plus a translation contribution link.
 func (moduleStruct) genFullLanguageKb() [][]gotgbot.InlineKeyboardButton {
 	keyboard := keyboard.MakeLanguageKeyboard()
 	tr := i18n.MustNewTranslator("en")
@@ -37,8 +35,6 @@ func (moduleStruct) genFullLanguageKb() [][]gotgbot.InlineKeyboardButton {
 	return keyboard
 }
 
-// changeLanguage displays the language selection menu for users or groups.
-// Shows current language and allows users/admins to select a different interface language.
 func (m moduleStruct) changeLanguage(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -56,7 +52,6 @@ func (m moduleStruct) changeLanguage(b *gotgbot.Bot, ctx *ext.Context) error {
 		replyString, _ = tr.GetString("language_current_user", i18n.TranslationParams{"s": keyboard.GetLangFormat(cLang)})
 	} else {
 
-		// language won't be changed if user is not admin
 		if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 			chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 			return ext.EndGroups
@@ -82,8 +77,6 @@ func (m moduleStruct) changeLanguage(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// langBtnHandler processes language selection callback queries from the language menu.
-// Updates user or group language preferences based on admin permissions and context.
 func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -120,16 +113,13 @@ func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	tr := i18n.MustNewTranslator(language)
 
-	// For group chats, check admin permissions first before any language operations
 	if chat.Type != "private" {
-		// Permission denied - callback answer is handled by PermissionResponder
 		if !chat_status.RequireUserAdmin(b, ctx, chat, user.Id) {
 			chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 			return ext.EndGroups
 		}
 	}
 
-	// Now we can safely create translator for the target language
 	var replyString string
 
 	if chat.Type == "private" {
@@ -141,7 +131,6 @@ func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		replyString, _ = tr.GetString("language_changed_user", i18n.TranslationParams{"s": keyboard.GetLangFormat(language)})
 	} else {
-		// User is admin (already verified above)
 		if err := lang.ChangeGroupLanguage(chat.Id, language); err != nil {
 			log.Errorf("[Language] ChangeGroupLanguage failed for chat %d: %v", chat.Id, err)
 			errText, _ := tr.GetString("common_settings_save_failed")
@@ -160,7 +149,6 @@ func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Answer the callback query to stop the loading spinner.
 	_, err := query.Answer(b, nil)
 	if err != nil {
 		log.Error(err)
@@ -178,8 +166,6 @@ func (moduleStruct) langBtnHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadLanguage registers language-related command and callback handlers.
-// Sets up language selection commands and keyboard navigation for internationalization.
 func LoadLanguage(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[languagesModule.moduleName] = true
 	DefaultHelpRegistry().helpableKb[languagesModule.moduleName] = languagesModule.genFullLanguageKb()

--- a/alita/modules/logchannels.go
+++ b/alita/modules/logchannels.go
@@ -252,7 +252,6 @@ func (moduleStruct) captureSetLogForward(b *gotgbot.Bot, ctx *ext.Context) error
 	return ext.ContinueGroups
 }
 
-// LoadLogChannels registers log-channel commands and the forward watcher.
 func LoadLogChannels(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[logChannelsModule.moduleName] = true
 

--- a/alita/modules/notes.go
+++ b/alita/modules/notes.go
@@ -46,12 +46,8 @@ func deleteNoteOverwriteCache(token string) {
 	deleteOverwriteCache(noteOverwriteCacheKey(token))
 }
 
-// addNote handles the /save command to create new notes
-// with support for various media types and formatting options.
-//
 //nolint:dupl // addNote shares validation logic with filters module by design
 func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -65,7 +61,6 @@ func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	args := ctx.Args()
 
-	// check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -105,8 +100,6 @@ func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// if user specifies both noprivate and private, the note will be sent to default.
-	// If privatenotes is enabled, the private else group
 	if grpOnly && pvtOnly {
 		grpOnly, pvtOnly = false, false
 		noteConflictText, _ := tr.GetString("notes_private_conflict_warning")
@@ -115,7 +108,6 @@ func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	noteWord = strings.ToLower(noteWord)
 
-	// check if note already exists or not
 	if notes.DoesNoteExists(chat.Id, noteWord) {
 		token, tokenErr := newOverwriteToken()
 		if tokenErr != nil {
@@ -185,7 +177,6 @@ func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Fix Issue 1: Remove go keyword and handle error synchronously
 	if err := notes.AddNote(chat.Id, noteWord, text, fileid, buttons, dataType, pvtOnly, grpOnly, adminOnly, webPrev, isProtected, noNotif); err != nil {
 		log.Errorf("[Notes] Failed to add note %s in chat %d: %v", noteWord, chat.Id, err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -207,11 +198,8 @@ func (m moduleStruct) addNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// rmNote handles the /clear command to remove existing notes
-// from the chat, requiring admin permissions.
 func (moduleStruct) rmNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -235,20 +223,17 @@ func (moduleStruct) rmNote(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Extract note word safely to prevent panic
 	parts := strings.SplitN(msg.Text, " ", 2)
 	if len(parts) < 2 {
-		return ext.EndGroups // should not happen due to len(args) check above
+		return ext.EndGroups
 	}
 	noteWord := strings.TrimLeft(parts[1], "#")
 
-	// check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
 	}
 
-	// check if note exists in admin notes as well
 	if !slices.Contains(notes.GetNotesList(chat.Id, true), strings.ToLower(noteWord)) {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("notes_not_exists")
@@ -261,7 +246,6 @@ func (moduleStruct) rmNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	noteWord, _ = extraction.ExtractQuotes(noteWord, false, true)
 
-	// Fix Issue 2: Add error handling for RemoveNote
 	if err := notes.RemoveNote(chat.Id, strings.ToLower(noteWord)); err != nil {
 		log.Errorf("[Notes] Failed to remove note %s in chat %d: %v", noteWord, chat.Id, err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -284,8 +268,6 @@ func (moduleStruct) rmNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// privNote handles the /privnote command to toggle private notes
-// setting, controlling whether notes are sent privately or in group.
 func (moduleStruct) privNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -306,14 +288,12 @@ func (moduleStruct) privNote(b *gotgbot.Bot, ctx *ext.Context) error {
 		case "on", "yes", "true":
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 			txt, _ = tr.GetString("notes_private_enabled")
-			// Fix Issue 2a: Remove go keyword and handle error
 			if err := notes.TooglePrivateNote(chat.Id, true); err != nil {
 				log.Errorf("[Notes] Failed to enable private notes for chat %d: %v", chat.Id, err)
 			}
 		case "off", "no", "false":
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 			txt, _ = tr.GetString("notes_private_disabled")
-			// Fix Issue 2b: Remove go keyword and handle error
 			if err := notes.TooglePrivateNote(chat.Id, false); err != nil {
 				log.Errorf("[Notes] Failed to disable private notes for chat %d: %v", chat.Id, err)
 			}
@@ -338,15 +318,11 @@ func (moduleStruct) privNote(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// notesList handles the /notes command to display all available
-// notes in the chat with appropriate access controls.
 func (moduleStruct) notesList(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "notes") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -371,10 +347,7 @@ func (moduleStruct) notesList(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// if user uses the /note command in private chat
-	// No matter if privRules are set or not
 	if ctx.Message.Chat.Type == "private" {
-		// check if want admin notes or not
 		admin := chat_status.IsUserAdmin(b, chat.Id, user.Id)
 		noteKeys := notes.GetNotesList(chat.Id, admin)
 		listText, _ := tr.GetString("notes_list_for_chat")
@@ -438,9 +411,6 @@ func (moduleStruct) notesList(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// rmAllNotes handles the /clearall command to remove all notes
-// from the chat, restricted to chat owners only.
-//
 //nolint:dupl // rmAllNotes shares confirmation pattern with filters module by design
 func (moduleStruct) rmAllNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	user := chat_status.RequireUser(b, ctx)
@@ -455,7 +425,6 @@ func (moduleStruct) rmAllNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// check notes in adminkeys as well
 	noteKeys := notes.GetNotesList(chat.Id, true)
 	if len(noteKeys) == 0 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -514,10 +483,6 @@ func (moduleStruct) rmAllNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// noteOverWriteHandler processes callback queries for note overwrite
-// confirmations when adding notes that already exist.
-// Callback format:
-// - v1 codec: notes.overwrite|v1|a={yes/no}&t={token}
 func (m moduleStruct) noteOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -525,7 +490,6 @@ func (m moduleStruct) noteOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) err
 	}
 	user := query.From
 
-	// permission checks
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
@@ -636,8 +600,6 @@ func (m moduleStruct) noteOverWriteHandler(b *gotgbot.Bot, ctx *ext.Context) err
 	return ext.EndGroups
 }
 
-// notesButtonHandler processes callback queries for the remove all notes
-// confirmation dialog, restricted to chat owners.
 func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -645,7 +607,6 @@ func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	user := query.From
 
-	// permission checks
 	if !chat_status.RequireUserOwner(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
 		return ext.EndGroups
@@ -665,7 +626,6 @@ func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	chat := ctx.EffectiveChat
 	switch response {
 	case "yes":
-		// Fix Issue 4: Add error handling for RemoveAllNotes
 		if chat == nil {
 			helpText, _ = tr.GetString("error_generic")
 			break
@@ -708,8 +668,6 @@ func (moduleStruct) notesButtonHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// notesWatcher monitors messages starting with '#' and automatically
-// sends the corresponding note if it exists in the chat.
 func (m moduleStruct) notesWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	chat := ctx.EffectiveChat
@@ -727,19 +685,17 @@ func (m moduleStruct) notesWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		replyMsgId = msg.MessageId
 	}
 
-	parseText := strings.ToLower(msg.Text)[1:] // remove '#' from note name
+	parseText := strings.ToLower(msg.Text)[1:]
 	noteNameArgs := strings.Split(parseText, " ")
 	noteName := noteNameArgs[0]
 	noformatNote := len(noteNameArgs) == 2 && noteNameArgs[1] == "noformat"
 
-	// if note does not exist, continue groups
 	if !slices.Contains(notes.GetNotesList(chat.Id, true), strings.ToLower(noteName)) {
 		return ext.ContinueGroups
 	}
 
 	noteData := notes.GetNote(chat.Id, strings.ToLower(noteName))
 
-	// check if notedata is correct or not
 	if noteData.NoteContent == "" && noteData.FileID == "" {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("notes_parsing_error")
@@ -751,8 +707,6 @@ func (m moduleStruct) notesWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// check for admin only notes
-	// admin notes follow the group note policy
 	if noteData.AdminOnly {
 		if !chat_status.IsUserAdmin(b, chat.Id, user.Id) {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -774,10 +728,8 @@ func (m moduleStruct) notesWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 	} else {
 
-		// chat has private notes enabled or note is private and not group note
 		privateNoteOnly := (notes.GetNotes(chat.Id).PrivateNotesEnabled() || noteData.PrivateOnly) && !noteData.GroupOnly
 
-		// send private note if private notes is enabled or note is private, and it is not group note
 		if privateNoteOnly {
 			if ctx.Message.Chat.Type == "private" {
 				_, err = media.SendNote(b, ctx, chat, noteData, replyMsgId, ctx.Message.MessageThreadId)
@@ -818,15 +770,11 @@ func (m moduleStruct) notesWatcher(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// getNotes handles the /get command to retrieve and send
-// specific notes by name with format options.
 func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(b, msg, "get") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(b, ctx, false, false)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -861,7 +809,6 @@ func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 	noteName := args[0]
 
-	// check if note exists or not
 	if !slices.Contains(notes.GetNotesList(chat.Id, true), strings.ToLower(noteName)) {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("notes_does_not_exist")
@@ -875,7 +822,6 @@ func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	noteData := notes.GetNote(chat.Id, strings.ToLower(noteName))
 
-	// check if notedata is correct or not
 	if noteData.NoteContent == "" && noteData.FileID == "" {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("notes_parsing_error_support")
@@ -887,8 +833,6 @@ func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// check for admin only notes
-	// admin notes follow the group note policy
 	if noteData.AdminOnly {
 		if !chat_status.IsUserAdmin(b, chat.Id, user.Id) {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -905,7 +849,6 @@ func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	if len(args) == 2 && strings.ToLower(args[1]) == "noformat" {
 		err = m.sendNoFormatNote(b, ctx, replyMsgId, noteData)
 	} else {
-		// send private note if private notes is enabled or note is private, and it is not group note
 		if (notes.GetNotes(chat.Id).PrivateNotesEnabled() || noteData.PrivateOnly) && !noteData.GroupOnly {
 			tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 			clickForPrivateText, _ := tr.GetString("notes_click_for_private")
@@ -942,8 +885,6 @@ func (m moduleStruct) getNotes(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// sendNoFormatNote sends a note in raw format without markdown processing,
-// showing the original formatting codes, restricted to admins.
 func (moduleStruct) sendNoFormatNote(b *gotgbot.Bot, ctx *ext.Context, replyMsgId int64, noteData *db.Notes) error {
 	user := chat_status.RequireUser(b, ctx)
 	if user == nil {
@@ -951,20 +892,15 @@ func (moduleStruct) sendNoFormatNote(b *gotgbot.Bot, ctx *ext.Context, replyMsgI
 		return ext.EndGroups
 	}
 
-	// check if user is admin or not
 	if !chat_status.RequireUserAdmin(b, ctx, nil, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_user_admin_cmd_error", "chat_status_user_admin_button_error", chat_status.WithReplyFallback())
 		return ext.EndGroups
 	}
 
-	// Reverse notedata
 	noteData.NoteContent = formatting.ReverseHTML2MD(noteData.NoteContent)
 
-	// show the buttons back as text
 	noteData.NoteContent += content.RevertButtons(noteData.Buttons)
 
-	// Send note using the new media package
-	// raw note does not need webpreview
 	_, err := media.Send(b, media.Content{
 		Text:    noteData.NoteContent,
 		FileID:  noteData.FileID,
@@ -975,7 +911,7 @@ func (moduleStruct) sendNoFormatNote(b *gotgbot.Bot, ctx *ext.Context, replyMsgI
 		ReplyMsgID:        replyMsgId,
 		ThreadID:          ctx.Message.MessageThreadId,
 		Keyboard:          &gotgbot.InlineKeyboardMarkup{InlineKeyboard: nil},
-		NoFormat:          true, // noformat mode
+		NoFormat:          true,
 		NoNotif:           noteData.NoNotif,
 		WebPreview:        false,
 		IsProtected:       noteData.IsProtected,
@@ -989,8 +925,6 @@ func (moduleStruct) sendNoFormatNote(b *gotgbot.Bot, ctx *ext.Context, replyMsgI
 	return nil
 }
 
-// LoadNotes registers all notes module handlers with the dispatcher,
-// including note management commands and the notes watcher.
 func LoadNotes(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[notesModule.moduleName] = true
 
@@ -1001,13 +935,12 @@ func LoadNotes(dispatcher *ext.Dispatcher) {
 				CallbackData: encodeCallbackData("helpq", map[string]string{"m": "Formatting"}),
 			},
 		},
-	} // Adds Formatting kb button to Notes Menu
+	}
 	dispatcher.AddHandler(handlers.NewCommand("save", notesModule.addNote))
 	dispatcher.AddHandler(handlers.NewCommand("addnote", notesModule.addNote))
 	dispatcher.AddHandler(handlers.NewCommand("clear", notesModule.rmNote))
 	dispatcher.AddHandler(handlers.NewCommand("rmnote", notesModule.rmNote))
 	dispatcher.AddHandler(handlers.NewCommand("notes", notesModule.notesList))
-	// Alias: /saved should behave like /notes per documentation
 	dispatcher.AddHandler(handlers.NewCommand("saved", notesModule.notesList))
 	helpers.AddCmdToDisableable("notes")
 	dispatcher.AddHandler(handlers.NewCommand("clearall", notesModule.rmAllNotes))
@@ -1037,7 +970,6 @@ func parseChatInfoFromDeepLink(b *gotgbot.Bot, ctx *ext.Context, arg string) (ch
 	nArgs := strings.SplitN(arg, "_", 3)
 	msg := ctx.EffectiveMessage
 
-	// Validate deep link has at least chat ID
 	if len(nArgs) < 2 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("helpers_invalid_deep_link")
@@ -1117,7 +1049,6 @@ func noteDeepLinkHandler(b *gotgbot.Bot, ctx *ext.Context, user *gotgbot.User, a
 	}
 
 	nArgs := strings.SplitN(arg, "_", 3)
-	// Validate deep link has note name
 	if len(nArgs) < 3 {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("helpers_invalid_deep_link")
@@ -1156,8 +1087,6 @@ func noteDeepLinkHandler(b *gotgbot.Bot, ctx *ext.Context, user *gotgbot.User, a
 	return ext.EndGroups
 }
 
-// invalidNoteDeepLinkHandler handles malformed note deep links (e.g. /start note without underscore).
-// Preserves the old behavior from the monolithic startHelpPrefixHandler.
 func invalidNoteDeepLinkHandler(b *gotgbot.Bot, ctx *ext.Context, user *gotgbot.User, arg string) error {
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 	text, _ := tr.GetString("helpers_invalid_deep_link")

--- a/alita/modules/reactions.go
+++ b/alita/modules/reactions.go
@@ -35,22 +35,17 @@ var supportedReactionEmoji = []string{
 	"🤷‍♀", "😡",
 }
 
-// LoadReactions loads the reactions module with all command handlers
 func LoadReactions(dispatcher *ext.Dispatcher) {
-	// Admin commands
 	dispatcher.AddHandler(handlers.NewCommand("addreaction", reactionsModule.addReaction))
 	dispatcher.AddHandler(handlers.NewCommand("removereaction", reactionsModule.removeReaction))
 	dispatcher.AddHandler(handlers.NewCommand("reactions", reactionsModule.listReactions))
 	dispatcher.AddHandler(handlers.NewCommand("resetreactions", reactionsModule.resetReactions))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("reactions_help"), reactionsModule.reactionsHelpHandler))
 
-	// Message watcher for reactions (positive handler group for monitoring)
 	dispatcher.AddHandlerToGroup(handlers.NewMessage(message.All, reactionsModule.checkReactions), reactionsModule.handlerGroup)
 
-	// Register module as disableable
 	DefaultHelpRegistry().AbleMap[reactionsModule.moduleName] = true
 
-	// Add help text
 	DefaultHelpRegistry().AltHelpOptions["Reactions"] = []string{"reaction"}
 	DefaultHelpRegistry().helpableKb["Reactions"] = [][]gotgbot.InlineKeyboardButton{
 		{
@@ -68,7 +63,6 @@ func LoadReactions(dispatcher *ext.Dispatcher) {
 	log.Info("[Modules] Reactions module loaded")
 }
 
-// reactionsHelpHandler handles inline help callbacks for reaction commands.
 func (m moduleStruct) reactionsHelpHandler(b *gotgbot.Bot, ctx *ext.Context) error {
 	query, ok := callbackQueryFromContext(ctx)
 	if !ok {
@@ -128,7 +122,6 @@ func (m moduleStruct) reactionsHelpHandler(b *gotgbot.Bot, ctx *ext.Context) err
 	return ext.EndGroups
 }
 
-// addReaction handles /addreaction <keyword> <emoji> command
 func (m moduleStruct) addReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -143,7 +136,6 @@ func (m moduleStruct) addReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check permission - only admins can add reactions
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -176,7 +168,6 @@ func (m moduleStruct) addReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Store in DB (cache is invalidated by the repository).
 	if err := reactions.AddReaction(chat.Id, keyword, emoji); err != nil {
 		log.Errorf("[Reactions] Failed to save reaction: %v", err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -199,7 +190,6 @@ func (m moduleStruct) addReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// removeReaction handles /removereaction <keyword> command
 func (m moduleStruct) removeReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -214,7 +204,6 @@ func (m moduleStruct) removeReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
@@ -236,7 +225,6 @@ func (m moduleStruct) removeReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 
 	reactionsMap := reactions.GetReactions(chat.Id)
 
-	// Check if keyword exists
 	if _, exists := reactionsMap[keyword]; !exists {
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 		text, _ := tr.GetString("reactions_keyword_not_found", i18n.TranslationParams{
@@ -246,7 +234,6 @@ func (m moduleStruct) removeReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Remove reaction from DB (cache is invalidated by the repository).
 	if err := reactions.RemoveReaction(chat.Id, keyword); err != nil {
 		log.Errorf("[Reactions] Failed to update reactions: %v", err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -268,7 +255,6 @@ func (m moduleStruct) removeReaction(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// listReactions handles /reactions command
 func (m moduleStruct) listReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -287,7 +273,6 @@ func (m moduleStruct) listReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Build list
 	var sb strings.Builder
 	for keyword, emoji := range reactionsMap {
 		fmt.Fprintf(&sb, "• %s → %s\n", html.EscapeString(keyword), html.EscapeString(emoji))
@@ -306,7 +291,6 @@ func (m moduleStruct) listReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetReactions handles /resetreactions command
 func (m moduleStruct) resetReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -321,13 +305,11 @@ func (m moduleStruct) resetReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.EndGroups
 	}
 
-	// Check permission
 	if !chat_status.CanUserChangeInfo(b, ctx, chat, user.Id) {
 		chat_status.NewPermissionResponder(b).Respond(ctx, "chat_status_change_info_cmd_error", "chat_status_change_info_button_error")
 		return ext.EndGroups
 	}
 
-	// Delete all reactions from DB (cache is invalidated by the repository).
 	if err := reactions.ResetReactions(chat.Id); err != nil {
 		log.Errorf("[Reactions] Failed to reset reactions: %v", err)
 		tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
@@ -347,7 +329,6 @@ func (m moduleStruct) resetReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// checkReactions checks incoming messages and reacts with emojis when keywords match
 func (m moduleStruct) checkReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 	defer func() {
 		if r := recover(); r != nil {
@@ -365,14 +346,11 @@ func (m moduleStruct) checkReactions(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	// Get reactions for this chat (read-through cache backed by the DB).
 	reactionsMap := reactions.GetReactions(chat.Id)
 	if len(reactionsMap) == 0 {
 		return ext.ContinueGroups
 	}
 
-	// Check if message text contains any keywords (case-insensitive).
-	// Collect all matching keywords first, then sort them for deterministic selection.
 	lowerText := strings.ToLower(msg.Text)
 	var matchedKeywords []string
 	for keyword := range reactionsMap {

--- a/alita/modules/rules.go
+++ b/alita/modules/rules.go
@@ -26,13 +26,9 @@ var rulesModule = moduleStruct{
 	defaultRulesBtn: "Rules",
 }
 
-// clearRules handles commands to completely remove all rules
-// from the chat, requiring admin permissions.
-//
 //nolint:dupl // clearRules has similar structure to resetRulesBtn
 func (moduleStruct) clearRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -56,11 +52,8 @@ func (moduleStruct) clearRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// privaterules handles the /privaterules command to toggle whether
-// rules are sent privately or in the group chat.
 func (moduleStruct) privaterules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -109,15 +102,11 @@ func (moduleStruct) privaterules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// sendRules handles the /rules command to display chat rules
-// either in the group or privately based on settings.
 func (m moduleStruct) sendRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// if command is disabled, return
 	if chat_status.CheckDisabledCmd(bot, msg, "rules") {
 		return ext.EndGroups
 	}
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, false, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -184,11 +173,8 @@ func (m moduleStruct) sendRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// setRules handles the /setrules command to create or update
-// chat rules with markdown formatting support.
 func (moduleStruct) setRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -204,12 +190,10 @@ func (moduleStruct) setRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 		if msg.ReplyToMessage != nil {
 			text = msg.ReplyToMessage.OriginalMDV2()
 		} else {
-			// Extract text safely to prevent panic and avoid setting empty rules
 			parts := strings.SplitN(msg.OriginalMDV2(), " ", 2)
 			if len(parts) >= 2 {
 				text = parts[1]
 			} else {
-				// No text provided after command - show error
 				text, _ = tr.GetString("rules_need_text")
 				_, err := msg.Reply(bot, text, formatting.Shtml())
 				if err != nil {
@@ -236,11 +220,8 @@ func (moduleStruct) setRules(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// rulesBtn handles the /rulesbutton command to set or view
-// the custom button text for private rules links.
 func (m moduleStruct) rulesBtn(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -292,13 +273,9 @@ func (m moduleStruct) rulesBtn(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// resetRulesBtn handles commands to reset the custom rules button
-// text back to the default value.
-//
 //nolint:dupl // resetRulesBtn has similar structure to clearRules
 func (moduleStruct) resetRulesBtn(bot *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
-	// connection status
 	connectedChat := chat_status.IsUserConnected(bot, ctx, true, true)
 	if connectedChat == nil {
 		return ext.EndGroups
@@ -322,8 +299,6 @@ func (moduleStruct) resetRulesBtn(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-// LoadRules registers all rules module handlers with the dispatcher,
-// including rules management and display commands.
 func LoadRules(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[rulesModule.moduleName] = true
 

--- a/alita/modules/rules_format.go
+++ b/alita/modules/rules_format.go
@@ -9,7 +9,6 @@ import (
 
 var htmlTagPattern = regexp.MustCompile(`(?i)<\/?[a-z][^>]*>`)
 
-// normalizeRulesForHTML ensures legacy markdown rules render correctly in HTML mode.
 func normalizeRulesForHTML(rawRules string) string {
 	trimmed := strings.TrimSpace(rawRules)
 	if trimmed == "" {

--- a/alita/modules/rules_format_test.go
+++ b/alita/modules/rules_format_test.go
@@ -22,7 +22,6 @@ func TestNormalizeRulesForHTML(t *testing.T) {
 		}
 	})
 
-	// HTML passthrough cases: function must return rawRules unchanged (not trimmed)
 	htmlPassthroughCases := []struct {
 		name  string
 		input string
@@ -36,14 +35,12 @@ func TestNormalizeRulesForHTML(t *testing.T) {
 		t.Run(tc.name+" passthrough", func(t *testing.T) {
 			t.Parallel()
 			got := normalizeRulesForHTML(tc.input)
-			// Must return rawRules (the original, not trimmed)
 			if got != tc.input {
 				t.Fatalf("normalizeRulesForHTML(%q) = %q, want unchanged %q", tc.input, got, tc.input)
 			}
 		})
 	}
 
-	// Markdown conversion cases: output must contain expected HTML
 	t.Run("markdown bold converted to HTML b tag", func(t *testing.T) {
 		t.Parallel()
 		input := "*bold*"
@@ -68,13 +65,11 @@ func TestNormalizeRulesForHTML(t *testing.T) {
 		t.Parallel()
 		input := "1 < 2 > 0"
 		got := normalizeRulesForHTML(input)
-		// htmlTagPattern does not match "< 2", so goes to MD2HTMLV2 which preserves plain text
 		if got == "" {
 			t.Fatalf("normalizeRulesForHTML(%q) returned empty, want non-empty", input)
 		}
 	})
 
-	// HTML entities without tags: not detected as HTML, processed as markdown
 	t.Run("HTML entities without tags processed as markdown", func(t *testing.T) {
 		t.Parallel()
 		input := "&amp; stuff"


### PR DESCRIPTION
Comment-only split of #830 (whose diff exceeded GitHub's 20k-line API limit for the lint action). No code, string, or test-name changes. Kept: go:build/embed, pedantic nolint/nosec, external-constraint notes, public-API contracts, test concurrency contracts.