### PR TITLE
fix: migration checks, restore state, and antiflood fast path

### DIFF
--- a/alita/db/backup/backup.go
+++ b/alita/db/backup/backup.go
@@ -745,7 +745,7 @@ func importNotes(tx *gorm.DB, chatID int64, payload interface{}, preserveLegacyO
 	if err := replaceChatRows(tx, chatID, data.Notes); err != nil {
 		return nil, err
 	}
-	return []string{cacheKey("notes_settings", chatID)}, nil
+	return []string{cacheKey("notes_settings", chatID), cacheKey("notes_list", chatID)}, nil
 }
 
 func importPins(tx *gorm.DB, chatID int64, payload interface{}) ([]string, error) {
@@ -1030,7 +1030,7 @@ func clearNotes(tx *gorm.DB, chatID int64) ([]string, error) {
 	if err := replaceChatSetting(tx, chatID, &models.NotesSettings{ChatId: chatID}); err != nil {
 		return nil, err
 	}
-	return []string{cacheKey("notes_settings", chatID)}, replaceChatRows[models.Notes](tx, chatID, nil)
+	return []string{cacheKey("notes_settings", chatID), cacheKey("notes_list", chatID)}, replaceChatRows[models.Notes](tx, chatID, nil)
 }
 
 func clearPins(tx *gorm.DB, chatID int64) ([]string, error) {

--- a/alita/db/backup/notes_cache_test.go
+++ b/alita/db/backup/notes_cache_test.go
@@ -1,0 +1,153 @@
+package backup
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	gocache "github.com/eko/gocache/lib/v4/cache"
+	"github.com/eko/gocache/lib/v4/marshaler"
+	gocache_store "github.com/eko/gocache/store/redis/v4"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/divkix/Alita_Robot/alita/db"
+	"github.com/divkix/Alita_Robot/alita/db/chats"
+	"github.com/divkix/Alita_Robot/alita/db/models"
+	"github.com/divkix/Alita_Robot/alita/db/notes"
+	utilsCache "github.com/divkix/Alita_Robot/alita/utils/cache"
+)
+
+// withMiniredisCache starts an in-process Redis server and installs it as the
+// cache marshaler so cache read-through and invalidation paths are exercised
+// without a live Redis server.
+func withMiniredisCache(t *testing.T) {
+	t.Helper()
+
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	previousMarshal := utilsCache.GetMarshal()
+	previousManager := utilsCache.Manager
+	manager := gocache.New[any](gocache_store.NewRedis(client))
+	utilsCache.Manager = manager
+	utilsCache.SetMarshal(marshaler.New(manager))
+	t.Cleanup(func() {
+		utilsCache.Manager = previousManager
+		utilsCache.SetMarshal(previousMarshal)
+	})
+}
+
+func notesImportPayload(t *testing.T, chatID int64, name string) map[string]interface{} {
+	t.Helper()
+
+	raw, err := json.Marshal(NotesBackup{
+		Notes: []models.Notes{{ChatId: chatID, NoteName: name, NoteContent: "content"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal notes backup payload: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal notes backup payload: %v", err)
+	}
+	return payload
+}
+
+func seedCachedNote(t *testing.T, chatID int64, name string) {
+	t.Helper()
+
+	if err := chats.EnsureChatInDb(chatID, "notes-cache-test"); err != nil {
+		t.Fatalf("EnsureChatInDb() error = %v", err)
+	}
+	if err := notes.AddNote(chatID, name, "content", "", nil, db.TEXT,
+		false, false, false, false, false, false); err != nil {
+		t.Fatalf("AddNote(%q) error = %v", name, err)
+	}
+	// Prime notes_list in Redis; every later GetNotesList must observe
+	// post-import state instead of this snapshot.
+	if primed := notes.GetNotesList(chatID, true); !slices.Contains(primed, name) {
+		t.Fatalf("primed GetNotesList() = %v, want it to contain %q", primed, name)
+	}
+}
+
+func cleanupNotesChat(t *testing.T, chatID int64) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.Notes{}).Error
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.NotesSettings{}).Error
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.Chat{}).Error
+	})
+}
+
+func TestImportNotesInvalidatesNotesListCache(t *testing.T) {
+	skipIfNoDb(t)
+	withMiniredisCache(t)
+
+	chatID := time.Now().UnixNano()
+	cleanupNotesChat(t, chatID)
+	seedCachedNote(t, chatID, "stale-note")
+
+	if err := ImportModuleData(chatID, BackupModuleNotes, notesImportPayload(t, chatID, "restored-note")); err != nil {
+		t.Fatalf("ImportModuleData(notes) error = %v", err)
+	}
+
+	if got := notes.GetNotesList(chatID, true); len(got) != 1 || got[0] != "restored-note" {
+		t.Fatalf("GetNotesList() after import = %v, want [restored-note]", got)
+	}
+}
+
+func TestClearNotesInvalidatesNotesListCache(t *testing.T) {
+	skipIfNoDb(t)
+	withMiniredisCache(t)
+
+	chatID := time.Now().UnixNano() + 1
+	cleanupNotesChat(t, chatID)
+	seedCachedNote(t, chatID, "doomed-note")
+
+	if err := ClearModuleData(chatID, BackupModuleNotes); err != nil {
+		t.Fatalf("ClearModuleData(notes) error = %v", err)
+	}
+
+	if got := notes.GetNotesList(chatID, true); len(got) != 0 {
+		t.Fatalf("GetNotesList() after clear = %v, want empty", got)
+	}
+}
+
+func TestImportDisablingPreservesExplicitFalse(t *testing.T) {
+	skipIfNoDb(t)
+
+	chatID := time.Now().UnixNano() + 2
+	t.Cleanup(func() {
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.DisableSettings{}).Error
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.DisableChatSettings{}).Error
+		_ = db.DB.Where("chat_id = ?", chatID).Delete(&models.Chat{}).Error
+	})
+
+	// Backup imports keep every row field, including an explicit
+	// disabled=false (this is the row DisableCMD must flip to true).
+	payload := map[string]interface{}{
+		"commands": []interface{}{
+			map[string]interface{}{"command": "ban", "disabled": false},
+		},
+	}
+	if err := ImportModuleData(chatID, BackupModuleDisabling, payload); err != nil {
+		t.Fatalf("ImportModuleData(disabling) error = %v", err)
+	}
+
+	var row models.DisableSettings
+	if err := db.DB.Where("chat_id = ? AND command = ?", chatID, "ban").Take(&row).Error; err != nil {
+		t.Fatalf("read back imported DisableSettings error = %v", err)
+	}
+	if row.Disabled {
+		t.Fatal("imported DisableSettings.Disabled = true, want preserved false")
+	}
+}

