### PR TITLE
Deepen membership intake + command pipeline (838)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# Alita_Robot
+
+Group-management bot: moderates Telegram groups (joins, permissions, triggers, sends).
+
+## Language
+
+**Membership intake**:
+What a chat decides when a user joins — whether the newcomer is greeted, challenged, or let through silently.
+_Avoid_: join handling, greet flow

--- a/alita/modules/bans.go
+++ b/alita/modules/bans.go
@@ -1055,39 +1055,86 @@ func (m moduleStruct) unbanAllCallback(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
+func restrictChecks(cmd string) []helpers.CheckFunc {
+	return []helpers.CheckFunc{
+		helpers.CheckDisabled(cmd),
+		helpers.RequireGroup(),
+		helpers.RequireUserAdmin(),
+		helpers.RequireBotAdmin(),
+		helpers.CanUserRestrict(),
+		helpers.CanBotRestrict(),
+	}
+}
+
+func deleteRestrictChecks(cmd string) []helpers.CheckFunc {
+	return append(restrictChecks(cmd), helpers.CanBotDelete(), helpers.CanUserDelete())
+}
+
+var (
+	banDesc        = helpers.CommandDescriptor{Name: "ban", RequiredChecks: []helpers.CheckFunc(nil)}
+	sbanDesc       = helpers.CommandDescriptor{Name: "sban"}
+	tbanDesc       = helpers.CommandDescriptor{Name: "tban"}
+	dbanDesc       = helpers.CommandDescriptor{Name: "dban"}
+	unbanDesc      = helpers.CommandDescriptor{Name: "unban"}
+	banmeDesc      = helpers.CommandDescriptor{Name: "banme", Disableable: true}
+	unbanAllDesc   = helpers.CommandDescriptor{Name: "unbanall"}
+	kickDesc       = helpers.CommandDescriptor{Name: "kick"}
+	dkickDesc      = helpers.CommandDescriptor{Name: "dkick"}
+	skickDesc      = helpers.CommandDescriptor{Name: "skick"}
+	kickmeDesc     = helpers.CommandDescriptor{Name: "kickme", Disableable: true}
+	restrictDesc   = helpers.CommandDescriptor{Name: "restrict"}
+	unrestrictDesc = helpers.CommandDescriptor{Name: "unrestrict"}
+)
+
+func initBanDescs() {
+	banDesc.RequiredChecks = restrictChecks("ban")
+	sbanDesc.RequiredChecks = deleteRestrictChecks("sban")
+	tbanDesc.RequiredChecks = restrictChecks("tban")
+	dbanDesc.RequiredChecks = deleteRestrictChecks("dban")
+	unbanDesc.RequiredChecks = restrictChecks("unban")
+	banmeDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("banme"), helpers.RequireGroup(), helpers.CanBotRestrict()}
+	unbanAllDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("unbanall"), helpers.RequireGroup(), helpers.RequireUserOwner(), helpers.CanBotRestrict()}
+	kickDesc.RequiredChecks = restrictChecks("kick")
+	dkickDesc.RequiredChecks = deleteRestrictChecks("dkick")
+	skickDesc.RequiredChecks = deleteRestrictChecks("skick")
+	kickmeDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("kickme"), helpers.RequireGroup(), helpers.CanBotRestrict()}
+	restrictDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("restrict"), helpers.RequireGroup(), helpers.CanUserRestrict(), helpers.CanBotRestrict()}
+	unrestrictDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("unrestrict"), helpers.RequireGroup(), helpers.CanUserRestrict(), helpers.CanBotRestrict()}
+}
+
 func LoadBans(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[bansModule.moduleName] = true
+	initBanDescs()
 
-	dispatcher.AddHandler(handlers.NewCommand("ban", bansModule.ban))
-	dispatcher.AddHandler(handlers.NewCommand("sban", bansModule.sBan))
-	dispatcher.AddHandler(handlers.NewCommand("tban", bansModule.tBan))
-	dispatcher.AddHandler(handlers.NewCommand("dban", bansModule.dBan))
-	dispatcher.AddHandler(handlers.NewCommand("unban", bansModule.unban))
-	dispatcher.AddHandler(handlers.NewCommand("banme", bansModule.banme))
-	helpers.AddCmdToDisableable("banme")
-	dispatcher.AddHandler(handlers.NewCommand("unbanall", bansModule.unbanAllHandler))
+	helpers.WrapCommand(dispatcher, banDesc, pipelineHandler(bansModule.ban))
+	helpers.WrapCommand(dispatcher, sbanDesc, pipelineHandler(bansModule.sBan))
+	helpers.WrapCommand(dispatcher, tbanDesc, pipelineHandler(bansModule.tBan))
+	helpers.WrapCommand(dispatcher, dbanDesc, pipelineHandler(bansModule.dBan))
+	helpers.WrapCommand(dispatcher, unbanDesc, pipelineHandler(bansModule.unban))
+	helpers.WrapCommand(dispatcher, banmeDesc, pipelineHandler(bansModule.banme))
+	helpers.WrapCommand(dispatcher, unbanAllDesc, pipelineHandler(bansModule.unbanAllHandler))
 
-	dispatcher.AddHandler(handlers.NewCommand("kick", bansModule.kick))
-	dispatcher.AddHandler(handlers.NewCommand("dkick", bansModule.dkick))
-	dispatcher.AddHandler(handlers.NewCommand("skick", bansModule.sKick))
-	dispatcher.AddHandler(handlers.NewCommand("kickme", bansModule.kickme))
-	helpers.AddCmdToDisableable("kickme")
+	helpers.WrapCommand(dispatcher, kickDesc, pipelineHandler(bansModule.kick))
+	helpers.WrapCommand(dispatcher, dkickDesc, pipelineHandler(bansModule.dkick))
+	helpers.WrapCommand(dispatcher, skickDesc, pipelineHandler(bansModule.sKick))
+	helpers.WrapCommand(dispatcher, kickmeDesc, pipelineHandler(bansModule.kickme))
 
-	dispatcher.AddHandler(handlers.NewCommand("restrict", bansModule.restrict))
+	helpers.WrapCommand(dispatcher, restrictDesc, pipelineHandler(bansModule.restrict))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("restrict"), bansModule.restrictButtonHandler))
-	dispatcher.AddHandler(handlers.NewCommand("unrestrict", bansModule.unrestrict))
+	helpers.WrapCommand(dispatcher, unrestrictDesc, pipelineHandler(bansModule.unrestrict))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("unrestrict"), bansModule.unrestrictButtonHandler))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("unbanall|"), bansModule.unbanAllCallback))
 }
 
 func init() {
 	RegisterLegacyModule("Bans", 70, LoadBans)
-	RegisterAnonymousAdminHandler("ban", bansModule.ban)
-	RegisterAnonymousAdminHandler("dban", bansModule.dBan)
-	RegisterAnonymousAdminHandler("sban", bansModule.sBan)
-	RegisterAnonymousAdminHandler("tban", bansModule.tBan)
-	RegisterAnonymousAdminHandler("unban", bansModule.unban)
-	RegisterAnonymousAdminHandler("skick", bansModule.sKick)
-	RegisterAnonymousAdminHandler("restrict", bansModule.restrict)
-	RegisterAnonymousAdminHandler("unrestrict", bansModule.unrestrict)
+	initBanDescs()
+	RegisterAnonymousAdminHandler("ban", anonPipelineHandler(banDesc, bansModule.ban))
+	RegisterAnonymousAdminHandler("dban", anonPipelineHandler(dbanDesc, bansModule.dBan))
+	RegisterAnonymousAdminHandler("sban", anonPipelineHandler(sbanDesc, bansModule.sBan))
+	RegisterAnonymousAdminHandler("tban", anonPipelineHandler(tbanDesc, bansModule.tBan))
+	RegisterAnonymousAdminHandler("unban", anonPipelineHandler(unbanDesc, bansModule.unban))
+	RegisterAnonymousAdminHandler("skick", anonPipelineHandler(skickDesc, bansModule.sKick))
+	RegisterAnonymousAdminHandler("restrict", anonPipelineHandler(restrictDesc, bansModule.restrict))
+	RegisterAnonymousAdminHandler("unrestrict", anonPipelineHandler(unrestrictDesc, bansModule.unrestrict))
 }

