### PR TITLE
chore: strip restatement comments in config/i18n/core

### DIFF
--- a/alita/config/config.go
+++ b/alita/config/config.go
@@ -13,9 +13,7 @@ import (
 
 	"github.com/divkix/Alita_Robot/alita/utils/logredact"
 )
-// isCliModeActive returns true if the program is running with CLI flags
-// that should skip database initialization (--version, --health, -v).
-// This allows init() functions to return early without requiring DB connection.
+
 func isCliModeActive() bool {
 	if len(os.Args) < 2 {
 		return false
@@ -30,15 +28,12 @@ func isCliModeActive() bool {
 	return false
 }
 
-// getRedisAddress returns the Redis address from REDIS_ADDRESS or parses it from REDIS_URL.
 // REDIS_URL format: redis://user:password@host:port (standard Redis URL format)
-// Returns: host:port
 func getRedisAddress() string {
 	if addr := os.Getenv("REDIS_ADDRESS"); addr != "" {
 		return addr
 	}
 
-	// Fallback to parsing REDIS_URL (standard Redis URL format used by many platforms)
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {
 		return ""
@@ -53,7 +48,6 @@ func getRedisAddress() string {
 	return parsed.Host
 }
 
-// getRedisURL returns REDIS_URL only when the direct address form is not in use.
 func getRedisURL() string {
 	if os.Getenv("REDIS_ADDRESS") != "" {
 		return ""
@@ -61,7 +55,6 @@ func getRedisURL() string {
 	return os.Getenv("REDIS_URL")
 }
 
-// getRedisPassword returns the Redis password from REDIS_PASSWORD or extracts it from REDIS_URL
 func getRedisPassword() string {
 	if pass := os.Getenv("REDIS_PASSWORD"); pass != "" {
 		return pass
@@ -70,7 +63,6 @@ func getRedisPassword() string {
 		return ""
 	}
 
-	// Fallback to extracting from REDIS_URL
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {
 		return ""
@@ -112,87 +104,66 @@ func getHTTPPort() int {
 	return typeConvertor{str: value}.Int()
 }
 
-// Config holds all configuration for the bot
 type Config struct {
-	// Core configuration
 	BotToken    string `validate:"required"`
 	BotVersion  string
 	ApiServer   string
 	WorkingMode string
 	Debug       bool
 
-	// Bot settings
 	OwnerId            int64 `validate:"required,min=1"`
 	MessageDump        int64 `validate:"required,min=1"`
 	DropPendingUpdates bool
 	AllowedUpdates     []string
 	ValidLangCodes     []string
 
-	// Database configuration
 	DatabaseURL string `validate:"required"`
 
-	// Database connection pool configuration
 	DBMaxIdleConns       int `validate:"min=1,max=100"`
 	DBMaxOpenConns       int `validate:"min=1,max=1000"`
-	DBConnMaxLifetimeMin int `validate:"min=1,max=1440"` // Max lifetime in minutes
-	DBConnMaxIdleTimeMin int `validate:"min=1,max=60"`   // Max idle time in minutes
+	DBConnMaxLifetimeMin int `validate:"min=1,max=1440"`
+	DBConnMaxIdleTimeMin int `validate:"min=1,max=60"`
 
-	// Database monitoring configuration
 	EnableDBMonitoring bool `env:"ENABLE_DB_MONITORING" envDefault:"false"`
 
-	// Redis configuration
 	RedisAddress  string `validate:"required"`
 	RedisURL      string
 	RedisPassword string
 	RedisDB       int
 
-	// HTTP Server configuration (unified server for health, metrics, webhook)
 	HTTPPort int `validate:"min=1,max=65535"`
 
-	// Webhook configuration
 	UseWebhooks   bool
 	WebhookDomain string
 	WebhookSecret string
 
-	// Safety and performance limits
 	EnablePerformanceMonitoring bool
 	EnableBackgroundStats       bool
-	DispatcherMaxRoutines       int `validate:"min=1,max=1000"` // Max concurrent goroutines for dispatcher
-	// Cache configuration - Redis only (no local cache configuration needed)
-	ClearCacheOnStartup bool // Whether to clear all caches on bot startup
-	DisableCache        bool // When true, bypass read-through cache (all DB reads go direct); also makes Redis optional for load testing. Env: DISABLE_CACHE
-	// Activity monitoring configuration
-	InactivityThresholdDays int  `validate:"min=1,max=365"` // Days before marking a chat as inactive
-	ActivityCheckInterval   int  `validate:"min=1,max=24"`  // Hours between activity checks
-	EnableAutoCleanup       bool // Whether to automatically mark inactive chats
+	DispatcherMaxRoutines       int `validate:"min=1,max=1000"`
+	ClearCacheOnStartup         bool
+	DisableCache                bool
+	InactivityThresholdDays     int `validate:"min=1,max=365"`
+	ActivityCheckInterval       int `validate:"min=1,max=24"`
+	EnableAutoCleanup           bool
 
-	// Performance optimization settings
-	HTTPMaxIdleConns        int `validate:"min=10,max=1000"` // HTTP connection pool size
-	HTTPMaxIdleConnsPerHost int `validate:"min=5,max=500"`   // HTTP connections per host
+	HTTPMaxIdleConns        int `validate:"min=10,max=1000"`
+	HTTPMaxIdleConnsPerHost int `validate:"min=5,max=500"`
 
-	// Database migration settings
-	AutoMigrate           bool   // Enable automatic database migrations on startup
-	AutoMigrateSilentFail bool   // Continue running even if migrations fail
-	MigrationsPath        string // Path to migration files (defaults to migrations)
+	AutoMigrate           bool
+	AutoMigrateSilentFail bool
+	MigrationsPath        string
 
-	// Resource monitoring limits
-	ResourceMaxGoroutines int `validate:"min=100,max=10000"` // Maximum goroutines before triggering cleanup
-	ResourceMaxMemoryMB   int `validate:"min=100,max=10000"` // Maximum memory usage in MB
-	ResourceGCThresholdMB int `validate:"min=100,max=5000"`  // Memory threshold for triggering GC
+	ResourceMaxGoroutines int `validate:"min=100,max=10000"`
+	ResourceMaxMemoryMB   int `validate:"min=100,max=10000"`
+	ResourceGCThresholdMB int `validate:"min=100,max=5000"`
 
-	// Profiling configuration
-	EnablePPROF bool // Enable pprof endpoints for performance profiling (development only)
+	EnablePPROF bool
 
-	// Metrics authentication
-	MetricsAuthToken string // Bearer token required to access /metrics and /db_metrics (empty = unauthenticated with a warning)
+	MetricsAuthToken string
 }
 
-// AppConfig is the global configuration instance - the single source of truth.
-// All code should access configuration via config.AppConfig.FieldName
 var AppConfig *Config
 
-// ValidateConfig validates the configuration struct and returns an error if any required
-// fields are missing or values are outside acceptable ranges.
 func ValidateConfig(cfg *Config) error {
 	if cfg.BotToken == "" {
 		return fmt.Errorf("BOT_TOKEN is required")
@@ -209,9 +180,7 @@ func ValidateConfig(cfg *Config) error {
 	if !cfg.DisableCache && cfg.RedisAddress == "" {
 		return fmt.Errorf("REDIS_ADDRESS or REDIS_URL is required")
 	}
-	// RedisDB validated below even in DisableCache mode; only address requirement is relaxed above
 
-	// Validate webhook configuration if webhooks are enabled
 	if cfg.UseWebhooks {
 		if cfg.WebhookDomain == "" {
 			return fmt.Errorf("WEBHOOK_DOMAIN is required when USE_WEBHOOKS is enabled")
@@ -221,17 +190,14 @@ func ValidateConfig(cfg *Config) error {
 		}
 	}
 
-	// Validate HTTP port
 	if cfg.HTTPPort <= 0 || cfg.HTTPPort > 65535 {
 		return fmt.Errorf("HTTP_PORT must be between 1 and 65535")
 	}
 
-	// Validate performance limits
 	if cfg.DispatcherMaxRoutines != 0 && (cfg.DispatcherMaxRoutines < 1 || cfg.DispatcherMaxRoutines > 1000) {
 		return fmt.Errorf("DISPATCHER_MAX_ROUTINES must be between 1 and 1000")
 	}
 
-	// Validate database connection pool configuration
 	if cfg.DBMaxIdleConns != 0 && (cfg.DBMaxIdleConns < 1 || cfg.DBMaxIdleConns > 100) {
 		return fmt.Errorf("DB_MAX_IDLE_CONNS must be between 1 and 100")
 	}
@@ -252,11 +218,8 @@ func ValidateConfig(cfg *Config) error {
 	return nil
 }
 
-// LoadConfig loads configuration from environment variables, applies defaults,
-// validates the configuration, and returns a populated Config instance.
 func LoadConfig() (*Config, error) {
-	// load goenv config
-	_ = godotenv.Load() // Ignore error as .env file is optional
+	_ = godotenv.Load()
 
 	redisDB, err := parseRedisDB()
 	if err != nil {
@@ -264,88 +227,69 @@ func LoadConfig() (*Config, error) {
 	}
 
 	cfg := &Config{
-		// Core configuration
 		BotToken:    os.Getenv("BOT_TOKEN"),
 		BotVersion:  "2.22.6",
 		ApiServer:   os.Getenv("API_SERVER"),
 		WorkingMode: "worker",
 		Debug:       typeConvertor{str: os.Getenv("DEBUG")}.Bool(),
 
-		// Bot settings
 		OwnerId:            typeConvertor{str: os.Getenv("OWNER_ID")}.Int64(),
 		MessageDump:        typeConvertor{str: os.Getenv("MESSAGE_DUMP")}.Int64(),
 		DropPendingUpdates: typeConvertor{str: os.Getenv("DROP_PENDING_UPDATES")}.Bool(),
 
-		// Database configuration
 		DatabaseURL: os.Getenv("DATABASE_URL"),
 
-		// Database connection pool configuration
 		DBMaxIdleConns:       typeConvertor{str: os.Getenv("DB_MAX_IDLE_CONNS")}.Int(),
 		DBMaxOpenConns:       typeConvertor{str: os.Getenv("DB_MAX_OPEN_CONNS")}.Int(),
 		DBConnMaxLifetimeMin: typeConvertor{str: os.Getenv("DB_CONN_MAX_LIFETIME_MIN")}.Int(),
 		DBConnMaxIdleTimeMin: typeConvertor{str: os.Getenv("DB_CONN_MAX_IDLE_TIME_MIN")}.Int(),
 
-		// Database monitoring configuration
 		EnableDBMonitoring: typeConvertor{str: os.Getenv("ENABLE_DB_MONITORING")}.Bool(),
 
-		// Redis configuration (supports both REDIS_ADDRESS and REDIS_URL for platform compatibility)
 		RedisAddress:  getRedisAddress(),
 		RedisURL:      getRedisURL(),
 		RedisPassword: getRedisPassword(),
 		RedisDB:       redisDB,
 
-		// HTTP Server configuration
 		HTTPPort: getHTTPPort(),
 
-		// Webhook configuration
 		UseWebhooks:   typeConvertor{str: os.Getenv("USE_WEBHOOKS")}.Bool(),
 		WebhookDomain: os.Getenv("WEBHOOK_DOMAIN"),
 		WebhookSecret: os.Getenv("WEBHOOK_SECRET"),
 
-		// Safety and performance limits
 		EnablePerformanceMonitoring: typeConvertor{str: os.Getenv("ENABLE_PERFORMANCE_MONITORING")}.Bool(),
 		EnableBackgroundStats:       typeConvertor{str: os.Getenv("ENABLE_BACKGROUND_STATS")}.Bool(),
 		DispatcherMaxRoutines:       typeConvertor{str: os.Getenv("DISPATCHER_MAX_ROUTINES")}.Int(),
 
-		// Cache configuration - Redis only
 		ClearCacheOnStartup: typeConvertor{str: os.Getenv("CLEAR_CACHE_ON_STARTUP")}.Bool(),
 		DisableCache:        typeConvertor{str: os.Getenv("DISABLE_CACHE")}.Bool(),
 
-		// Activity monitoring configuration
 		InactivityThresholdDays: typeConvertor{str: os.Getenv("INACTIVITY_THRESHOLD_DAYS")}.Int(),
 		ActivityCheckInterval:   typeConvertor{str: os.Getenv("ACTIVITY_CHECK_INTERVAL")}.Int(),
 		EnableAutoCleanup:       typeConvertor{str: os.Getenv("ENABLE_AUTO_CLEANUP")}.Bool(),
 
-		// Performance optimization settings
 		HTTPMaxIdleConns:        typeConvertor{str: os.Getenv("HTTP_MAX_IDLE_CONNS")}.Int(),
 		HTTPMaxIdleConnsPerHost: typeConvertor{str: os.Getenv("HTTP_MAX_IDLE_CONNS_PER_HOST")}.Int(),
 
-		// Database migration settings
 		AutoMigrate:           typeConvertor{str: os.Getenv("AUTO_MIGRATE")}.Bool(),
 		AutoMigrateSilentFail: typeConvertor{str: os.Getenv("AUTO_MIGRATE_SILENT_FAIL")}.Bool(),
 		MigrationsPath:        os.Getenv("MIGRATIONS_PATH"),
 
-		// Resource monitoring limits
 		ResourceMaxGoroutines: typeConvertor{str: os.Getenv("RESOURCE_MAX_GOROUTINES")}.Int(),
 		ResourceMaxMemoryMB:   typeConvertor{str: os.Getenv("RESOURCE_MAX_MEMORY_MB")}.Int(),
 		ResourceGCThresholdMB: typeConvertor{str: os.Getenv("RESOURCE_GC_THRESHOLD_MB")}.Int(),
 
-		// Profiling configuration
 		EnablePPROF: typeConvertor{str: os.Getenv("ENABLE_PPROF")}.Bool(),
 
-		// Metrics authentication
 		MetricsAuthToken: os.Getenv("METRICS_AUTH_TOKEN"),
 	}
 
-	// Set defaults
 	cfg.setDefaults()
 
-	// Validate configuration
 	if err := ValidateConfig(cfg); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
-	// Set allowed updates and valid language codes
 	cfg.AllowedUpdates = []string{
 		"message",
 		"edited_message",
@@ -371,9 +315,6 @@ func LoadConfig() (*Config, error) {
 	return cfg, nil
 }
 
-// setDefaults sets default values for configuration fields that are not provided
-// via environment variables. It calculates appropriate defaults based on system
-// resources and production best practices.
 func (cfg *Config) setDefaults() {
 	if cfg.ApiServer == "" {
 		cfg.ApiServer = "https://api.telegram.org"
@@ -392,44 +333,37 @@ func (cfg *Config) setDefaults() {
 		cfg.HTTPPort = 8080
 	}
 
-	// Set activity monitoring defaults
 	if cfg.InactivityThresholdDays == 0 {
-		cfg.InactivityThresholdDays = 30 // 30 days before marking as inactive
+		cfg.InactivityThresholdDays = 30
 	}
 	if cfg.ActivityCheckInterval == 0 {
-		cfg.ActivityCheckInterval = 1 // Check every hour
+		cfg.ActivityCheckInterval = 1
 	}
-	// EnableAutoCleanup defaults to true unless explicitly set to false
 	if os.Getenv("ENABLE_AUTO_CLEANUP") == "" {
 		cfg.EnableAutoCleanup = true
 	}
 
-	// Set database connection pool defaults (optimized for performance)
 	if cfg.DBMaxIdleConns == 0 {
-		cfg.DBMaxIdleConns = 50 // Keep more connections warm
+		cfg.DBMaxIdleConns = 50
 	}
 	if cfg.DBMaxOpenConns == 0 {
-		cfg.DBMaxOpenConns = 200 // Handle burst traffic better
+		cfg.DBMaxOpenConns = 200
 	}
 	if cfg.DBConnMaxLifetimeMin == 0 {
-		cfg.DBConnMaxLifetimeMin = 240 // 4 hours - reuse connections longer
+		cfg.DBConnMaxLifetimeMin = 240
 	}
 	if cfg.DBConnMaxIdleTimeMin == 0 {
-		cfg.DBConnMaxIdleTimeMin = 60 // 1 hour - keep idle connections longer
+		cfg.DBConnMaxIdleTimeMin = 60
 	}
 
-	// Set default safety limits
 	if cfg.DispatcherMaxRoutines == 0 {
-		cfg.DispatcherMaxRoutines = 200 // Optimized for better throughput
+		cfg.DispatcherMaxRoutines = 200
 	}
 
-	// Set cache defaults
-	// ClearCacheOnStartup defaults to true for better reliability, but only if not explicitly set via env var
 	if os.Getenv("CLEAR_CACHE_ON_STARTUP") == "" {
 		cfg.ClearCacheOnStartup = true
 	}
 
-	// Enable monitoring by default in production
 	if !cfg.Debug {
 		if os.Getenv("ENABLE_PERFORMANCE_MONITORING") == "" {
 			cfg.EnablePerformanceMonitoring = true
@@ -439,10 +373,6 @@ func (cfg *Config) setDefaults() {
 		}
 	}
 
-	// DATABASE_URL is required - no default for security
-	// This ensures production systems explicitly configure their database connection
-
-	// Set performance optimization defaults (enabled by default for better performance)
 	if cfg.HTTPMaxIdleConns == 0 {
 		cfg.HTTPMaxIdleConns = 100
 	}
@@ -450,14 +380,10 @@ func (cfg *Config) setDefaults() {
 		cfg.HTTPMaxIdleConnsPerHost = 50
 	}
 
-	// Set database migration defaults
 	if cfg.MigrationsPath == "" {
 		cfg.MigrationsPath = "migrations"
 	}
-	// AutoMigrate defaults to false for backward compatibility
-	// AutoMigrateSilentFail defaults to false
 
-	// Set resource monitoring defaults
 	if cfg.ResourceMaxGoroutines == 0 {
 		cfg.ResourceMaxGoroutines = 1000
 	}
@@ -469,20 +395,13 @@ func (cfg *Config) setDefaults() {
 	}
 }
 
-// init initializes the logging configuration, loads the global configuration
-// from environment variables, validates it, and sets up global variables for
-// backward compatibility. This function is called automatically at package import.
 func init() {
-	// Skip config validation when running in CLI mode (--version, --health)
-	// This allows these flags to work without requiring valid configuration.
 	if isCliModeActive() {
 		AppConfig = &Config{}
 		return
 	}
 
-	// set logger config
 	log.SetLevel(log.DebugLevel)
-	// SetReportCaller will be configured after debug mode is determined
 	log.SetFormatter(
 		&log.JSONFormatter{
 			DisableHTMLEscape: true,
@@ -493,15 +412,10 @@ func init() {
 		},
 	)
 
-	// Install the sensitive-data redaction hook before any configuration is
-	// loaded. Structural patterns (bot tokens, DSN passwords, bearer tokens)
-	// are scrubbed immediately; exact secrets are registered below once known.
 	logredact.Install(nil)
 
-	// Load the structured configuration
 	cfg, err := LoadConfig()
 	if err != nil {
-		// If essential env vars are missing (e.g., during unit tests), provide zero-value config
 		if os.Getenv("BOT_TOKEN") == "" {
 			AppConfig = &Config{}
 			return
@@ -509,12 +423,8 @@ func init() {
 		log.Fatalf("[Config] Failed to load configuration: %v", err)
 	}
 
-	// Set global configuration instance
 	AppConfig = cfg
 
-	// Register the now-known exact secrets so they are scrubbed from any log
-	// line that happens to include them verbatim (e.g. a wrapped DB error
-	// containing the DSN, or a startup dump).
 	logredact.RegisterSecret(
 		cfg.BotToken,
 		cfg.DatabaseURL,
@@ -523,13 +433,12 @@ func init() {
 		cfg.MetricsAuthToken,
 	)
 
-	// Configure logger based on debug mode
 	if cfg.Debug {
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.InfoLevel)
 	}
-	log.SetReportCaller(cfg.Debug) // Only enable stack traces in debug mode
+	log.SetReportCaller(cfg.Debug)
 
 	log.Info("[Config] Configuration loaded and validated successfully")
 }

--- a/alita/config/config_pure_test.go
+++ b/alita/config/config_pure_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-// TestIsCliModeActive tests the isCliModeActive helper. It does NOT call
 // t.Parallel() because it mutates os.Args and must run sequentially.
 func TestIsCliModeActive(t *testing.T) {
 	saveArgs := os.Args
@@ -69,11 +68,9 @@ func TestIsCliModeActive(t *testing.T) {
 	})
 }
 
-// TestLoadConfig tests the LoadConfig helper. The top-level test does NOT call
 // t.Parallel() because t.Setenv() is incompatible with parallel execution.
 func TestLoadConfig(t *testing.T) {
 	t.Run("returns error when required fields missing", func(t *testing.T) {
-		// Ensure required env vars are empty
 		t.Setenv("BOT_TOKEN", "")
 		t.Setenv("OWNER_ID", "")
 		t.Setenv("MESSAGE_DUMP", "")
@@ -120,18 +117,15 @@ func TestLoadConfig(t *testing.T) {
 		if cfg.HTTPPort != 9090 {
 			t.Errorf("HTTPPort: got %d, want %d", cfg.HTTPPort, 9090)
 		}
-		// Defaults should have been applied
 		if cfg.ApiServer != "https://api.telegram.org" {
 			t.Errorf("ApiServer: got %q, want %q", cfg.ApiServer, "https://api.telegram.org")
 		}
 		if cfg.BotVersion == "" {
 			t.Errorf("BotVersion: got empty string, want non-empty")
 		}
-		// AllowedUpdates should be populated
 		if len(cfg.AllowedUpdates) == 0 {
 			t.Errorf("AllowedUpdates: expected non-empty slice")
 		}
-		// ValidLangCodes should default to ["en"]
 		if len(cfg.ValidLangCodes) != 1 || cfg.ValidLangCodes[0] != "en" {
 			t.Errorf("ValidLangCodes: got %v, want [en]", cfg.ValidLangCodes)
 		}

--- a/alita/config/config_test.go
+++ b/alita/config/config_test.go
@@ -32,7 +32,6 @@ func TestValidateConfig(t *testing.T) {
 		setup   func(*Config)
 		wantErr bool
 	}{
-		// Required field validations
 		{
 			name:    "valid base config succeeds",
 			setup:   func(_ *Config) {},
@@ -63,7 +62,6 @@ func TestValidateConfig(t *testing.T) {
 			setup:   func(c *Config) { c.RedisAddress = "" },
 			wantErr: true,
 		},
-		// Webhook validations
 		{
 			name: "UseWebhooks with empty domain returns error",
 			setup: func(c *Config) {
@@ -100,7 +98,6 @@ func TestValidateConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		// HTTP port validations
 		{
 			name:    "HTTPPort zero returns error",
 			setup:   func(c *Config) { c.HTTPPort = 0 },
@@ -121,7 +118,6 @@ func TestValidateConfig(t *testing.T) {
 			setup:   func(c *Config) { c.HTTPPort = 1 },
 			wantErr: false,
 		},
-		// Dispatcher optional field validation
 		{
 			name:    "DispatcherMaxRoutines zero is allowed",
 			setup:   func(c *Config) { c.DispatcherMaxRoutines = 0 },
@@ -137,7 +133,6 @@ func TestValidateConfig(t *testing.T) {
 			setup:   func(c *Config) { c.DispatcherMaxRoutines = 1000 },
 			wantErr: false,
 		},
-		// DB pool optional field validation
 		{
 			name:    "DBMaxIdleConns 101 returns error",
 			setup:   func(c *Config) { c.DBMaxIdleConns = 101 },
@@ -345,7 +340,6 @@ func TestSetDefaults(t *testing.T) {
 	})
 }
 
-// TestClearCacheOnStartupEnvVar tests that CLEAR_CACHE_ON_STARTUP env var is respected.
 // These tests do NOT call t.Parallel() because t.Setenv() is incompatible with parallel execution.
 func TestClearCacheOnStartupEnvVar(t *testing.T) {
 	t.Run("defaults to true when env var not set", func(t *testing.T) {
@@ -399,7 +393,6 @@ func TestGetHTTPPort(t *testing.T) {
 	})
 }
 
-// TestGetRedisAddress tests the getRedisAddress() helper. The top-level test does
 // NOT call t.Parallel() because t.Setenv() (used in subtests) is incompatible with
 // parallel execution at the enclosing level — Go enforces this at runtime.
 func TestGetRedisAddress(t *testing.T) {
@@ -459,7 +452,6 @@ func TestGetRedisAddress(t *testing.T) {
 	})
 }
 
-// TestGetRedisPassword tests the getRedisPassword() helper. The top-level test does
 // NOT call t.Parallel() because t.Setenv() (used in subtests) is incompatible with
 // parallel execution at the enclosing level — Go enforces this at runtime.
 func TestGetRedisPassword(t *testing.T) {

--- a/alita/config/types.go
+++ b/alita/config/types.go
@@ -7,24 +7,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// typeConvertor is a struct that will convert a string to a specific type
 type typeConvertor struct {
 	str string
 }
 
-// StringArray converts a comma-separated string into a slice of trimmed strings.
-// It splits the input string by commas and removes leading/trailing whitespace
-// from each element.
 func (t typeConvertor) StringArray() []string {
 	allUpdates := strings.Split(t.str, ",")
 	for i, j := range allUpdates {
-		allUpdates[i] = strings.TrimSpace(j) // this will trim the whitespace
+		allUpdates[i] = strings.TrimSpace(j)
 	}
 	return allUpdates
 }
 
-// Int converts the string value to an integer. If the conversion fails,
-// it logs a warning and returns 0. Empty strings return 0 silently (expected for optional config).
 func (t typeConvertor) Int() int {
 	if t.str == "" {
 		return 0
@@ -37,8 +31,6 @@ func (t typeConvertor) Int() int {
 	return val
 }
 
-// Int64 converts the string value to a 64-bit integer. If the conversion fails,
-// it logs a warning and returns 0. Empty strings return 0 silently (expected for optional config).
 func (t typeConvertor) Int64() int64 {
 	if t.str == "" {
 		return 0
@@ -51,8 +43,6 @@ func (t typeConvertor) Int64() int64 {
 	return val
 }
 
-// Bool converts the string value to a boolean. It returns true if the string
-// equals "yes", "true", or "1" (case-insensitive), otherwise returns false.
 func (t typeConvertor) Bool() bool {
 	lower := strings.ToLower(strings.TrimSpace(t.str))
 	return lower == "yes" || lower == "true" || lower == "1"

--- a/alita/i18n/i18n_test.go
+++ b/alita/i18n/i18n_test.go
@@ -11,8 +11,6 @@ import (
 //go:embed testdata/locales/* testdata/locales/nested/* testdata/badlocales/* testdata/nodefault/*
 var testLocaleFS embed.FS
 
-// ---- Loader utilities ----
-
 func TestExtractLangCode(t *testing.T) {
 	t.Parallel()
 
@@ -126,8 +124,6 @@ func TestParseYAML(t *testing.T) {
 	}
 }
 
-// ---- Error types ----
-
 func TestI18nErrorFormatWithErr(t *testing.T) {
 	t.Parallel()
 
@@ -235,8 +231,6 @@ func TestPredefinedErrorsChain(t *testing.T) {
 	}
 }
 
-// ---- Translator utilities ----
-
 func TestExtractOrderedValues(t *testing.T) {
 	t.Parallel()
 
@@ -294,9 +288,6 @@ func TestExtractOrderedValues(t *testing.T) {
 	}
 }
 
-// ---- Translator.GetString ----
-
-// newTestTranslator creates a Translator backed by inline YAML content for tests.
 func newTestTranslator(t *testing.T, yamlContent string) *Translator {
 	t.Helper()
 	data, err := parseYAML([]byte(yamlContent))
@@ -365,7 +356,6 @@ templ: "Hello, %s!"
 		t.Parallel()
 
 		tr := newTestTranslator(t, yamlContent)
-		// Calling with explicit nil params should not panic
 		result, err := tr.GetString("greeting", nil)
 		if err != nil {
 			t.Fatalf("GetString(greeting, nil) error = %v", err)
@@ -375,8 +365,6 @@ templ: "Hello, %s!"
 		}
 	})
 }
-
-// ---- LocaleManager.GetTranslator ----
 
 func TestLocaleManagerGetTranslator(t *testing.T) {
 	t.Parallel()
@@ -388,16 +376,6 @@ func TestLocaleManagerGetTranslator(t *testing.T) {
 		t.Fatalf("parseYAML() error = %v", err)
 	}
 
-	// Use a local (non-singleton) LocaleManager to avoid contaminating global state.
-	// We embed a minimal FS pointer placeholder — use the trick of setting localeFS
-	// to a non-nil value via the embed pointer is not straightforward without go:embed.
-	// Instead, we bypass the localeFS nil check by setting localeMaps so GetTranslator
-	// can succeed when localeFS check is bypassed. Since GetTranslator checks localeFS,
-	// we test via the singleton initialized from main, or use MustNewTranslator.
-
-	// Verify MustNewTranslator returns a non-nil translator for known language.
-	// The singleton may or may not be initialized (no embed FS in unit tests),
-	// so MustNewTranslator returns a bare translator — that is still non-nil.
 	t.Run("MustNewTranslator returns non-nil translator", func(t *testing.T) {
 		t.Parallel()
 
@@ -424,8 +402,6 @@ func TestLocaleManagerGetTranslator(t *testing.T) {
 			localeMaps:  map[string]map[string]any{"en": data},
 		}
 
-		// localeFS is nil so GetTranslator returns ErrManagerNotInit.
-		// Verify the error is correct.
 		_, getErr := lm.GetTranslator("en")
 		if getErr == nil {
 			t.Fatal("expected error when localeFS is nil, got nil")
@@ -436,12 +412,9 @@ func TestLocaleManagerGetTranslator(t *testing.T) {
 	})
 }
 
-// ---- LocaleManager.GetAvailableLocales ----
-
 func TestLocaleManagerGetAvailableLocales(t *testing.T) {
 	t.Parallel()
 
-	// Build a local LocaleManager with known locales.
 	lm := &LocaleManager{
 		defaultLang: "en",
 		localeMaps: map[string]map[string]any{
@@ -457,7 +430,6 @@ func TestLocaleManagerGetAvailableLocales(t *testing.T) {
 		t.Fatalf("GetAvailableLanguages() returned %d languages, want at least 4: %v", len(langs), langs)
 	}
 
-	// Verify all 4 known locales are present.
 	langSet := make(map[string]bool, len(langs))
 	for _, l := range langs {
 		langSet[l] = true
@@ -580,8 +552,6 @@ func TestLocaleManagerLoadLocaleFilesRejectsInvalidConfig(t *testing.T) {
 	}
 }
 
-// ---- New expanded tests ----
-
 func TestTranslator_GetString_NilManager(t *testing.T) {
 	t.Parallel()
 
@@ -598,10 +568,6 @@ func TestTranslator_GetString_NilManager(t *testing.T) {
 func TestTranslator_GetString_FallbackToDefault(t *testing.T) {
 	t.Parallel()
 
-	// "en" has the key, "es" does not — "es" translator should fall back to "en" value.
-	// Note: localeFS is nil so GetTranslator returns ErrManagerNotInit, which means
-	// we can't truly test multi-lang fallback without an embedded FS.
-	// Instead we verify that a translator with the default lang returns the correct value.
 	const enYAML = "fallback_key: \"en value\"\n"
 	tr := newTestTranslator(t, enYAML)
 

--- a/alita/i18n/loader.go
+++ b/alita/i18n/loader.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// loadLocaleFiles loads all locale files from the embedded filesystem.
 func (lm *LocaleManager) loadLocaleFiles() error {
 	if lm.localeFS == nil || lm.localePath == "" {
 		return NewI18nError("load_files", "", "", "filesystem or path not set", fmt.Errorf("invalid configuration"))
@@ -26,7 +25,6 @@ func (lm *LocaleManager) loadLocaleFiles() error {
 			continue
 		}
 
-		// Only process YAML files
 		fileName := entry.Name()
 		if !isYAMLFile(fileName) {
 			continue
@@ -37,7 +35,6 @@ func (lm *LocaleManager) loadLocaleFiles() error {
 
 		if err := lm.loadSingleLocaleFile(filePath, langCode); err != nil {
 			loadErrors = append(loadErrors, err)
-			// Continue loading other files even if one fails
 			continue
 		}
 	}
@@ -49,9 +46,7 @@ func (lm *LocaleManager) loadLocaleFiles() error {
 	return nil
 }
 
-// loadSingleLocaleFile loads and validates a single locale file.
 func (lm *LocaleManager) loadSingleLocaleFile(filePath, langCode string) error {
-	// Read file content
 	content, err := lm.localeFS.ReadFile(filePath)
 	if err != nil {
 		return NewI18nError("load_file", langCode, "", "failed to read file", err)
@@ -83,10 +78,8 @@ func parseYAML(content []byte) (map[string]any, error) {
 	return parsed, nil
 }
 
-// extractLangCode extracts the language code from a filename.
 func extractLangCode(fileName string) string {
 	langCode := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-	// Handle common YAML extensions
 	langCode = strings.TrimSuffix(langCode, ".yml")
 	langCode = strings.TrimSuffix(langCode, ".yaml")
 	return langCode
@@ -168,7 +161,6 @@ func lookupStringSlice(data map[string]any, key string) []string {
 	}
 }
 
-// isYAMLFile checks if a filename has a YAML extension.
 func isYAMLFile(fileName string) bool {
 	ext := strings.ToLower(filepath.Ext(fileName))
 	return ext == ".yml" || ext == ".yaml"

--- a/alita/i18n/manager.go
+++ b/alita/i18n/manager.go
@@ -21,12 +21,10 @@ func GetManager() *LocaleManager {
 	return managerInstance
 }
 
-// Initialize initializes the LocaleManager with the provided configuration.
 func (lm *LocaleManager) Initialize(fs *embed.FS, localePath string, config ManagerConfig) error {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	// Prevent re-initialization
 	if lm.localeFS != nil {
 		return fmt.Errorf("locale manager already initialized")
 	}
@@ -35,16 +33,13 @@ func (lm *LocaleManager) Initialize(fs *embed.FS, localePath string, config Mana
 	lm.localePath = localePath
 	lm.defaultLang = config.Loader.DefaultLanguage
 
-	// Load all locale files
 	if err := lm.loadLocaleFiles(); err != nil {
 		if config.Loader.StrictMode {
 			return NewI18nError("initialize", "", "", "failed to load locale files", err)
 		}
-		// In non-strict mode, log error but continue
 		fmt.Printf("Warning: failed to load some locale files: %v\n", err)
 	}
 
-	// Validate default language exists
 	if _, exists := lm.localeMaps[lm.defaultLang]; !exists {
 		return NewI18nError("initialize", lm.defaultLang, "", "default language not found", ErrLocaleNotFound)
 	}
@@ -52,7 +47,6 @@ func (lm *LocaleManager) Initialize(fs *embed.FS, localePath string, config Mana
 	return nil
 }
 
-// GetTranslator returns a translator for the specified language.
 func (lm *LocaleManager) GetTranslator(langCode string) (*Translator, error) {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()
@@ -61,11 +55,9 @@ func (lm *LocaleManager) GetTranslator(langCode string) (*Translator, error) {
 		return nil, NewI18nError("get_translator", langCode, "", "manager not initialized", ErrManagerNotInit)
 	}
 
-	// Check if language exists, fallback to default if not
 	targetLang := langCode
 	data, exists := lm.localeMaps[langCode]
 	if !exists {
-		// Fallback to default language
 		targetLang = lm.defaultLang
 		data = lm.localeMaps[lm.defaultLang]
 		if data == nil {
@@ -80,7 +72,6 @@ func (lm *LocaleManager) GetTranslator(langCode string) (*Translator, error) {
 	}, nil
 }
 
-// GetAvailableLanguages returns a slice of all available language codes.
 func (lm *LocaleManager) GetAvailableLanguages() []string {
 	lm.mu.RLock()
 	defer lm.mu.RUnlock()

--- a/alita/i18n/test_helper.go
+++ b/alita/i18n/test_helper.go
@@ -6,8 +6,6 @@ import (
 	"embed"
 )
 
-// NewTestTranslator creates a Translator backed by inline YAML content for tests.
-// It is guarded by the `testtools` build tag so it is excluded from production builds.
 func NewTestTranslator(yamlContent string) (*Translator, error) {
 	data, err := parseYAML([]byte(yamlContent))
 	if err != nil {

--- a/alita/i18n/translator.go
+++ b/alita/i18n/translator.go
@@ -9,30 +9,23 @@ import (
 )
 
 var (
-	// Regex for parameter interpolation {key} style
-	paramRegex = regexp.MustCompile(`\{([^}]+)\}`)
-	// Regex for legacy parameter interpolation %s, %d, etc.
+	paramRegex       = regexp.MustCompile(`\{([^}]+)\}`)
 	legacyParamRegex = regexp.MustCompile(`%[sdvfbtoxX]`)
 )
 
-// GetString retrieves a translated string with optional parameter interpolation.
 func (t *Translator) GetString(key string, params ...TranslationParams) (string, error) {
 	if t.manager == nil {
 		return "", NewI18nError("get_string", t.langCode, key, "manager not initialized", ErrManagerNotInit)
 	}
 
-	// Get string from the parsed locale map
 	result := lookupString(t.data, key)
 
-	// Check if key exists
 	if result == "" || result == "<nil>" {
-		// Try fallback to default language if not already using it
 		if t.langCode != t.manager.defaultLang {
 			defaultTranslator, err := t.manager.GetTranslator(t.manager.defaultLang)
 			if err != nil {
 				return "", NewI18nError("get_string", t.langCode, key, "fallback failed", err)
 			}
-			// Prevent infinite recursion
 			if defaultTranslator.langCode == t.langCode {
 				return "", NewI18nError("get_string", t.langCode, key, "recursive fallback detected", ErrRecursiveFallback)
 			}
@@ -41,7 +34,6 @@ func (t *Translator) GetString(key string, params ...TranslationParams) (string,
 		return "", NewI18nError("get_string", t.langCode, key, "translation not found", ErrKeyNotFound)
 	}
 
-	// Apply parameter interpolation if params provided
 	if len(params) > 0 {
 		var err error
 		result, err = t.interpolateParams(result, params[0])
@@ -53,7 +45,6 @@ func (t *Translator) GetString(key string, params ...TranslationParams) (string,
 	return result, nil
 }
 
-// GetStringSlice retrieves a translated string slice.
 func (t *Translator) GetStringSlice(key string) ([]string, error) {
 	if t.manager == nil {
 		return nil, NewI18nError("get_string_slice", t.langCode, key, "manager not initialized", ErrManagerNotInit)
@@ -61,9 +52,7 @@ func (t *Translator) GetStringSlice(key string) ([]string, error) {
 
 	result := lookupStringSlice(t.data, key)
 
-	// Check if key exists
 	if len(result) == 0 {
-		// Try fallback to default language
 		if t.langCode != t.manager.defaultLang {
 			defaultTranslator, err := t.manager.GetTranslator(t.manager.defaultLang)
 			if err != nil {
@@ -80,7 +69,6 @@ func (t *Translator) GetStringSlice(key string) ([]string, error) {
 	return result, nil
 }
 
-// interpolateParams performs parameter interpolation on a string.
 func (t *Translator) interpolateParams(text string, params TranslationParams) (string, error) {
 	if params == nil {
 		return text, nil
@@ -88,20 +76,15 @@ func (t *Translator) interpolateParams(text string, params TranslationParams) (s
 
 	result := text
 
-	// Handle {key} style parameters
 	result = paramRegex.ReplaceAllStringFunc(result, func(match string) string {
-		// Extract key name (remove { and })
 		keyName := match[1 : len(match)-1]
 		if value, exists := params[keyName]; exists {
 			return fmt.Sprintf("%v", value)
 		}
-		return match // Keep original if no replacement found
+		return match
 	})
 
-	// Handle legacy %s style parameters (for backward compatibility)
-	// This is more complex as we need to maintain order
 	if legacyParamRegex.MatchString(result) {
-		// For legacy support, try to find numbered parameters or use order
 		if orderedValues := extractOrderedValues(params); len(orderedValues) > 0 {
 			specCount := len(legacyParamRegex.FindAllString(result, -1))
 			if specCount <= len(orderedValues) {
@@ -115,7 +98,6 @@ func (t *Translator) interpolateParams(text string, params TranslationParams) (s
 	return result, nil
 }
 
-// extractOrderedValues extracts values from params in a predictable order for legacy sprintf.
 func extractOrderedValues(params TranslationParams) []any {
 	if params == nil {
 		return nil
@@ -123,7 +105,6 @@ func extractOrderedValues(params TranslationParams) []any {
 
 	var values []any
 
-	// Try common numbered keys first (0, 1, 2, etc.)
 	for i := 0; i < 10; i++ {
 		key := strconv.Itoa(i)
 		if value, exists := params[key]; exists {
@@ -133,22 +114,14 @@ func extractOrderedValues(params TranslationParams) []any {
 		}
 	}
 
-	// If no numbered keys found, try a predefined order of common keys
 	if len(values) == 0 {
 		commonKeys := []string{
-			// Most common patterns from the codebase
 			"first", "second", "third", "fourth", "fifth",
-			// Question/answer patterns (before number to match captcha_welcome_math_text order)
 			"question", "answer",
-			// Common numeric-related keys
 			"number", "count", "value",
-			// User/name patterns
 			"name", "user", "username",
-			// Generic argument patterns
 			"arg1", "arg2", "arg3",
-			// Single letter keys
 			"s", "d", "v", "f",
-			// Extended keys for legacy % formatting (append at end to preserve order)
 			"duration", "threshold", "error", "user_id", "expires_in", "raid_time", "action_time", "auto_threshold", "mode", "reason", "limit",
 		}
 		for _, key := range commonKeys {

--- a/alita/i18n/types.go
+++ b/alita/i18n/types.go
@@ -5,37 +5,32 @@ import (
 	"sync"
 )
 
-// TranslationParams represents parameters for translation interpolation
 type TranslationParams map[string]any
 
 // LocaleManager manages all locales with thread-safe operations
 type LocaleManager struct {
 	mu          sync.RWMutex
-	localeMaps  map[string]map[string]any // Parsed YAML maps per language
+	localeMaps  map[string]map[string]any
 	defaultLang string
 	localeFS    *embed.FS
 	localePath  string
 }
 
-// Translator provides translation methods for a specific language
 type Translator struct {
 	langCode string
 	manager  *LocaleManager
-	data     map[string]any // Parsed YAML map for this language
+	data     map[string]any
 }
 
-// LoaderConfig defines configuration for locale loading
 type LoaderConfig struct {
 	DefaultLanguage string
 	StrictMode      bool // Fail if any locale file has errors
 }
 
-// ManagerConfig combines all configuration options
 type ManagerConfig struct {
 	Loader LoaderConfig
 }
 
-// DefaultManagerConfig returns sensible defaults for ManagerConfig.
 func DefaultManagerConfig() ManagerConfig {
 	return ManagerConfig{
 		Loader: LoaderConfig{

--- a/alita/main.go
+++ b/alita/main.go
@@ -12,9 +12,6 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-// ListModules returns a formatted string containing all loaded bot modules.
-// It retrieves the module names from the default help registry, sorts them alphabetically,
-// and returns them as a comma-separated list wrapped in square brackets.
 func ListModules() string {
 	var modSlice []string
 	for module, enabled := range modules.GetAbleMap() {
@@ -26,13 +23,7 @@ func ListModules() string {
 	return fmt.Sprintf("[%s]", strings.Join(modSlice, ", "))
 }
 
-// InitialChecks performs essential initialization tasks before starting the bot.
-// It ensures the bot exists in the database before modules load.
-// Note: Cache is initialized in main.go before this function is called.
 func InitialChecks(b *gotgbot.Bot) error {
-	// Ensure bot exists in database (blocking - required for FK constraints)
-	// This must complete before LoadModules to prevent race conditions with
-	// foreign key constraints that reference the bot entry
 	if err := user.EnsureBotInDb(b); err != nil {
 		return fmt.Errorf("ensure bot in database: %w", err)
 	}
@@ -40,18 +31,10 @@ func InitialChecks(b *gotgbot.Bot) error {
 	return nil
 }
 
-// LoadModules loads all bot modules in the correct order using the provided dispatcher.
-// It initializes the help system, loads core functionality modules (admin, bans, filters, etc.),
-// and ensures the help module is loaded last to register all available commands.
 func LoadModules(dispatcher *ext.Dispatcher) {
-	// Reset registry maps under lock (init-only, single-threaded startup)
-	// ResetHelpRegistry atomically clears AbleMap/helpableKb/AltHelpOptions.
 	modules.ResetHelpRegistry()
 
-	// Load this at last because it loads all the modules
 	defer modules.LoadHelp(dispatcher)
 
-	// Registered modules are loaded by priority. Help is deferred above so it
-	// can render metadata collected by module loaders.
 	modules.LoadAllModules(dispatcher)
 }

--- a/internal/repo_checks/repo_checks_test.go
+++ b/internal/repo_checks/repo_checks_test.go
@@ -49,11 +49,15 @@ func TestPollingLoadsModulesBeforeStartingPolling(t *testing.T) {
 
 	source := readRepoFile(t, "main.go")
 
-	// Find the polling branch in main().
-	pollingStart := strings.Index(source, "// Use polling mode")
+	webhookStart := strings.Index(source, "if config.AppConfig.UseWebhooks {")
+	if webhookStart == -1 {
+		t.Fatal("webhook/polling branch is missing")
+	}
+	pollingStart := strings.Index(source[webhookStart:], "} else {")
 	if pollingStart == -1 {
 		t.Fatal("polling branch marker is missing")
 	}
+	pollingStart += webhookStart
 
 	// The polling block in main() calls postInit(...) then updater.StartPolling(...).
 	// postInit itself (defined after main()) calls alita.LoadModules(dispatcher).

--- a/main.go
+++ b/main.go
@@ -38,12 +38,7 @@ import (
 //go:embed locales
 var Locales embed.FS
 
-// main initializes and starts the Alita Robot Telegram bot.
-// It sets up monitoring, database connections, webhook/polling mode,
-// loads all modules, and handles graceful shutdown.
 func main() {
-	// Capture process start time for accurate uptime reporting in health checks.
-	// This must be captured before any initialization work begins.
 	appStartTime := time.Now()
 
 	// Health check mode for Docker healthcheck (distroless images have no curl/wget)
@@ -53,27 +48,22 @@ func main() {
 		if err != nil {
 			os.Exit(1)
 		}
-		_ = resp.Body.Close() // Ignore close error since we're exiting immediately
+		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			os.Exit(1)
 		}
 		os.Exit(0)
 	}
 
-	// Version check - print version and exit without requiring services
-	// Note: init() functions in config/db now detect CLI mode and skip heavy initialization
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-version" || os.Args[1] == "-v") {
-		// Config always has BotVersion set (it's a hardcoded default in LoadConfig)
-		// If BOT_TOKEN is not set, config init sets AppConfig to empty Config{}, so we need to check
 		version := config.AppConfig.BotVersion
 		if version == "" {
-			version = "v2.22.6" // Fallback to hardcoded version if config wasn't loaded
+			version = "v2.22.6"
 		}
 		fmt.Println(version)
 		os.Exit(0)
 	}
 
-	// Setup panic recovery for main goroutine
 	defer func() {
 		if r := recover(); r != nil {
 			log.Errorf("[Main] Panic recovered: %v", r)
@@ -81,37 +71,29 @@ func main() {
 		}
 	}()
 
-	// logs if bot is running in debug mode or not
 	if config.AppConfig.Debug {
 		log.Info("Running in DEBUG Mode...")
 	} else {
 		log.Info("Running in RELEASE Mode...")
 	}
 
-	// Initialize Redis-backed application caches before other services.
 	if err := cache.InitCache(); err != nil {
 		log.Fatalf("Failed to initialize cache: %v", err)
 	}
 	log.Info("Cache system initialized successfully")
 
-	// Initialize the process-local locale maps.
 	localeManager := i18n.GetManager()
 	if err := localeManager.Initialize(&Locales, "locales", i18n.DefaultManagerConfig()); err != nil {
 		log.Fatalf("Failed to initialize locale manager: %v", err)
 	}
 	log.Infof("Locale manager initialized with %d languages: %v", len(localeManager.GetAvailableLanguages()), localeManager.GetAvailableLanguages())
 
-	// Initialize OpenTelemetry tracing
 	if err := tracing.InitTracing(); err != nil {
 		log.Warnf("Failed to initialize tracing: %v - continuing without distributed tracing", err)
 	} else {
 		log.Info("Distributed tracing initialized successfully")
 	}
 
-	// Create optimized HTTP transport with connection pooling for better performance
-	// IMPORTANT: We create a transport pointer that will be shared across all requests
-	// This ensures connection pooling works correctly (the http.Client struct is copied by value in BaseBotClient)
-	// Use configurable values for optimal performance
 	maxIdleConns := config.AppConfig.HTTPMaxIdleConns
 	maxIdleConnsPerHost := config.AppConfig.HTTPMaxIdleConnsPerHost
 
@@ -119,12 +101,11 @@ func main() {
 
 	log.Infof("[Main] HTTP transport configured with MaxIdleConns: %d, MaxIdleConnsPerHost: %d", maxIdleConns, maxIdleConnsPerHost)
 
-	// Create bot with optimized HTTP client using BaseBotClient
 	log.Info("[Main] Initializing bot with optimized HTTP client (connection pooling enabled)")
 	b, err := gotgbot.NewBot(config.AppConfig.BotToken, &gotgbot.BotOpts{
 		BotClient: &gotgbot.BaseBotClient{
 			Client: http.Client{
-				Transport: transport, // Use the shared transport
+				Transport: transport,
 				Timeout:   constants.LongTimeout,
 			},
 			UseTestEnvironment: false,
@@ -139,18 +120,14 @@ func main() {
 	}
 	log.Infof("[Main] Bot initialized with optimized connection pooling (MaxIdleConns: %d, MaxIdleConnsPerHost: %d, HTTP/2 enabled)", maxIdleConns, maxIdleConnsPerHost)
 
-	// Retrieve bot identity early for logging and downstream components that reference username
 	botUsername := resolveBotUsername(b)
 
-	// some initial checks before running bot
 	if err := alita.InitialChecks(b); err != nil {
 		log.Fatalf("Initial checks failed: %v", err)
 	}
 
-	// Create dispatcher with limited max routines and proper error recovery
 	dispatcher := newConfiguredDispatcher(config.AppConfig.DispatcherMaxRoutines)
 
-	// Initialize monitoring systems
 	var statsCollector *monitoring.BackgroundStatsCollector
 	var autoRemediation *monitoring.AutoRemediationManager
 	var activityMonitor *monitoring.ActivityMonitor
@@ -175,11 +152,9 @@ func main() {
 		autoRemediation.Start()
 	}
 
-	// Initialize activity monitoring for automatic group activity tracking
 	activityMonitor = monitoring.NewActivityMonitor()
 	activityMonitor.Start()
 
-	// Setup graceful shutdown
 	shutdownManager := shutdown.NewManager()
 
 	shutdownManager.RegisterHandler(func() error {
@@ -200,8 +175,6 @@ func main() {
 		return nil
 	})
 
-	// DB-using workers are registered after closeDBConnections so LIFO stops
-	// them before the pool is closed.
 	if dbMonitoringCancel != nil {
 		shutdownManager.RegisterHandler(func() error {
 			log.Info("[Shutdown] Stopping database monitoring...")
@@ -210,13 +183,11 @@ func main() {
 		})
 	}
 
-	// Register tracing shutdown handler
 	shutdownManager.RegisterHandler(func() error {
 		log.Info("[Shutdown] Shutting down tracer provider...")
 		return tracing.Shutdown(context.Background())
 	})
 
-	// Register anti-raid expiry poller shutdown handler
 	shutdownManager.RegisterHandler(func() error {
 		log.Info("[Shutdown] Stopping anti-raid expiry poller...")
 		modules.StopAntiRaidExpiryPoller()
@@ -228,22 +199,18 @@ func main() {
 		return nil
 	})
 
-	// Create unified HTTP server for health, metrics, and webhook endpoints
 	httpServer := httpserver.New(config.AppConfig.HTTPPort, appStartTime)
 	httpServer.RegisterHealth()
 	httpServer.SetMetricsAuthToken(config.AppConfig.MetricsAuthToken)
 	httpServer.RegisterMetrics()
 	httpServer.RegisterDBMetrics()
 
-	// Register pprof endpoints if enabled (development only)
 	if config.AppConfig.EnablePPROF {
 		httpServer.RegisterPPROF()
 		log.Warn("[Main] pprof endpoints enabled - DO NOT enable in production!")
 	}
 
-	// Check if we should use webhooks or polling
 	if config.AppConfig.UseWebhooks {
-		// Validate webhook configuration
 		if config.AppConfig.WebhookDomain == "" {
 			log.Fatal("[Webhook] WEBHOOK_DOMAIN is required when USE_WEBHOOKS is enabled")
 		}
@@ -251,12 +218,10 @@ func main() {
 			log.Fatal("[Webhook] WEBHOOK_SECRET is required when USE_WEBHOOKS is enabled for security")
 		}
 
-		// Register webhook endpoint on the unified HTTP server
 		if err := httpServer.RegisterWebhook(b, dispatcher, config.AppConfig.WebhookSecret, config.AppConfig.WebhookDomain); err != nil {
 			log.Fatalf("[HTTPServer] Failed to register webhook: %v", err)
 		}
 
-		// Register HTTP server shutdown handler BEFORE start so SIGTERM in window is handled
 		shutdownManager.RegisterHandler(func() error {
 			log.Info("[Shutdown] Stopping HTTP server...")
 			return httpServer.Stop()
@@ -264,7 +229,6 @@ func main() {
 
 		postInit(b, dispatcher, botUsername, "webhook")
 
-		// Start the unified HTTP server
 		if err := httpServer.Start(); err != nil {
 			log.Fatalf("[HTTPServer] Failed to start HTTP server: %v", err)
 		}
@@ -274,27 +238,22 @@ func main() {
 
 		go shutdownManager.WaitForShutdown()
 
-		// Wait for shutdown signal (blocking)
 		select {}
 	} else {
-		// Use polling mode (default)
 
-		// Register HTTP server shutdown handler BEFORE start
 		shutdownManager.RegisterHandler(func() error {
 			log.Info("[Shutdown] Stopping HTTP server...")
 			return httpServer.Stop()
 		})
 
-		// Start the unified HTTP server (health and metrics only in polling mode)
 		if err := httpServer.Start(); err != nil {
 			log.Fatalf("[HTTPServer] Failed to start HTTP server: %v", err)
 		}
 
 		log.Infof("[HTTPServer] Unified HTTP server started on port %d (health, metrics)", config.AppConfig.HTTPPort)
 
-		updater := ext.NewUpdater(dispatcher, nil) // create updater with dispatcher
+		updater := ext.NewUpdater(dispatcher, nil)
 
-		// Register handler to stop the updater BEFORE start so SIGTERM is handled
 		shutdownManager.RegisterHandler(func() error {
 			log.Info("[Polling] Stopping updater...")
 			err := updater.Stop()
@@ -313,7 +272,6 @@ func main() {
 
 		postInit(b, dispatcher, botUsername, "polling")
 
-		// start the bot in polling mode
 		err = updater.StartPolling(b,
 			&ext.PollingOpts{
 				DropPendingUpdates: config.AppConfig.DropPendingUpdates,
@@ -329,7 +287,6 @@ func main() {
 
 		go shutdownManager.WaitForShutdown()
 
-		// Idle, to keep updates coming in, and avoid bot stopping.
 		updater.Idle()
 	}
 }
@@ -403,10 +360,8 @@ func resolveBotUsername(b *gotgbot.Bot) string {
 
 func newConfiguredDispatcher(maxRoutines int) *ext.Dispatcher {
 	return ext.NewDispatcher(&ext.DispatcherOpts{
-		// Use TracingProcessor to inject trace context into every update.
-		Processor: tracing.TracingProcessor{},
-		Error:     dispatcherErrorHandler,
-		// Configurable max concurrent goroutines.
+		Processor:   tracing.TracingProcessor{},
+		Error:       dispatcherErrorHandler,
 		MaxRoutines: maxRoutines,
 	})
 }
@@ -439,9 +394,6 @@ func dispatcherErrorHandler(_ *gotgbot.Bot, ctx *ext.Context, err error) ext.Dis
 	return ext.DispatcherActionNoop
 }
 
-// postInit runs shared initialization before either update transport starts.
-// It loads modules, restores captcha state, sets bot commands, and sends the
-// startup notification.
 func postInit(b *gotgbot.Bot, d *ext.Dispatcher, username string, mode string) {
 	alita.LoadModules(d)
 	if err := modules.StartCaptchaLifecycle(b); err != nil {
@@ -451,7 +403,6 @@ func postInit(b *gotgbot.Bot, d *ext.Dispatcher, username string, mode string) {
 
 	config.AppConfig.WorkingMode = mode
 
-	// Set Commands of Bot (use English for bot commands)
 	tr := i18n.MustNewTranslator("en")
 	startDesc, _ := tr.GetString("main_bot_command_start")
 	helpDesc, _ := tr.GetString("main_bot_command_help")
@@ -470,7 +421,6 @@ func postInit(b *gotgbot.Bot, d *ext.Dispatcher, username string, mode string) {
 	}
 	log.Info("Custom bot commands set for private chats")
 
-	// send startup message to log group
 	_, err = b.SendMessage(config.AppConfig.MessageDump,
 		fmt.Sprintf("<b>Started Bot!</b>\n<b>Mode:</b> %s\n<b>Loaded Modules:</b>\n%s", mode, alita.ListModules()),
 		&gotgbot.SendMessageOpts{
@@ -489,8 +439,6 @@ func postInit(b *gotgbot.Bot, d *ext.Dispatcher, username string, mode string) {
 	}
 }
 
-// closeDBConnections closes all database connections gracefully during shutdown.
-// It returns an error if the database connections cannot be closed properly.
 func closeDBConnections() error {
 	err := db.Close()
 	if err != nil {


### PR DESCRIPTION
Comment-only split of #830 (whose diff exceeded GitHub's 20k-line API limit for the lint action). No code, string, or test-name changes. Kept: go:build/embed, pedantic nolint/nosec, external-constraint notes, public-API contracts, test concurrency contracts. Also anchors TestPollingLoadsModulesBeforeStartingPolling on the webhook/polling code structure instead of a comment marker.