--- a/alita/db/disabling/repository.go
+++ b/alita/db/disabling/repository.go
@@ -18,9 +18,11 @@ func DisableCMD(chatID int64, cmd string) error {
 		Disabled: true,
 	}
 
+	// Backup imports preserve disabled=false rows, so a conflicting row must be
+	// flipped to true instead of ignored (mirrors locks.UpdateLock).
 	err := db.DB.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "chat_id"}, {Name: "command"}},
-		DoNothing: true,
+		DoUpdates: clause.AssignmentColumns([]string{"disabled"}),
 	}).Create(disableSetting).Error
 	if err != nil {
 		log.Errorf("[Database][DisableCMD]: %v", err)

--- a/alita/db/disabling/repository_cache_test.go
+++ b/alita/db/disabling/repository_cache_test.go
@@ -15,7 +15,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-func TestGetChatDisabledCMDsCachedDoesNotCacheDatabaseErrors(t *testing.T) {
+func setupDisablingCacheDB(t *testing.T) {
+	t.Helper()
 	originalDB := db.DB
 	testDB, err := gorm.Open(
 		sqlite.Open(fmt.Sprintf("file:disabling-%d?mode=memory&cache=shared", time.Now().UnixNano())),
@@ -36,6 +37,10 @@ func TestGetChatDisabledCMDsCachedDoesNotCacheDatabaseErrors(t *testing.T) {
 		db.DB = originalDB
 	})
 
+}
+
+func TestGetChatDisabledCMDsCachedDoesNotCacheDatabaseErrors(t *testing.T) {
+	setupDisablingCacheDB(t)
 	const chatID = int64(-100123)
 	if got := GetChatDisabledCMDsCached(chatID); len(got) != 0 {
 		t.Fatalf("disabled commands with missing table = %v, want empty", got)
@@ -55,5 +60,44 @@ func TestGetChatDisabledCMDsCachedDoesNotCacheDatabaseErrors(t *testing.T) {
 	got := GetChatDisabledCMDsCached(chatID)
 	if len(got) != 1 || got[0] != "rules" {
 		t.Fatalf("disabled commands after DB recovery = %v, want [rules]", got)
+	}
+}
+
+func TestDisableCMDFlipsImportedFalseRow(t *testing.T) {
+	setupDisablingCacheDB(t)
+	if err := db.DB.AutoMigrate(&models.DisableSettings{}); err != nil {
+		t.Fatalf("AutoMigrate DisableSettings: %v", err)
+	}
+
+	chatID := time.Now().UnixNano() + 9000
+	cmd := "ban"
+
+	// Backup imports preserve disabled=false rows because replaceChatRows
+	// inserts maps (all keys included), so seed one the same way. A struct
+	// Create would silently apply the column default of true instead.
+	if err := db.DB.Model(&models.DisableSettings{}).Create(map[string]any{
+		"chat_id":  chatID,
+		"command":  cmd,
+		"disabled": false,
+	}).Error; err != nil {
+		t.Fatalf("seed disabled=false row error = %v", err)
+	}
+	if IsCommandDisabled(chatID, cmd) {
+		t.Fatal("IsCommandDisabled() = true before DisableCMD, want false")
+	}
+
+	if err := DisableCMD(chatID, cmd); err != nil {
+		t.Fatalf("DisableCMD() error = %v", err)
+	}
+
+	var row models.DisableSettings
+	if err := db.DB.Where("chat_id = ? AND command = ?", chatID, cmd).Take(&row).Error; err != nil {
+		t.Fatalf("read back DisableSettings error = %v", err)
+	}
+	if !row.Disabled {
+		t.Fatal("DisableSettings.Disabled = false after DisableCMD, want true")
+	}
+	if !IsCommandDisabled(chatID, cmd) {
+		t.Fatal("IsCommandDisabled() = false after DisableCMD, want true")
 	}
 }

--- a/alita/db/disabling/repository_test.go
+++ b/alita/db/disabling/repository_test.go
@@ -195,8 +195,8 @@ func TestDisableSameCommandTwice(t *testing.T) {
 		db.DB.Where("chat_id = ? AND command = ?", chatID, cmd).Delete(&models.DisableSettings{})
 	})
 
-	// Disable "start" twice -- DisableCMD uses ON CONFLICT DO NOTHING, so the
-	// second call is a no-op (no duplicate row, no error). The important
+	// Disable "start" twice -- DisableCMD uses ON CONFLICT DO UPDATE, so the
+	// second call is idempotent (no duplicate row, no error). The important
 	// invariant is that IsCommandDisabled returns true and exactly one row
 	// exists in the list.
 	if err := DisableCMD(chatID, cmd); err != nil {

--- a/alita/db/migrations/runner.go
+++ b/alita/db/migrations/runner.go
@@ -60,16 +60,9 @@ func (m *MigrationRunner) RunMigrations() error {
 
 	log.Infof("[Migrations] Found %d migration files", len(files))
 
-	var appliedCount int64
-	if err := m.db.Model(&SchemaMigration{}).Count(&appliedCount).Error; err != nil {
-		return fmt.Errorf("failed to count applied migrations: %w", err)
-	}
-	if appliedCount == int64(len(files)) {
-		log.Infof("[Migrations] All %d migrations already applied; nothing to do", len(files))
-		m.logMigrationStatus()
-		return nil
-	}
-
+	// No count-only shortcut: every file must be checked by name and checksum
+	// so tampered or swapped migrations are detected even when the total count
+	// already matches the number of applied rows.
 	applied := 0
 	skipped := 0
 

--- a/alita/db/migrations/runner_test.go
+++ b/alita/db/migrations/runner_test.go
@@ -1136,3 +1136,92 @@ func TestLegacyRowWithoutChecksumDoesNotFalseAlarm(t *testing.T) {
 }
 
 func timeNow() time.Time { return time.Now().UTC() }
+
+func isolatedMigrationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	skipIfNoDb(t)
+	tx := getTestDB().Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { _ = tx.Rollback().Error })
+	if err := (&MigrationRunner{db: tx}).ensureMigrationsTable(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Exec("DELETE FROM schema_migrations").Error; err != nil {
+		t.Fatal(err)
+	}
+	return tx
+}
+
+func TestRunMigrationsDetectsTamperedFileAfterFullApply(t *testing.T) {
+	database := isolatedMigrationDB(t)
+
+	previousConfig := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = previousConfig })
+	config.AppConfig = &config.Config{AutoMigrateSilentFail: false}
+
+	dir := t.TempDir()
+	version := "903_tamper_after_apply.sql"
+	migrationPath := filepath.Join(dir, version)
+	original := []byte(`CREATE TABLE migration_tamper_after_apply_test (id INTEGER PRIMARY KEY);`)
+	if err := os.WriteFile(migrationPath, original, 0o600); err != nil {
+		t.Fatalf("failed to write migration file: %v", err)
+	}
+
+	runner := &MigrationRunner{db: database, migrationsPath: dir}
+	if err := runner.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations() first run error = %v", err)
+	}
+
+	// Tamper after the DB is fully applied: file count still matches the
+	// applied-row count, so a count-only shortcut would miss this.
+	tampered := append(append([]byte(nil), original...), []byte("\n-- tampered after apply")...)
+	if err := os.WriteFile(migrationPath, tampered, 0o600); err != nil {
+		t.Fatalf("failed to tamper migration file: %v", err)
+	}
+
+	err := runner.RunMigrations()
+	if err == nil {
+		t.Fatal("RunMigrations() after tamper error = nil, want checksum mismatch error")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("RunMigrations() error = %q, want it to mention 'checksum mismatch'", err)
+	}
+}
+
+func TestRunMigrationsAppliesSwappedFileAtSameCount(t *testing.T) {
+	database := isolatedMigrationDB(t)
+
+	dir := t.TempDir()
+	versionA := "904_swap_a.sql"
+	versionB := "904_swap_b.sql"
+	if err := os.WriteFile(filepath.Join(dir, versionA),
+		[]byte(`CREATE TABLE migration_swap_a_test (id INTEGER PRIMARY KEY);`), 0o600); err != nil {
+		t.Fatalf("failed to write migration file: %v", err)
+	}
+
+	runner := &MigrationRunner{db: database, migrationsPath: dir}
+	if err := runner.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations() first run error = %v", err)
+	}
+
+	// Swap identity at the same file count: a count-only shortcut skips this.
+	if err := os.Remove(filepath.Join(dir, versionA)); err != nil {
+		t.Fatalf("failed to remove migration file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, versionB),
+		[]byte(`CREATE TABLE migration_swap_b_test (id INTEGER PRIMARY KEY);`), 0o600); err != nil {
+		t.Fatalf("failed to write replacement migration file: %v", err)
+	}
+
+	if err := runner.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations() after swap error = %v", err)
+	}
+	if !migrationApplied(t, runner, versionB) {
+		t.Fatalf("swapped migration %s was not applied", versionB)
+	}
+	if !database.Migrator().HasTable("migration_swap_b_test") {
+		t.Fatal("migration_swap_b_test table missing after RunMigrations")
+	}
+}