--- a/alita/modules/captcha.go
+++ b/alita/modules/captcha.go
@@ -2049,14 +2049,25 @@ func LoadCaptcha(dispatcher *ext.Dispatcher) {
 
 	dispatcher.AddHandlerToGroup(handlers.NewMessage(nil, captchaModule.handlePendingCaptchaMessage), -10)
 
-	dispatcher.AddHandler(handlers.NewCommand("captcha", captchaModule.captchaCommand))
-	dispatcher.AddHandler(handlers.NewCommand("captchamode", captchaModule.captchaModeCommand))
-	dispatcher.AddHandler(handlers.NewCommand("captchatime", captchaModule.captchaTimeCommand))
-	dispatcher.AddHandler(handlers.NewCommand("captchaaction", captchaModule.captchaActionCommand))
-	dispatcher.AddHandler(handlers.NewCommand("captchamaxattempts", captchaModule.captchaMaxAttemptsCommand))
-
-	dispatcher.AddHandler(handlers.NewCommand("captchapending", captchaModule.viewPendingMessages))
-	dispatcher.AddHandler(handlers.NewCommand("captchaclear", captchaModule.clearPendingMessages))
+	fullAdmin := []helpers.CheckFunc{helpers.RequireGroup(), helpers.RequireUserAdmin(), helpers.RequireBotAdmin()}
+	userAdmin := []helpers.CheckFunc{helpers.RequireGroup(), helpers.RequireUserAdmin()}
+	userOnly := []helpers.CheckFunc{helpers.RequireUserAdmin()}
+	for _, cfg := range []struct {
+		name    string
+		checks  []helpers.CheckFunc
+		handler func(*gotgbot.Bot, *ext.Context) error
+	}{
+		{"captcha", append([]helpers.CheckFunc{helpers.CheckDisabled("captcha")}, fullAdmin...), captchaModule.captchaCommand},
+		{"captchamode", append([]helpers.CheckFunc{helpers.CheckDisabled("captchamode")}, userAdmin...), captchaModule.captchaModeCommand},
+		{"captchatime", append([]helpers.CheckFunc{helpers.CheckDisabled("captchatime")}, userAdmin...), captchaModule.captchaTimeCommand},
+		{"captchaaction", append([]helpers.CheckFunc{helpers.CheckDisabled("captchaaction")}, userAdmin...), captchaModule.captchaActionCommand},
+		{"captchamaxattempts", append([]helpers.CheckFunc{helpers.CheckDisabled("captchamaxattempts")}, fullAdmin...), captchaModule.captchaMaxAttemptsCommand},
+		{"captchapending", append([]helpers.CheckFunc{helpers.CheckDisabled("captchapending")}, userOnly...), captchaModule.viewPendingMessages},
+		{"captchaclear", append([]helpers.CheckFunc{helpers.CheckDisabled("captchaclear")}, userOnly...), captchaModule.clearPendingMessages},
+	} {
+		desc := helpers.CommandDescriptor{Name: cfg.name, RequiredChecks: cfg.checks}
+		helpers.WrapCommand(dispatcher, desc, pipelineHandler(cfg.handler))
+	}
 
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("captcha_verify"), captchaModule.captchaVerifyCallback))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("captcha_refresh"), captchaModule.captchaRefreshCallback))

--- a/alita/modules/greetings.go
+++ b/alita/modules/greetings.go
@@ -32,8 +32,6 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/media"
 )
 
-const maxConcurrentMemberProcessing = 5
-
 var recentJoinProcessTTL = 5 * time.Second
 
 var greetingsModule = moduleStruct{moduleName: "Greetings"}
@@ -740,36 +738,45 @@ func (moduleStruct) leftMember(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
-func processSingleNewMember(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64, newMember gotgbot.User, captchaEnabled bool) error {
-	if newMember.Id == bot.Id {
-		return nil
-	}
-
-	if !claimRecentJoinProcessing(chat.Id, newMember.Id) {
-		log.Debugf("[Greetings][cleanService] Skipping duplicate join processing for user %d in chat %d", newMember.Id, chat.Id)
-		return nil
-	}
-
-	if captchaEnabled && !chat_status.IsApproved(bot, chat.Id, newMember.Id) {
-		ctxCopy := ext.Context{EffectiveChat: chat}
-		if threadID != 0 {
-			ctxCopy.EffectiveMessage = &gotgbot.Message{Chat: *chat, MessageThreadId: threadID}
-		}
-		if err := SendCaptcha(bot, &ctxCopy, newMember.Id, newMember.FirstName); err != nil {
-			if errors.Is(err, errCaptchaDisabled) {
-			} else {
-				log.Errorf("Failed to send captcha to user %d: %v", newMember.Id, err)
+func membershipDepsForJoin(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64) MembershipDeps {
+	return MembershipDeps{
+		Claim: claimRecentJoinProcessing,
+		IsApproved: func(chatID, userID int64) bool {
+			return chat_status.IsApproved(bot, chatID, userID)
+		},
+		Challenge: func(user gotgbot.User) error {
+			ctxCopy := ext.Context{EffectiveChat: chat}
+			if threadID != 0 {
+				ctxCopy.EffectiveMessage = &gotgbot.Message{Chat: *chat, MessageThreadId: threadID}
+			}
+			if err := SendCaptcha(bot, &ctxCopy, user.Id, user.FirstName); err != nil {
+				if errors.Is(err, errCaptchaDisabled) {
+					return ErrChallengeDisabled
+				}
 				return err
 			}
-		} else {
 			return nil
-		}
+		},
+		Welcome: func(user gotgbot.User) error {
+			ctxCopy := ext.Context{EffectiveChat: chat}
+			if threadID != 0 {
+				ctxCopy.EffectiveMessage = &gotgbot.Message{Chat: *chat, MessageThreadId: threadID}
+			}
+			return SendWelcomeMessage(bot, &ctxCopy, user.Id, user.FirstName)
+		},
 	}
-	ctxCopy := ext.Context{EffectiveChat: chat}
-	if threadID != 0 {
-		ctxCopy.EffectiveMessage = &gotgbot.Message{Chat: *chat, MessageThreadId: threadID}
+}
+
+func processSingleNewMember(bot *gotgbot.Bot, chat *gotgbot.Chat, threadID int64, newMember gotgbot.User, captchaEnabled bool) error {
+	outcome, err := ProcessSingleJoin(chat.Id, bot.Id, newMember, captchaEnabled, membershipDepsForJoin(bot, chat, threadID))
+	if err != nil {
+		log.Errorf("Failed to send captcha to user %d: %v", newMember.Id, err)
+		return err
 	}
-	return SendWelcomeMessage(bot, &ctxCopy, newMember.Id, newMember.FirstName)
+	if outcome == JoinIgnore && newMember.Id != bot.Id {
+		log.Debugf("[Greetings][cleanService] Skipping duplicate join processing for user %d in chat %d", newMember.Id, chat.Id)
+	}
+	return nil
 }
 
 func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
@@ -798,36 +805,12 @@ func (moduleStruct) cleanService(bot *gotgbot.Bot, ctx *ext.Context) error {
 		}
 		chatCopyBase := *chat
 
-		numMembers := len(msg.NewChatMembers)
-		if numMembers > 1 {
-			var wg sync.WaitGroup
-			sem := make(chan struct{}, maxConcurrentMemberProcessing)
-
-			for _, newMember := range msg.NewChatMembers {
-				if newMember.Id == bot.Id {
+		if len(msg.NewChatMembers) > 0 {
+			deps := membershipDepsForJoin(bot, &chatCopyBase, threadID)
+			for _, outcome := range ProcessJoins(chat.Id, bot.Id, msg.NewChatMembers, captchaEnabled, deps) {
+				if outcome == JoinIgnore {
 					continue
 				}
-
-				wg.Add(1)
-				sem <- struct{}{}
-
-				go func(member gotgbot.User) {
-					defer wg.Done()
-					defer func() { <-sem }()
-					defer error_handling.RecoverFromPanic("processNewMember", "Greetings")
-
-					chatCopy := chatCopyBase
-					if err := processSingleNewMember(bot, &chatCopy, threadID, member, captchaEnabled); err != nil {
-						log.Error(err)
-					}
-				}(newMember)
-			}
-
-			wg.Wait()
-		} else if numMembers == 1 {
-			chatCopy := chatCopyBase
-			if err := processSingleNewMember(bot, &chatCopy, threadID, msg.NewChatMembers[0], captchaEnabled); err != nil {
-				log.Error(err)
 			}
 		}
 	}
@@ -1129,16 +1112,27 @@ func LoadGreetings(dispatcher *ext.Dispatcher) {
 		),
 	)
 
-	dispatcher.AddHandler(handlers.NewCommand("welcome", greetingsModule.welcome))
-	dispatcher.AddHandler(handlers.NewCommand("setwelcome", greetingsModule.setWelcome))
-	dispatcher.AddHandler(handlers.NewCommand("resetwelcome", greetingsModule.resetWelcome))
-	dispatcher.AddHandler(handlers.NewCommand("goodbye", greetingsModule.goodbye))
-	dispatcher.AddHandler(handlers.NewCommand("setgoodbye", greetingsModule.setGoodbye))
-	dispatcher.AddHandler(handlers.NewCommand("resetgoodbye", greetingsModule.resetGoodbye))
-	dispatcher.AddHandler(handlers.NewCommand("cleanwelcome", greetingsModule.cleanWelcome))
-	dispatcher.AddHandler(handlers.NewCommand("cleangoodbye", greetingsModule.cleanGoodbye))
-	dispatcher.AddHandler(handlers.NewCommand("cleanservice", greetingsModule.delJoined))
-	dispatcher.AddHandler(handlers.NewCommand("autoapprove", greetingsModule.autoApprove))
+	for _, cfg := range []struct {
+		name    string
+		handler func(*gotgbot.Bot, *ext.Context) error
+	}{
+		{"welcome", greetingsModule.welcome},
+		{"setwelcome", greetingsModule.setWelcome},
+		{"resetwelcome", greetingsModule.resetWelcome},
+		{"goodbye", greetingsModule.goodbye},
+		{"setgoodbye", greetingsModule.setGoodbye},
+		{"resetgoodbye", greetingsModule.resetGoodbye},
+		{"cleanwelcome", greetingsModule.cleanWelcome},
+		{"cleangoodbye", greetingsModule.cleanGoodbye},
+		{"cleanservice", greetingsModule.delJoined},
+		{"autoapprove", greetingsModule.autoApprove},
+	} {
+		desc := helpers.CommandDescriptor{
+			Name:           cfg.name,
+			RequiredChecks: []helpers.CheckFunc{helpers.CheckDisabled(cfg.name)},
+		}
+		helpers.WrapCommand(dispatcher, desc, pipelineHandler(cfg.handler))
+	}
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("join_request"), greetingsModule.joinRequestHandler))
 }
 

--- a/alita/modules/membership.go
+++ b/alita/modules/membership.go
@@ -1,0 +1,88 @@
+package modules
+
+import (
+	"errors"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+// ErrChallengeDisabled signals the challenge adapter is disabled; the caller
+// falls through to welcome, matching the historic greetings/captcha behavior.
+var ErrChallengeDisabled = errors.New("challenge disabled")
+
+type JoinOutcome int
+
+const (
+	JoinIgnore JoinOutcome = iota
+	JoinWelcome
+	JoinChallenge
+)
+
+type JoinInput struct {
+	IsBotSelf      bool
+	IsApproved     bool
+	CaptchaEnabled bool
+}
+
+func DecideJoin(in JoinInput) JoinOutcome {
+	if in.IsBotSelf {
+		return JoinIgnore
+	}
+	if in.CaptchaEnabled && !in.IsApproved {
+		return JoinChallenge
+	}
+	return JoinWelcome
+}
+
+type MembershipDeps struct {
+	Claim      func(chatID, userID int64) bool
+	IsApproved func(chatID, userID int64) bool
+	Challenge  func(user gotgbot.User) error
+	Welcome    func(user gotgbot.User) error
+}
+
+func ProcessSingleJoin(chatID, botID int64, user gotgbot.User, captchaEnabled bool, deps MembershipDeps) (JoinOutcome, error) {
+	if user.Id == botID {
+		return JoinIgnore, nil
+	}
+	if deps.Claim != nil && !deps.Claim(chatID, user.Id) {
+		return JoinIgnore, nil
+	}
+	approved := false
+	if deps.IsApproved != nil {
+		approved = deps.IsApproved(chatID, user.Id)
+	}
+	switch DecideJoin(JoinInput{IsApproved: approved, CaptchaEnabled: captchaEnabled}) {
+	case JoinChallenge:
+		if deps.Challenge != nil {
+			if err := deps.Challenge(user); err != nil {
+				if errors.Is(err, ErrChallengeDisabled) {
+					break
+				}
+				return JoinIgnore, err
+			}
+			return JoinChallenge, nil
+		}
+		return JoinChallenge, nil
+	default:
+	}
+	if deps.Welcome != nil {
+		if err := deps.Welcome(user); err != nil {
+			return JoinIgnore, err
+		}
+	}
+	return JoinWelcome, nil
+}
+
+func ProcessJoins(chatID, botID int64, members []gotgbot.User, captchaEnabled bool, deps MembershipDeps) []JoinOutcome {
+	out := make([]JoinOutcome, 0, len(members))
+	for _, m := range members {
+		o, err := ProcessSingleJoin(chatID, botID, m, captchaEnabled, deps)
+		if err != nil {
+			log.Error(err)
+		}
+		out = append(out, o)
+	}
+	return out
+}

--- a/alita/modules/membership_test.go
+++ b/alita/modules/membership_test.go
@@ -1,0 +1,134 @@
+package modules
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+func testMembershipDeps(claim func(int64, int64) bool, approved map[int64]bool, challengeErr error) (MembershipDeps, *[]int64, *[]int64) {
+	var challenged, welcomed []int64
+	return MembershipDeps{
+		Claim: claim,
+		IsApproved: func(_, uid int64) bool {
+			return approved[uid]
+		},
+		Challenge: func(u gotgbot.User) error {
+			if challengeErr != nil {
+				return challengeErr
+			}
+			challenged = append(challenged, u.Id)
+			return nil
+		},
+		Welcome: func(u gotgbot.User) error {
+			welcomed = append(welcomed, u.Id)
+			return nil
+		},
+	}, &challenged, &welcomed
+}
+
+func TestDecideJoin(t *testing.T) {
+	cases := []struct {
+		name string
+		in   JoinInput
+		want JoinOutcome
+	}{
+		{"bot self ignored", JoinInput{IsBotSelf: true, CaptchaEnabled: true}, JoinIgnore},
+		{"challenge when captcha on unapproved", JoinInput{CaptchaEnabled: true}, JoinChallenge},
+		{"welcome approved bypass", JoinInput{CaptchaEnabled: true, IsApproved: true}, JoinWelcome},
+		{"welcome captcha off", JoinInput{}, JoinWelcome},
+	}
+	for _, c := range cases {
+		if got := DecideJoin(c.in); got != c.want {
+			t.Fatalf("%s: got %d want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestProcessSingleJoinDuplicate(t *testing.T) {
+	claimed := map[int64]bool{}
+	deps, challenged, welcomed := testMembershipDeps(
+		func(_, uid int64) bool {
+			if claimed[uid] {
+				return false
+			}
+			claimed[uid] = true
+			return true
+		},
+		nil, nil,
+	)
+	u := gotgbot.User{Id: 11, FirstName: "N"}
+	if o, _ := ProcessSingleJoin(1, 999, u, false, deps); o != JoinWelcome {
+		t.Fatalf("first join = %d, want welcome", o)
+	}
+	if o, _ := ProcessSingleJoin(1, 999, u, false, deps); o != JoinIgnore {
+		t.Fatalf("duplicate join = %d, want ignore", o)
+	}
+	if len(*challenged) != 0 || len(*welcomed) != 1 {
+		t.Fatalf("challenged=%v welcomed=%v, want 0/1", *challenged, *welcomed)
+	}
+}
+
+func TestProcessSingleJoinApprovedBypass(t *testing.T) {
+	deps, challenged, welcomed := testMembershipDeps(nil, map[int64]bool{7: true}, nil)
+	o, err := ProcessSingleJoin(1, 999, gotgbot.User{Id: 7}, true, deps)
+	if err != nil || o != JoinWelcome {
+		t.Fatalf("approved join = %d,%v want welcome,nil", o, err)
+	}
+	if len(*challenged) != 0 || len(*welcomed) != 1 {
+		t.Fatalf("challenged=%v welcomed=%v", *challenged, *welcomed)
+	}
+}
+
+func TestProcessSingleJoinChallengeRouting(t *testing.T) {
+	deps, challenged, _ := testMembershipDeps(nil, nil, nil)
+	o, _ := ProcessSingleJoin(1, 999, gotgbot.User{Id: 5}, true, deps)
+	if o != JoinChallenge || len(*challenged) != 1 {
+		t.Fatalf("challenge routing = %d challenged=%v", o, *challenged)
+	}
+	if o, _ := ProcessSingleJoin(1, 999, gotgbot.User{Id: 999}, true, deps); o != JoinIgnore {
+		t.Fatalf("bot self = %d, want ignore", o)
+	}
+}
+
+func TestProcessSingleJoinChallengeDisabledFallsThrough(t *testing.T) {
+	deps, challenged, welcomed := testMembershipDeps(nil, nil, ErrChallengeDisabled)
+	o, err := ProcessSingleJoin(1, 999, gotgbot.User{Id: 5}, true, deps)
+	if err != nil || o != JoinWelcome {
+		t.Fatalf("disabled challenge = %d,%v want welcome,nil", o, err)
+	}
+	if len(*challenged) != 0 || len(*welcomed) != 1 {
+		t.Fatalf("challenged=%v welcomed=%v", *challenged, *welcomed)
+	}
+}
+
+func TestProcessSingleJoinChallengeError(t *testing.T) {
+	boom := errors.New("boom")
+	deps, _, _ := testMembershipDeps(nil, nil, boom)
+	if _, err := ProcessSingleJoin(1, 999, gotgbot.User{Id: 5}, true, deps); !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+}
+
+func TestProcessJoinsMultiMember(t *testing.T) {
+	claimed := map[int64]bool{2: true}
+	deps, challenged, welcomed := testMembershipDeps(
+		func(_, uid int64) bool {
+			if claimed[uid] {
+				return false
+			}
+			claimed[uid] = true
+			return true
+		},
+		map[int64]bool{3: true}, nil,
+	)
+	members := []gotgbot.User{{Id: 2}, {Id: 3}, {Id: 4}}
+	out := ProcessJoins(1, 999, members, true, deps)
+	if len(out) != 3 || out[0] != JoinIgnore || out[1] != JoinWelcome || out[2] != JoinChallenge {
+		t.Fatalf("outcomes = %v", out)
+	}
+	if len(*challenged) != 1 || len(*welcomed) != 1 {
+		t.Fatalf("challenged=%v welcomed=%v", *challenged, *welcomed)
+	}
+}

--- a/alita/modules/moderation.go
+++ b/alita/modules/moderation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
 	"github.com/divkix/Alita_Robot/alita/utils/extraction"
 	"github.com/divkix/Alita_Robot/alita/utils/formatting"
+	"github.com/divkix/Alita_Robot/alita/utils/helpers"
 )
 
 // moderationCtx holds the decomposed context for a moderation command.
@@ -331,4 +332,29 @@ func extractTemporalTarget(c *moderationCtx, t *target) int64 {
 	t.timeVal = timeVal
 	t.reason = reason
 	return _time
+}
+
+// pipelineHandler adapts a legacy (bot,ctx) moderation handler to the command
+// pipeline. WrapCommand already ran desc.RequiredChecks; the domain handler
+// keeps its legacy gates as a redundant safety net during migration.
+func pipelineHandler(domain func(*gotgbot.Bot, *ext.Context) error) func(*helpers.CommandContext) error {
+	return func(c *helpers.CommandContext) error {
+		return domain(c.Bot, c.Ctx)
+	}
+}
+
+// anonPipelineHandler is the post-proof anonymous-admin entry point for migrated
+// commands. It re-runs the same pipeline checks via helpers.RunChecks, making
+// migrated commands anon-safe by default without per-module re-enforcement.
+func anonPipelineHandler(desc helpers.CommandDescriptor, domain func(*gotgbot.Bot, *ext.Context) error) AnonymousAdminHandler {
+	return func(b *gotgbot.Bot, ctx *ext.Context) error {
+		c, err := helpers.BuildCommandContext(b, ctx)
+		if err != nil {
+			return ext.EndGroups
+		}
+		if !helpers.RunChecks(c, desc.RequiredChecks) {
+			return ext.EndGroups
+		}
+		return domain(b, ctx)
+	}
 }

--- a/alita/modules/moderation_pipeline_test.go
+++ b/alita/modules/moderation_pipeline_test.go
@@ -1,0 +1,28 @@
+//go:build testtools
+
+package modules
+
+import (
+	"testing"
+)
+
+func TestMigratedDescriptorsHaveChecks(t *testing.T) {
+	initBanDescs()
+	initMuteDescs()
+	initWarnDescs()
+	initPurgeDescs()
+	descs := map[string]int{
+		"ban": len(banDesc.RequiredChecks), "sban": len(sbanDesc.RequiredChecks),
+		"mute": len(muteDesc.RequiredChecks), "warn": len(warnDesc.RequiredChecks),
+		"del": len(delDesc.RequiredChecks), "purge": len(purgeDesc.RequiredChecks),
+		"resetwarns": len(resetWarnsDesc.RequiredChecks), "warns": len(warnsStatusDesc.RequiredChecks),
+	}
+	for name, n := range descs {
+		if n == 0 {
+			t.Fatalf("%s descriptor has no checks", name)
+		}
+	}
+	if len(warnsStatusDesc.RequiredChecks) != 1 {
+		t.Fatalf("warns status checks = %d, want 1 (disabled only)", len(warnsStatusDesc.RequiredChecks))
+	}
+}

--- a/alita/modules/mute.go
+++ b/alita/modules/mute.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
-	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/divkix/Alita_Robot/alita/utils/chat_status"
@@ -272,21 +271,39 @@ func (m moduleStruct) unmute(b *gotgbot.Bot, ctx *ext.Context) error {
 	return moderationUnmute(&m).run(b, ctx)
 }
 
+var (
+	muteDesc   = helpers.CommandDescriptor{Name: "mute"}
+	smuteDesc  = helpers.CommandDescriptor{Name: "smute"}
+	tmuteDesc  = helpers.CommandDescriptor{Name: "tmute"}
+	dmuteDesc  = helpers.CommandDescriptor{Name: "dmute"}
+	unmuteDesc = helpers.CommandDescriptor{Name: "unmute"}
+)
+
+func initMuteDescs() {
+	muteDesc.RequiredChecks = restrictChecks("mute")
+	smuteDesc.RequiredChecks = deleteRestrictChecks("smute")
+	tmuteDesc.RequiredChecks = restrictChecks("tmute")
+	dmuteDesc.RequiredChecks = deleteRestrictChecks("dmute")
+	unmuteDesc.RequiredChecks = restrictChecks("unmute")
+}
+
 func LoadMutes(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[mutesModule.moduleName] = true
+	initMuteDescs()
 
-	dispatcher.AddHandler(handlers.NewCommand("mute", mutesModule.mute))
-	dispatcher.AddHandler(handlers.NewCommand("smute", mutesModule.sMute))
-	dispatcher.AddHandler(handlers.NewCommand("tmute", mutesModule.tMute))
-	dispatcher.AddHandler(handlers.NewCommand("dmute", mutesModule.dMute))
-	dispatcher.AddHandler(handlers.NewCommand("unmute", mutesModule.unmute))
+	helpers.WrapCommand(dispatcher, muteDesc, pipelineHandler(mutesModule.mute))
+	helpers.WrapCommand(dispatcher, smuteDesc, pipelineHandler(mutesModule.sMute))
+	helpers.WrapCommand(dispatcher, tmuteDesc, pipelineHandler(mutesModule.tMute))
+	helpers.WrapCommand(dispatcher, dmuteDesc, pipelineHandler(mutesModule.dMute))
+	helpers.WrapCommand(dispatcher, unmuteDesc, pipelineHandler(mutesModule.unmute))
 }
 
 func init() {
 	RegisterLegacyModule("Mutes", 80, LoadMutes)
-	RegisterAnonymousAdminHandler("mute", mutesModule.mute)
-	RegisterAnonymousAdminHandler("smute", mutesModule.sMute)
-	RegisterAnonymousAdminHandler("dmute", mutesModule.dMute)
-	RegisterAnonymousAdminHandler("tmute", mutesModule.tMute)
-	RegisterAnonymousAdminHandler("unmute", mutesModule.unmute)
+	initMuteDescs()
+	RegisterAnonymousAdminHandler("mute", anonPipelineHandler(muteDesc, mutesModule.mute))
+	RegisterAnonymousAdminHandler("smute", anonPipelineHandler(smuteDesc, mutesModule.sMute))
+	RegisterAnonymousAdminHandler("dmute", anonPipelineHandler(dmuteDesc, mutesModule.dMute))
+	RegisterAnonymousAdminHandler("tmute", anonPipelineHandler(tmuteDesc, mutesModule.tMute))
+	RegisterAnonymousAdminHandler("unmute", anonPipelineHandler(unmuteDesc, mutesModule.unmute))
 }

--- a/alita/modules/pins.go
+++ b/alita/modules/pins.go
@@ -630,16 +630,11 @@ func (moduleStruct) GetPinType(msg *gotgbot.Message) (fileid, text string, dataT
 // could pin/unpin via the anon flow (the bot issues the API call, so Telegram
 // only checks the bot's rights, not the caller's).
 func enforcePinChecks(c *helpers.CommandContext) bool {
-	for _, check := range []helpers.CheckFunc{
+	return helpers.RunChecks(c, []helpers.CheckFunc{
 		helpers.RequireBotAdmin(),
 		helpers.CanUserPin(),
 		helpers.CanBotPin(),
-	} {
-		if !check(c) {
-			return false
-		}
-	}
-	return true
+	})
 }
 
 func (m moduleStruct) pinAnonAdmin(b *gotgbot.Bot, ctx *ext.Context) error {

--- a/alita/modules/purges.go
+++ b/alita/modules/purges.go
@@ -474,18 +474,45 @@ func (m moduleStruct) purgeTo(bot *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
+func purgeChecks(cmd string) []helpers.CheckFunc {
+	return []helpers.CheckFunc{
+		helpers.CheckDisabled(cmd),
+		helpers.RequireGroup(),
+		helpers.RequireBotAdmin(),
+		helpers.CanBotDelete(),
+		helpers.RequireUserAdmin(),
+		helpers.CanUserDelete(),
+	}
+}
+
+var (
+	delDesc       = helpers.CommandDescriptor{Name: "del"}
+	purgeDesc     = helpers.CommandDescriptor{Name: "purge"}
+	purgeFromDesc = helpers.CommandDescriptor{Name: "purgefrom"}
+	purgeToDesc   = helpers.CommandDescriptor{Name: "purgeto"}
+)
+
+func initPurgeDescs() {
+	delDesc.RequiredChecks = purgeChecks("del")
+	purgeDesc.RequiredChecks = purgeChecks("purge")
+	purgeFromDesc.RequiredChecks = purgeChecks("purgefrom")
+	purgeToDesc.RequiredChecks = purgeChecks("purgeto")
+}
+
 func LoadPurges(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[purgesModule.moduleName] = true
+	initPurgeDescs()
 
-	dispatcher.AddHandler(handlers.NewCommand("del", purgesModule.delCmd))
-	dispatcher.AddHandler(handlers.NewCommand("purge", purgesModule.purge))
-	dispatcher.AddHandler(handlers.NewCommand("purgefrom", purgesModule.purgeFrom))
-	dispatcher.AddHandler(handlers.NewCommand("purgeto", purgesModule.purgeTo))
+	helpers.WrapCommand(dispatcher, delDesc, pipelineHandler(purgesModule.delCmd))
+	helpers.WrapCommand(dispatcher, purgeDesc, pipelineHandler(purgesModule.purge))
+	helpers.WrapCommand(dispatcher, purgeFromDesc, pipelineHandler(purgesModule.purgeFrom))
+	helpers.WrapCommand(dispatcher, purgeToDesc, pipelineHandler(purgesModule.purgeTo))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("deleteMsg"), purgesModule.deleteButtonHandler))
 }
 
 func init() {
 	RegisterLegacyModule("Purges", 90, LoadPurges)
-	RegisterAnonymousAdminHandler("purge", purgesModule.purge)
-	RegisterAnonymousAdminHandler("del", purgesModule.delCmd)
+	initPurgeDescs()
+	RegisterAnonymousAdminHandler("purge", anonPipelineHandler(purgeDesc, purgesModule.purge))
+	RegisterAnonymousAdminHandler("del", anonPipelineHandler(delDesc, purgesModule.delCmd))
 }

--- a/alita/modules/warns.go
+++ b/alita/modules/warns.go
@@ -333,10 +333,6 @@ func (moduleStruct) warns(b *gotgbot.Bot, ctx *ext.Context) error {
 	msg := ctx.EffectiveMessage
 	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
-	if chat_status.CheckDisabledCmd(b, msg, "warns") {
-		return ext.EndGroups
-	}
-
 	userId := extraction.ExtractUser(b, ctx)
 	if userId == -1 {
 		if ctx.EffectiveUser == nil {
@@ -782,29 +778,74 @@ func (moduleStruct) removeWarn(b *gotgbot.Bot, ctx *ext.Context) error {
 	return ext.EndGroups
 }
 
+var (
+	warnDesc        = helpers.CommandDescriptor{Name: "warn"}
+	swarnDesc       = helpers.CommandDescriptor{Name: "swarn"}
+	dwarnDesc       = helpers.CommandDescriptor{Name: "dwarn"}
+	resetWarnsDesc  = helpers.CommandDescriptor{Name: "resetwarns", Aliases: []string{"resetwarn"}}
+	removeWarnDesc  = helpers.CommandDescriptor{Name: "rmwarn", Aliases: []string{"unwarn"}}
+	warnsStatusDesc = helpers.CommandDescriptor{Name: "warns", Disableable: true}
+)
+
+func adminBotUserChecks(cmd string) []helpers.CheckFunc {
+	return []helpers.CheckFunc{
+		helpers.CheckDisabled(cmd),
+		helpers.RequireGroup(),
+		helpers.RequireBotAdmin(),
+		helpers.RequireUserAdmin(),
+	}
+}
+
+func initWarnDescs() {
+	warnDesc.RequiredChecks = restrictChecks("warn")
+	swarnDesc.RequiredChecks = restrictChecks("swarn")
+	dwarnDesc.RequiredChecks = restrictChecks("dwarn")
+	resetWarnsDesc.RequiredChecks = adminBotUserChecks("resetwarns")
+	removeWarnDesc.RequiredChecks = adminBotUserChecks("rmwarn")
+	warnsStatusDesc.RequiredChecks = []helpers.CheckFunc{helpers.CheckDisabled("warns")}
+}
+
 func LoadWarns(dispatcher *ext.Dispatcher) {
 	DefaultHelpRegistry().AbleMap[warnsModule.moduleName] = true
+	initWarnDescs()
 
-	dispatcher.AddHandler(handlers.NewCommand("warn", warnsModule.warnUser))
-	dispatcher.AddHandler(handlers.NewCommand("swarn", warnsModule.sWarnUser))
-	dispatcher.AddHandler(handlers.NewCommand("dwarn", warnsModule.dWarnUser))
-	dispatcher.AddHandler(handlers.NewCommand("resetwarns", warnsModule.resetWarns))
-	dispatcher.AddHandler(handlers.NewCommand("resetwarn", warnsModule.resetWarns))
-	dispatcher.AddHandler(handlers.NewCommand("rmwarn", warnsModule.removeWarn))
-	dispatcher.AddHandler(handlers.NewCommand("unwarn", warnsModule.removeWarn))
-	dispatcher.AddHandler(handlers.NewCommand("warns", warnsModule.warns))
-	helpers.AddCmdToDisableable("warns")
-	dispatcher.AddHandler(handlers.NewCommand("setwarnlimit", warnsModule.setWarnLimit))
-	dispatcher.AddHandler(handlers.NewCommand("setwarnmode", warnsModule.setWarnMode))
-	dispatcher.AddHandler(handlers.NewCommand("resetallwarns", warnsModule.resetAllWarns))
+	helpers.WrapCommand(dispatcher, warnDesc, pipelineHandler(warnsModule.warnUser))
+	helpers.WrapCommand(dispatcher, swarnDesc, pipelineHandler(warnsModule.sWarnUser))
+	helpers.WrapCommand(dispatcher, dwarnDesc, pipelineHandler(warnsModule.dWarnUser))
+	helpers.WrapCommand(dispatcher, resetWarnsDesc, pipelineHandler(warnsModule.resetWarns))
+	helpers.WrapCommand(dispatcher, removeWarnDesc, pipelineHandler(warnsModule.removeWarn))
+	helpers.WrapCommand(dispatcher, warnsStatusDesc, pipelineHandler(warnsModule.warns))
+	for _, cfg := range []struct {
+		name    string
+		handler func(*gotgbot.Bot, *ext.Context) error
+	}{
+		{"setwarnlimit", warnsModule.setWarnLimit},
+		{"setwarnmode", warnsModule.setWarnMode},
+		{"resetallwarns", warnsModule.resetAllWarns},
+	} {
+		desc := helpers.CommandDescriptor{
+			Name:           cfg.name,
+			RequiredChecks: []helpers.CheckFunc{helpers.CheckDisabled(cfg.name)},
+		}
+		helpers.WrapCommand(dispatcher, desc, pipelineHandler(cfg.handler))
+	}
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("rmAllChatWarns"), warnsModule.warnsButtonHandler))
-	dispatcher.AddHandler(handlers.NewCommand("warnings", warnsModule.warnings))
+	helpers.WrapCommand(dispatcher, helpers.CommandDescriptor{
+		Name: "warnings",
+		RequiredChecks: []helpers.CheckFunc{
+			helpers.CheckDisabled("warnings"),
+			helpers.RequireGroup(),
+			helpers.RequireBotAdmin(),
+			helpers.RequireUserAdmin(),
+		},
+	}, pipelineHandler(warnsModule.warnings))
 	dispatcher.AddHandler(handlers.NewCallback(callbackquery.Prefix("rmWarn"), warnsModule.rmWarnButton))
 }
 
 func init() {
 	RegisterLegacyModule("Warns", 200, LoadWarns)
-	RegisterAnonymousAdminHandler("warn", warnsModule.warnUser)
-	RegisterAnonymousAdminHandler("swarn", warnsModule.sWarnUser)
-	RegisterAnonymousAdminHandler("dwarn", warnsModule.dWarnUser)
+	initWarnDescs()
+	RegisterAnonymousAdminHandler("warn", anonPipelineHandler(warnDesc, warnsModule.warnUser))
+	RegisterAnonymousAdminHandler("swarn", anonPipelineHandler(swarnDesc, warnsModule.sWarnUser))
+	RegisterAnonymousAdminHandler("dwarn", anonPipelineHandler(dwarnDesc, warnsModule.dWarnUser))
 }

--- a/alita/utils/helpers/command_pipeline.go
+++ b/alita/utils/helpers/command_pipeline.go
@@ -210,3 +210,73 @@ func CanBotChangeInfo() CheckFunc {
 		return result
 	}
 }
+
+func CanUserRestrict() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		result := chat_status.CanUserRestrict(c.Bot, c.Ctx, nil, c.User.Id)
+		if !result {
+			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_restrict_cmd_error", "chat_status_restrict_button_error")
+		}
+		return result
+	}
+}
+
+func CanBotRestrict() CheckFunc {
+	return func(c *CommandContext) bool {
+		result := chat_status.CanBotRestrict(c.Bot, c.Ctx, nil)
+		if !result {
+			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_bot_restrict_group_error", "chat_status_bot_restrict_error")
+		}
+		return result
+	}
+}
+
+func RequireUserOwner() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		result := chat_status.RequireUserOwner(c.Bot, c.Ctx, nil, c.User.Id)
+		if !result {
+			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_owner_cmd_error", "chat_status_owner_button_error", chat_status.WithReply())
+		}
+		return result
+	}
+}
+
+func CanUserDelete() CheckFunc {
+	return func(c *CommandContext) bool {
+		if c.User == nil {
+			return false
+		}
+		result := chat_status.CanUserDelete(c.Bot, c.Ctx, nil, c.User.Id)
+		if !result {
+			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_delete_cmd_error", "chat_status_delete_button_error", chat_status.WithReply())
+		}
+		return result
+	}
+}
+
+func CanBotDelete() CheckFunc {
+	return func(c *CommandContext) bool {
+		result := chat_status.CanBotDelete(c.Bot, c.Ctx, nil)
+		if !result {
+			chat_status.NewPermissionResponder(c.Bot).Respond(c.Ctx, "chat_status_bot_delete_error", "", chat_status.WithReply())
+		}
+		return result
+	}
+}
+
+// RunChecks re-runs pipeline checks, for anonymous-admin post-proof handlers
+// which bypass WrapCommand's RequiredChecks. Returns false on first failure.
+func RunChecks(c *CommandContext, checks []CheckFunc) bool {
+	for _, check := range checks {
+		if !check(c) {
+			return false
+		}
+	}
+	return true
+}

--- a/alita/utils/helpers/command_pipeline_test.go
+++ b/alita/utils/helpers/command_pipeline_test.go
@@ -455,3 +455,73 @@ func TestRegisterWithGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestNewChecksTrueBranches(t *testing.T) {
+	cases := []struct {
+		name  string
+		check CheckFunc
+		c     *CommandContext
+	}{
+		{"CanUserRestrict admin", CanUserRestrict(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 10), User: &gotgbot.User{Id: 10}}},
+		{"CanBotRestrict full bot", CanBotRestrict(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")}},
+		{"RequireUserOwner owner", RequireUserOwner(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 12), User: &gotgbot.User{Id: 12}}},
+		{"CanUserDelete admin", CanUserDelete(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 10), User: &gotgbot.User{Id: 10}}},
+		{"CanBotDelete full bot", CanBotDelete(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContext("supergroup")}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.check(tc.c); !got {
+				t.Fatalf("%s returned false, want true", tc.name)
+			}
+		})
+	}
+}
+
+func TestNewChecksFalseBranches(t *testing.T) {
+	cases := []struct {
+		name  string
+		check CheckFunc
+		c     *CommandContext
+	}{
+		{"CanUserRestrict member", CanUserRestrict(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 42), User: &gotgbot.User{Id: 42}}},
+		{"CanBotRestrict limited bot", CanBotRestrict(), &CommandContext{Bot: newCpBot(998), Ctx: makeCpContext("supergroup")}},
+		{"RequireUserOwner non-owner", RequireUserOwner(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 10), User: &gotgbot.User{Id: 10}}},
+		{"CanUserDelete member", CanUserDelete(), &CommandContext{Bot: newCpBot(999), Ctx: makeCpContextWithUser("supergroup", 42), User: &gotgbot.User{Id: 42}}},
+		{"CanBotDelete limited bot", CanBotDelete(), &CommandContext{Bot: newCpBot(998), Ctx: makeCpContext("supergroup")}},
+		{"CanUserRestrict nil user", CanUserRestrict(), &CommandContext{Bot: newCpBot(999)}},
+		{"RequireUserOwner nil user", RequireUserOwner(), &CommandContext{Bot: newCpBot(999)}},
+		{"CanUserDelete nil user", CanUserDelete(), &CommandContext{Bot: newCpBot(999)}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.check(tc.c); got {
+				t.Fatalf("%s returned true, want false", tc.name)
+			}
+		})
+	}
+}
+
+func TestRunChecksOrder(t *testing.T) {
+	calls := []string{}
+	mk := func(name string, ret bool) CheckFunc {
+		return func(_ *CommandContext) bool {
+			calls = append(calls, name)
+			return ret
+		}
+	}
+	c := &CommandContext{}
+	if !RunChecks(c, []CheckFunc{mk("a", true), mk("b", true)}) {
+		t.Fatal("RunChecks all-true = false, want true")
+	}
+	calls = nil
+	if RunChecks(c, []CheckFunc{mk("a", true), mk("b", false), mk("c", true)}) {
+		t.Fatal("RunChecks with false = true, want false")
+	}
+	if len(calls) != 2 || calls[0] != "a" || calls[1] != "b" {
+		t.Fatalf("RunChecks calls = %v, want [a b] (short-circuit)", calls)
+	}
+}