--- a/alita/modules/antiflood.go
+++ b/alita/modules/antiflood.go
@@ -251,8 +251,6 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 		return ext.ContinueGroups
 	}
 
-	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
-
 	var (
 		fmode    string
 		keyboard [][]gotgbot.InlineKeyboardButton
@@ -272,6 +270,9 @@ func (m *moduleStruct) checkFlood(b *gotgbot.Bot, ctx *ext.Context) error {
 	if !flooded {
 		return ext.ContinueGroups
 	}
+
+	// Translator is only needed for punishment replies; keep it off the fast path.
+	tr := i18n.MustNewTranslator(lang.GetLanguage(ctx))
 
 	if flood.Action == "mute" || flood.Action == "kick" || flood.Action == "ban" {
 		if !chat_status.CanBotRestrict(b, ctx, chat) {


### PR DESCRIPTION
## Summary
- Always verify migration filenames and checksums, including when applied/file counts match.
- Invalidate `notes_list` after notes imports and resets commit.
- Make `/disable` update existing `disabled=false` rows preserved by backup imports.
- Defer antiflood language lookup/translator creation until a message triggers the flood limit.
- Add focused regression tests for migration identity/checksum checks, notes cache invalidation, and imported command state.

## Validation
- `make test` passed, including race checks, before rebasing onto latest main.
- After rebase: `go test -tags testtools ./alita/db/backup ./alita/db/disabling ./alita/db/migrations ./alita/modules -timeout 3m` passed.
- Untagged backup/disabling tests passed; `git diff --check` passed.
- PostgreSQL-backed migration regressions skipped locally because no database was available; still need execution against PostgreSQL.
- `make lint` blocked locally: installed golangci-lint panics with `file requires newer Go version go1.27 (application built with go1.26)`.
- Antiflood optimization removes unnecessary work; no measured latency/throughput claim.