### PR DESCRIPTION
Closes #838.

Pure deepening, zero behavior change. Admins/newcomers see identical behavior; each bug class fixed once.

Tickets (Herdr-orchestrated, sequential, workspace w13 tab w13:t2):
- T1: membership seam (`alita/modules/membership.go` Decide/ProcessSingle/ProcessJoins, pure + injected deps, matrix tests)
- T2: flagless cutover of greetings newMember/cleanService behind seam (antiraid untouched)
- T3: pipeline +5 checks (user-restrict, bot-restrict, user-owner, user-delete, bot-delete) + RunChecks centralization + matrix tests
- T4: migrate ban/mute/warn/purge families to WrapCommand (disabled-first, anon registry runs same checks via anonPipelineHandler, direct disabled removed from warns status)
- T5: migrate greeting/captcha/warn config commands to WrapCommand; pins enforcePinChecks via RunChecks

Validation:
- `go test -tags testtools ./alita/...` all ok (modules 3.7s)
- `make check-translations` pass, `make check-docs` no drift
- `go vet -tags testtools ./alita/...` clean; changed files gofmt-clean (one pre-existing gofmt nit in greetings_command_test.go untouched)
- `make lint` (golangci-lint v2) crashes with internal go/types panic in this env — pre-existing tool failure, not caused by this diff (vet/gofmt clean)

Risk: double-gating during migration (WrapCommand checks + legacy domain gates re-run, harmless redundant pass); legacy gates removable after verification. No schema/migration/i18n changes.